### PR TITLE
Add text extraction by source / Adds missing sources / Miscelleanous scraping improvements

### DIFF
--- a/ace.egg-info/PKG-INFO
+++ b/ace.egg-info/PKG-INFO
@@ -5,5 +5,10 @@ Summary: Automated Coordinate Extraction
 Home-page: http://github.com/neurosynth/ace
 Maintainer: Tal Yarkoni
 Maintainer-email: tyarkoni@gmail.com
+License: UNKNOWN
+Platform: UNKNOWN
 Provides-Extra: test
 License-File: LICENSE
+
+UNKNOWN
+

--- a/ace.egg-info/SOURCES.txt
+++ b/ace.egg-info/SOURCES.txt
@@ -8,6 +8,7 @@ ace/datatable.py
 ace/evaluate.py
 ace/export.py
 ace/extract.py
+ace/ingest.py
 ace/label.py
 ace/scrape.py
 ace/sources.py
@@ -21,6 +22,7 @@ ace.egg-info/top_level.txt
 ace/sources/Frontiers.json
 ace/sources/HighWire.json
 ace/sources/JournalOfCognitiveNeuroscience.json
+ace/sources/OUP.json
 ace/sources/Plos.json
 ace/sources/Sage.json
 ace/sources/ScienceDirect.json
@@ -28,6 +30,8 @@ ace/sources/Springer.json
 ace/sources/Wiley.json
 ace/tests/__init__.py
 ace/tests/test_ace.py
+ace/tests/data/brain.html
+ace/tests/data/cerebral_cortex.html
 ace/tests/data/frontiers.html
 ace/tests/data/jcogneuro.html
 ace/tests/data/jneuro.html

--- a/ace/database.py
+++ b/ace/database.py
@@ -214,7 +214,16 @@ class Activation(Base):
         self.columns = {}
 
     def set_coords(self, x, y, z):
-        self.x, self.y, self.z = [float(e.replace(' ', '').rstrip('.')) for e in [x, y, z]]
+        new_xyz = []
+        for c in [x, y, z]:
+            if c == '' or c is None:
+                c = None
+            else:
+                c = c.replace(' ', '').replace('--', '-').rstrip('.')
+                c = float(c)
+            new_xyz.append(c)
+
+        self.x, self.y, self.z = new_xyz
 
     def add_col(self, key, val):
         self.columns[key] = val

--- a/ace/database.py
+++ b/ace/database.py
@@ -214,7 +214,7 @@ class Activation(Base):
         self.columns = {}
 
     def set_coords(self, x, y, z):
-        self.x, self.y, self.z = [float(e.replace(' ', '')) for e in [x, y, z]]
+        self.x, self.y, self.z = [float(e.replace(' ', '').rstrip('.')) for e in [x, y, z]]
 
     def add_col(self, key, val):
         self.columns[key] = val

--- a/ace/database.py
+++ b/ace/database.py
@@ -1,6 +1,6 @@
 # Database stuff and models
 
-from sqlalchemy import (TypeDecorator, Table, Column, Integer, Float, String,
+from sqlalchemy import (TypeDecorator, Table, Column, Integer, Float, String, Boolean,
                         ForeignKey, DateTime, Text)
 from sqlalchemy.orm import relationship, backref, sessionmaker
 from sqlalchemy import create_engine
@@ -208,6 +208,8 @@ class Activation(Base):
     size = Column(String(100))
     statistic = Column(String(100))
     p_value = Column(String(100))
+
+    missing_source = Column(Boolean, default=False)
 
     def __init__(self):
         self.problems = []

--- a/ace/database.py
+++ b/ace/database.py
@@ -214,7 +214,7 @@ class Activation(Base):
         self.columns = {}
 
     def set_coords(self, x, y, z):
-        self.x, self.y, self.z = [float(e) for e in [x, y, z]]
+        self.x, self.y, self.z = [float(e.replace(' ', '')) for e in [x, y, z]]
 
     def add_col(self, key, val):
         self.columns[key] = val

--- a/ace/database.py
+++ b/ace/database.py
@@ -71,7 +71,7 @@ class Database:
     def print_stats(self):
         ''' Summarize the current state of the DB. '''
         n_articles = self.session.query(Article).count()
-        n_articles_with_coordinates = self.session.query(Table).filter(Table.n_activations>0).distinct('article_id').count()
+        n_articles_with_coordinates = self.session.query(Article).join(Table).filter(Table.n_activations>0).distinct('article_id').count()
         n_tables = self.session.query(Table).count()
         n_activations = self.session.query(Activation).count()
         n_links = self.session.query(NeurovaultLink).count()

--- a/ace/export.py
+++ b/ace/export.py
@@ -76,17 +76,24 @@ def export_database(db, foldername, skip_empty=True):
         writer.writerows(texts)
 
     # Save NV links
-    with (foldername / 'neurovault.tsv').open('w', newline='') as f:
+    with (foldername / 'neurovault_collections.tsv').open('w', newline='') as f:
         writer = csv.writer(f, delimiter='\t')
-        writer.writerow(nv_columns)
-        writer.writerows(nv_links)
+        writer.writerow(nv_colls_col)
+        writer.writerows(nv_colls)
+
+    with (foldername / 'neurovault_images.tsv').open('w', newline='') as f:
+        writer = csv.writer(f, delimiter='\t')
+        writer.writerow(nv_images_col)
+        writer.writerows(nv_images)
 
     # Save json file with time of export
     export_md = {
         "exported": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         "n_articles": len(art_results),
         "n_activations": len(coordinates),
-        "n_nv_links": len(nv_links)
+        "n_nv_collections": len(nv_colls),
+        "n_nv_images": len(nv_images)
+
     }
 
     with (foldername / 'export.json').open('w') as f:

--- a/ace/export.py
+++ b/ace/export.py
@@ -20,7 +20,7 @@ def export_database(db, foldername, skip_empty=True):
         'x', 'y', 'z', 'p_value', 'region', 'size', 'statistic', 'groups']
     coordinates = []
 
-    text_columns = ['pmid', 'title' ,'abstract', 'text']
+    text_columns = ['pmid', 'title' ,'abstract', 'body']
     texts = []
 
     nv_columns = ['pmid', 'type', 'nv_id']

--- a/ace/export.py
+++ b/ace/export.py
@@ -23,8 +23,11 @@ def export_database(db, foldername, skip_empty=True):
     text_columns = ['pmid', 'title' ,'abstract', 'body']
     texts = []
 
-    nv_columns = ['pmid', 'type', 'nv_id']
-    nv_links = []
+    nv_colls_col = ['pmid','collection_id']
+    nv_colls = []
+
+    nv_images_col = ['pmid','image_id']
+    nv_images = []
 
     articles = db.session.query(Article)
     if skip_empty:
@@ -49,7 +52,10 @@ def export_database(db, foldername, skip_empty=True):
                     p.x, p.y, p.z, p.p_value, p.region, p.size, p.statistic, groups])
             
         for nv in art.neurovault_links:
-            nv_links.append([art.id, nv.type, nv.neurovault_id])
+            if nv.type == 'collection':
+                nv_colls.append([art.id, nv.neurovault_id])
+            elif nv.type == 'image':
+                nv_images.append([art.id, nv.neurovault_id])
 
     # Save articles as tab separated file
     with (foldername / 'articles.tsv').open('w', newline='') as f:

--- a/ace/export.py
+++ b/ace/export.py
@@ -5,6 +5,7 @@ import csv
 from pathlib import Path
 import datetime
 import json
+from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -29,13 +30,13 @@ def export_database(db, foldername, skip_empty=True):
     nv_images_col = ['pmid','image_id']
     nv_images = []
 
+    print("Exporting database to %s" % foldername)
+
     articles = db.session.query(Article)
     if skip_empty:
         articles = articles.filter(or_(Article.tables.any(), Article.neurovault_links.any()))
 
-    for art in articles:
-        logger.info('Processing article %s...' % art.id)
-
+    for art in tqdm(articles):
         art_results.append([art.id, art.doi, art.authors, art.title, art.journal, art.year, art.space])
         texts.append([art.id, art.title, art.abstract, art.text])
 

--- a/ace/export.py
+++ b/ace/export.py
@@ -58,31 +58,31 @@ def export_database(db, foldername, skip_empty=True):
                 nv_images.append([art.id, nv.neurovault_id])
 
     # Save articles as tab separated file
-    with (foldername / 'articles.tsv').open('w', newline='') as f:
-        writer = csv.writer(f, delimiter='\t')
+    with (foldername / 'metadata.csv').open('w', newline='') as f:
+        writer = csv.writer(f)
         writer.writerow(article_columns)
         writer.writerows(art_results)
 
     # Save coordinates as tab separated file
-    with (foldername / 'coordinates.tsv').open('w', newline='') as f:
-        writer = csv.writer(f, delimiter='\t')
+    with (foldername / 'coordinates.csv').open('w', newline='') as f:
+        writer = csv.writer(f)
         writer.writerow(coordinate_columns)
         writer.writerows(coordinates)
 
     # Save texts as tab separated file
-    with (foldername / 'texts.tsv').open('w', newline='') as f:
-        writer = csv.writer(f, delimiter='\t')
+    with (foldername / 'text.csv').open('w', newline='') as f:
+        writer = csv.writer(f)
         writer.writerow(text_columns)
         writer.writerows(texts)
 
     # Save NV links
-    with (foldername / 'neurovault_collections.tsv').open('w', newline='') as f:
-        writer = csv.writer(f, delimiter='\t')
+    with (foldername / 'neurovault_collections.csv').open('w', newline='') as f:
+        writer = csv.writer(f)
         writer.writerow(nv_colls_col)
         writer.writerows(nv_colls)
 
-    with (foldername / 'neurovault_images.tsv').open('w', newline='') as f:
-        writer = csv.writer(f, delimiter='\t')
+    with (foldername / 'neurovault_images.csv').open('w', newline='') as f:
+        writer = csv.writer(f)
         writer.writerow(nv_images_col)
         writer.writerows(nv_images)
 

--- a/ace/ingest.py
+++ b/ace/ingest.py
@@ -1,6 +1,7 @@
 from os import path
 import logging
 from . import sources, config
+from .scrape import _validate_scrape
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,11 @@ def add_articles(db, files, commit=True, table_dir=None, limit=None,
     for i, f in enumerate(files):
         logger.info("Processing article %s..." % f)
         html = open(f).read()
+
+        if not _validate_scrape(html):
+            logger.warning("Invalid HTML for %s" % f)
+            continue
+
         source = manager.identify_source(html)
         if source is None:
             logger.warning("Could not identify source for %s" % f)

--- a/ace/ingest.py
+++ b/ace/ingest.py
@@ -5,7 +5,7 @@ from . import sources, config
 logger = logging.getLogger(__name__)
 
 def add_articles(db, files, commit=True, table_dir=None, limit=None,
-    pmid_filenames=False, metadata_dir=None, **kwargs):
+    pmid_filenames=False, metadata_dir=None, force_ingest=True, **kwargs):
     ''' Process articles and add their data to the DB.
     Args:
         files: The path to the article(s) to process. Can be a single
@@ -26,6 +26,7 @@ def add_articles(db, files, commit=True, table_dir=None, limit=None,
             path is provided, will check there first before querying PubMed,
             and will save the result of the query if it doesn't already
             exist.
+        force_ingest: Ingest even if no source is identified. 
         kwargs: Additional keyword arguments to pass to parse_article.
     '''
 
@@ -47,7 +48,10 @@ def add_articles(db, files, commit=True, table_dir=None, limit=None,
         if source is None:
             logger.warning("Could not identify source for %s" % f)
             missing_sources.append(f)
-            continue
+            if not force_ingest:
+                continue
+            else:
+                source = sources.DefaultSource(db)
 
         pmid = path.splitext(path.basename(f))[0] if pmid_filenames else None
         article = source.parse_article(html, pmid, metadata_dir=metadata_dir, **kwargs)

--- a/ace/scrape.py
+++ b/ace/scrape.py
@@ -272,7 +272,7 @@ class Scraper:
         if mode == 'browser':
             for attempt in range(10):
                 try:
-                    driver = uc.Chrome()
+                    driver = uc.Chrome(headless=True)
                     driver.implicitly_wait(5)
                     driver.set_page_load_timeout(5)
                     driver.get(url)

--- a/ace/scrape.py
+++ b/ace/scrape.py
@@ -226,7 +226,8 @@ def _validate_scrape(html):
 
     patterns = ['Checking if you are a human', 
     'Please turn JavaScript on and reload the page', 
-    'Checking if the site connection is secure']
+    'Checking if the site connection is secure',
+    'Enable JavaScript and cookies to continue']
 
     for pattern in patterns:
         if pattern in html:

--- a/ace/scrape.py
+++ b/ace/scrape.py
@@ -269,10 +269,13 @@ class Scraper:
         or just gets the URL directly. '''
 
         if mode == 'browser':
-            driver = uc.Chrome()
-            driver.get(url)
-            url = driver.current_url
-            driver.get(url)
+            try:
+                driver = uc.Chrome()
+                driver.get(url)
+                url = driver.current_url
+                driver.get(url)
+            except TimeoutException:
+                pass
 
             # Check for URL substitution and get the new one if it's changed
             url = driver.current_url  # After the redirect from PubMed

--- a/ace/scrape.py
+++ b/ace/scrape.py
@@ -101,7 +101,11 @@ def get_pmid_from_doi(doi, api_key=None):
     '''
     query = f"{doi}[aid]"
     data = PubMedAPI(api_key=api_key).esearch(query=query)
-    return data[0]
+    if data:
+        data = data[0]
+    else:
+        data = None
+    return data
 
 
 def get_pubmed_metadata(pmid, parse=True, store=None, save=True, api_key=None):

--- a/ace/scrape.py
+++ b/ace/scrape.py
@@ -165,14 +165,17 @@ def parse_PMID_xml(xml):
     if doi_source is not None and doi_source['@EIdType'] == 'doi':
         doi = doi_source['#text']
 
-    authors = article['AuthorList']['Author']
+    authors = article.get('AuthorList', None)
+    
+    if authors:
+        authors = authors['Author']
 
-    _get_author = lambda a: a['LastName'] + ', ' + a['ForeName']
-    if isinstance(authors, list):
-        authors = [_get_author(a) for a in authors if 'ForeName' in a]
-    else:
-        authors = [_get_author(authors)]
-    authors = ';'.join(authors)
+        _get_author = lambda a: a['LastName'] + ', ' + a['ForeName']
+        if isinstance(authors, list):
+            authors = [_get_author(a) for a in authors if 'ForeName' in a]
+        else:
+            authors = [_get_author(authors)]
+        authors = ';'.join(authors)
 
     if 'MeshHeadingList' in di['MedlineCitation']:
         mesh = di['MedlineCitation']['MeshHeadingList']['MeshHeading']
@@ -183,9 +186,13 @@ def parse_PMID_xml(xml):
     if abstract != '':
         abstract = abstract.get('AbstractText', '')
 
+    cit = di['PubmedData']['ArticleIdList']['ArticleId']
+    if isinstance(cit, list):
+        cit = cit[1]
+
     metadata = {
         'authors': authors,
-        'citation': di['PubmedData']['ArticleIdList']['ArticleId'][1]['#text'],
+        'citation': cit['#text'],
         'comment': abstract,
         'doi': doi,
         'keywords': '',

--- a/ace/scrape.py
+++ b/ace/scrape.py
@@ -216,6 +216,7 @@ def parse_PMID_xml(xml):
                 if 'DescriptorName' in a:
                     a = a['DescriptorName']
                 a = a['#text']
+                
                 to_join.append(a)
             v = ' | '.join(to_join)
         elif isinstance(v, Mapping):
@@ -475,7 +476,7 @@ class Scraper:
             pmids = [get_pmid_from_doi(doi) for doi in dois]
 
             # Remove None values and log missing DOIs
-            ids = [pmid for pmid in pmids if pmid is not None]
+            pmids = [pmid for pmid in pmids if pmid is not None]
             missing_dois = [doi for doi, pmid in zip(dois, pmids) if pmid is None]
             if len(missing_dois) > 0:
                 logger.info("Missing DOIs: %s" % ', '.join(missing_dois))

--- a/ace/scrape.py
+++ b/ace/scrape.py
@@ -208,7 +208,7 @@ def parse_PMID_xml(xml):
                 to_join.append(a)
             v = ' | '.join(to_join)
         elif isinstance(v, Mapping):
-            v = v['#text']
+            v = v.get('#text', '')
         metadata[k] = v
 
     return metadata

--- a/ace/scrape.py
+++ b/ace/scrape.py
@@ -12,7 +12,7 @@ import os
 import random
 import xmltodict
 from requests.adapters import HTTPAdapter, Retry
-from selenium import webdriver
+import undetected_chromedriver as uc
 import selenium.webdriver.support.ui as ui
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -257,7 +257,7 @@ class Scraper:
         or just gets the URL directly. '''
 
         if mode == 'browser':
-            driver = webdriver.Chrome()
+            driver = uc.Chrome()
             driver.get(url)
             url = driver.current_url
             driver.get(url)
@@ -270,8 +270,7 @@ class Scraper:
 
             if url != new_url:
                 driver.get(new_url)
-                sleep(3
-                )
+                sleep(5)
                 if journal.lower() in ['human brain mapping',
                                             'european journal of neuroscience',
                                             'brain and behavior','epilepsia']:
@@ -377,7 +376,7 @@ class Scraper:
         if not overwrite and os.path.isfile(filename): 
             logger.info("\tAlready exists! Skipping...")
             
-            return None
+            return None, None
 
         # Save the HTML
         doc = self.get_html_by_pmid(id, journal, mode=mode)

--- a/ace/sources.py
+++ b/ace/sources.py
@@ -167,6 +167,9 @@ class Source(metaclass=abc.ABCMeta):
         ''' Extract text from the article.
          Publisher specific extraction of body text should be done in a subclass.
          '''
+
+        text = soup.get_text()
+
         # Remove any remaining HTML tags
         text = re.sub(r'<[^>]+>', '', text)
 
@@ -346,11 +349,9 @@ class HighWireSource(Source):
             for class_ in div_classes:
                 for tag in div.find_all(class_=class_):
                     tag.extract()
-            text = div.get_text()
-        else:
-            text = soup.get_text()
+            soup = div
 
-        return super(HighWireSource, self).extract_text(text)
+        return super(HighWireSource, self).extract_text(soup)
 
  
 class ScienceDirectSource(Source):

--- a/ace/sources.py
+++ b/ace/sources.py
@@ -288,7 +288,8 @@ class DefaultSource(Source):
         soup = super(DefaultSource, self).parse_article(html, pmid, **kwargs)
         if not soup:
             return False
-            
+
+        self.article.missing_source = True
         return self.article
 
 

--- a/ace/sources/HighWire.json
+++ b/ace/sources/HighWire.json
@@ -1,11 +1,9 @@
 {
   "name": "HighWire",
   "identifiers": [
-    "http://schema.highwire.org/Linking",
-    "highwire-journal-article"
+    "highwire-journal"
   ],
   "entities": {
-  	
   },
   "delay": 10
 }

--- a/ace/sources/JournalOfCognitiveNeuroscience.json
+++ b/ace/sources/JournalOfCognitiveNeuroscience.json
@@ -1,7 +1,7 @@
 {
   "name": "JournalOfCognitiveNeuroscience",
   "identifiers": [
-    "Journal of Cognitive Neuroscience | MIT Press</title>"
+    "property=\"og:site_name\" content=\"MIT Press\""
   ],
   "entities": {
   	"\u2002": " "

--- a/ace/sources/OUP.json
+++ b/ace/sources/OUP.json
@@ -1,0 +1,9 @@
+{
+    "name": "OUP",
+    "identifiers": [
+      "OUP Academic\" />"
+    ],
+    "entities": {
+    },
+    "delay": 10
+  }

--- a/ace/sources/OUP.json
+++ b/ace/sources/OUP.json
@@ -1,7 +1,7 @@
 {
     "name": "OUP",
     "identifiers": [
-      "OUP Academic\" />"
+      "OUP Academic"
     ],
     "entities": {
     },

--- a/ace/sources/ScienceDirect.json
+++ b/ace/sources/ScienceDirect.json
@@ -1,7 +1,7 @@
 {
   "name": "ScienceDirect",
   "identifiers": [
-    ""
+    "- ScienceDirect</title>"
   ],
   "entities": {
 

--- a/ace/sources/ScienceDirect.json
+++ b/ace/sources/ScienceDirect.json
@@ -1,7 +1,7 @@
 {
   "name": "ScienceDirect",
   "identifiers": [
-    "ScienceDirect</title>"
+    ""
   ],
   "entities": {
 

--- a/ace/sources/Springer.json
+++ b/ace/sources/Springer.json
@@ -1,7 +1,8 @@
 {
   "name": "Springer",
   "identifiers": [
-    "- Springer</title>"
+    "- Springer</title>",
+    "SpringerLink</title>"
   ],
   "entities": {
 

--- a/ace/tableparser.py
+++ b/ace/tableparser.py
@@ -287,7 +287,10 @@ def parse_table(data):
     for g in group_cols:
         onset, length = [int(i) for i in g.split('/')]
         for i in range(onset, onset+length):
-            cols_in_group[i] = True
+            try:
+                cols_in_group[i] = True
+            except IndexError:
+                return None
 
     # Loop over rows in table
     group_row = None

--- a/ace/tests/data/brain.html
+++ b/ace/tests/data/brain.html
@@ -1,0 +1,3019 @@
+
+
+
+
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+
+<head>
+
+
+
+
+<script src="https://www.cdn.privado.ai/b230e0658a2d4f23bd9374dc1930f2c9.js" type="text/javascript" ></script>
+
+
+
+                
+        <title>basal ganglia are hyperactive during the discrimination of tactile stimuli in writer's cramp | Brain | Oxford Academic</title>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js" type="text/javascript"></script>
+<script>window.jQuery || document.write('<script src="//oup.silverchair-cdn.com/Themes/Silver/app/js/jquery.2.2.4.min.js" type="text/javascript">\x3C/script>')</script>
+<script src="//oup.silverchair-cdn.com/Themes/Silver/app/vendor/v-638201282110071850/jquery-migrate-1.4.1.min.js" type="text/javascript"></script>    <script type='text/javascript' src='https://platform-api.sharethis.com/js/sharethis.js#property=643701de45aa460012e1032e&amp;product=sop' async='async'></script>
+
+
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10" />
+
+    
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+    <!-- Turn off telephone number detection. -->
+    <meta name="format-detection" content="telephone=no" />
+
+<!-- Bookmark Icons -->
+  <link rel="apple-touch-icon" sizes="180x180" href="//oup.silverchair-cdn.com/UI/app/img/v-638201281749154420/apple-touch-icon.png">
+  <link rel="icon" type="image/png" href="//oup.silverchair-cdn.com/UI/app/img/v-638201281749254392/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="//oup.silverchair-cdn.com/UI/app/img/v-638201281749204451/favicon-16x16.png" sizes="16x16">
+  <link rel="mask-icon" href="//oup.silverchair-cdn.com/UI/app/img/v-638201281749554598/safari-pinned-tab.svg" color="#5bbad5">
+  <link rel="icon" href="//oup.silverchair-cdn.com/UI/app/img/v-638201281749304381/favicon.ico">
+  <link rel="manifest" href="//oup.silverchair-cdn.com/UI/app/img/v-638201281749404395/manifest.json">
+  <meta name="msapplication-config" content="//oup.silverchair-cdn.com/UI/app/img/v-638201281749154420/browserconfig.xml">
+  <meta name="theme-color" content="#002f65">
+
+
+    
+
+
+
+
+<link rel="stylesheet" type="text/css" href="//oup.silverchair-cdn.com/UI/app/fonts/icons.css" />
+
+<link rel="stylesheet" type="text/css" href="//oup.silverchair-cdn.com/Themes/Client/app/css/v-638216041963981730/site.min.css" />
+
+        <link rel="stylesheet" type="text/css" href="//oup.silverchair-cdn.com/Themes/Client/app/vendor/jscrollpane/v-638201281748404445/jscrollpane.css" />
+        <link rel="stylesheet" type="text/css" href="//oup.silverchair-cdn.com/Themes/Client/app/vendor/jquery.tablesorter/v-638201281748404445/theme.default.css" />
+
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300,400,400italic,700,700italic|Source+Sans+Pro:400,400italic,700,700italic" />
+
+
+        <link href="//oup.silverchair-cdn.com/data/SiteBuilderAssetsOriginals/Live/CSS/journals/v-638217285138027635/global.css" rel="stylesheet" type="text/css" />
+            <link href="//oup.silverchair-cdn.com/data/SiteBuilderAssets/Live/CSS/brain/v-637527892180658408/Site.css" rel="stylesheet" type="text/css" />
+
+
+
+<script> var dataLayer = [{"full_title":"The basal ganglia are hyperactive during the discrimination of tactile stimuli in writer\u0027s cramp","short_title":"basal ganglia are hyperactive during the discrimination of tactile stimuli in writer\u0027s cramp","authors":"M. Peller,K. E. Zeuner,A. Munchau,A. Quartarone,M. Weiss,A. Knutzen,M. Hallett,G. Deuschl,H. R. Siebner","event_type":"full-text","supplier_tag":"SC_Journals","object_type":"Article","taxonomy":"taxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aSCI01870%7cnodeLabel%3aNeuroscience%7cnodeLevel%3a2%3btaxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aMED00310%7cnodeLabel%3aNeurology%7cnodeLevel%3a2","siteid":"brainj","authentication_method":"IP","authzrequired":"false","account_id":"22482551","account_list":"22482551,20003025,20001100,20058187","result_click":"true","authnips":"6QBp1vEPWYkq92K9JFrXNg==","doi":"10.1093/brain/awl181"}]; </script>
+            <script>
+                (function (w, d, s, l, i) {
+                    w[l] = w[l] || []; w[l].push({
+                        'gtm.start':
+                            new Date().getTime(), event: 'gtm.js'
+                    }); var f = d.getElementsByTagName(s)[0],
+                        j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
+                        j.setAttribute('type', 'text/javascript');
+                        j.setAttribute('class', 'optanon-category-C0002');
+                        j.async = true; j.src =
+                        'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+                })(window, document, 'script', 'dataLayer', 'GTM-W6DD7HV');
+            </script>
+
+    
+
+        <script type="text/javascript">
+            var App = App || {};
+            App.LoginUserInfo = {
+                isInstLoggedIn: 1,
+                isIndividualLoggedIn: 0
+            };
+
+            App.CurrentSubdomain = 'brain';
+            App.SiteURL = 'academic.oup.com/brain';
+        </script>
+    
+    
+    <link href="https://cdn.jsdelivr.net/chartist.js/latest/chartist.min.css" rel="stylesheet" type="text/css" />
+    <script type="application/ld+json">
+        {"@context":"https://schema.org","@type":"ScholarlyArticle","@id":"https://academic.oup.com/brain/article/129/10/2697/290089","name":"The basal ganglia are hyperactive during the discrimination of tactile stimuli in writer's cramp","about":["basal ganglia","dystonia","caudate nucleus","putamen","thalamus","cerebellum","writer's cramp","functional magnetic resonance imaging","blood oxygen level dependent","index finger"],"datePublished":"2006-07-19","isPartOf":{"@id":"https://academic.oup.com/brain/brain/issue/129/10","@type":"PublicationIssue","issueNumber":"10","datePublished":"2006-10-01","isPartOf":{"@id":"https://academic.oup.com/brain/brain","@type":"Periodical","name":"Brain","issn":["1460-2156"]}},"url":"https://dx.doi.org/10.1093/brain/awl181","keywords":["basal ganglia","dystonia","caudate nucleus","putamen","thalamus","cerebellum","writer's cramp","functional magnetic resonance imaging","blood oxygen level dependent","index finger","basal ganglia","focal hand dystonia","functional MRI","tactile discrimination","thalamus","writer's cramp"],"inLanguage":"en","copyrightHolder":"Guarantors of Brain","copyrightYear":"2023","publisher":"Oxford University Press","sameAs":"","author":[{"name":"Peller, M.","affiliation":"1  Department of Neurology, Christian-Albrechts-University Kiel  Kiel, Germany    2  NeuroImageNord Hamburg-Kiel-Lübeck  Lübeck, Germany","@type":"Person"},{"name":"Zeuner, K. E.","affiliation":"1  Department of Neurology, Christian-Albrechts-University Kiel  Kiel, Germany","@type":"Person"},{"name":"Munchau, A.","affiliation":"3  Department of Neurology  Hamburg University, Hamburg, Germany","@type":"Person"},{"name":"Quartarone, A.","affiliation":"4  Department of Neuroscience, Psychiatric and Anaesthesiological Sciences   University of Messina, Messina, Italy","@type":"Person"},{"name":"Weiss, M.","affiliation":"1  Department of Neurology, Christian-Albrechts-University Kiel  Kiel, Germany    2  NeuroImageNord Hamburg-Kiel-Lübeck  Lübeck, Germany","@type":"Person"},{"name":"Knutzen, A.","affiliation":"1  Department of Neurology, Christian-Albrechts-University Kiel  Kiel, Germany","@type":"Person"},{"name":"Hallett, M.","affiliation":"5  Human Motor Control Section, Medical Neurology Branch  National Institute of Neurological Disorders and Stroke, National Institutes of Health, Bethesda, MD, USA","@type":"Person"},{"name":"Deuschl, G.","affiliation":"1  Department of Neurology, Christian-Albrechts-University Kiel  Kiel, Germany","@type":"Person"},{"name":"Siebner, H. R.","affiliation":"1  Department of Neurology, Christian-Albrechts-University Kiel  Kiel, Germany    2  NeuroImageNord Hamburg-Kiel-Lübeck  Lübeck, Germany","@type":"Person"}],"description":"Abstract. Writer's cramp is a focal hand dystonia that specifically affects handwriting. Though writer's cramp has been attributed to a dysfunction of the basal","pageStart":"2697","pageEnd":"2708","siteName":"OUP Academic","thumbnailURL":"https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/m_awl181f1.gif?Expires=1749343144&Signature=4lB4ZotWO-FPWic77l5nOWfzbr4TxNaGsgkbua-FNayApL8Gp2Tzb4oFycBByBEv8OGKfyLRSMP86VNqx-n5Pg~V5Co6~lue5SIu-JwtG2zK07UOsYFc5sEW4~VuzqrnQHEh3neZZDLLJsHUWrq5SGDoV8QLPAvbwWvZYKYugWfIMPmxD7468WiXhsczWhPnPJMD-7NZjd-dDA3EJBQfgYxVellbtFzBQqPwuePF7-LfHDLFW~0PbGq1Gm1ia~OyPtgDXrKbXSNFvfbpFb4wazqQZZQaIz8BUaAKNX3CbVhV-N7qW4bEq94s6kmsJ2LO-VH~M2e3g7Wb7pv58seJ5Q__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA","headline":"The basal ganglia are hyperactive during the discrimination of tactile stimuli in writer's cramp","image":"https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/m_awl181f1.gif?Expires=1749343144&Signature=4lB4ZotWO-FPWic77l5nOWfzbr4TxNaGsgkbua-FNayApL8Gp2Tzb4oFycBByBEv8OGKfyLRSMP86VNqx-n5Pg~V5Co6~lue5SIu-JwtG2zK07UOsYFc5sEW4~VuzqrnQHEh3neZZDLLJsHUWrq5SGDoV8QLPAvbwWvZYKYugWfIMPmxD7468WiXhsczWhPnPJMD-7NZjd-dDA3EJBQfgYxVellbtFzBQqPwuePF7-LfHDLFW~0PbGq1Gm1ia~OyPtgDXrKbXSNFvfbpFb4wazqQZZQaIz8BUaAKNX3CbVhV-N7qW4bEq94s6kmsJ2LO-VH~M2e3g7Wb7pv58seJ5Q__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA","image:alt":"Experimental design. Each fMRI session consisted of two alternating 25-s epochs with and without tactile stimulation. During the stimulation blocks an experimenter gently pressed a horizontally or vertically oriented plastic dome onto the pad of the participant's right index finger. In a single block, the same stimulus was repeatedly applied for 1 s every 5 s. After the fifth stimulus, participants were required to indicate the orientation of the gratings by pressing a button with the left index finger (smooth surface), middle finger (vertical orientation) or ring finger (horizontal orientation). We used two domes with a gap value of 0.35 mm and of 3.0 mm and two grating orientations for tactile stimulation (panel marked by the dotted line). Gratings with a gap value of 0.35 mm were below tactile discrimination threshold and perceived as smooth surface. Conversely, gratings with a gap of 3.0 mm were above the tactile discrimination threshold and the horizontal and vertical grating orientations were easily perceived by the participants."}
+    </script>
+<meta property="og:site_name" content="OUP Academic" />
+<meta property="og:title" content="The basal ganglia are hyperactive during the discrimination of tactile stimuli in writer's cramp" />
+<meta property="og:description" content="Abstract. Writer's cramp is a focal hand dystonia that specifically affects handwriting. Though writer's cramp has been attributed to a dysfunction of the basal" />
+<meta property="og:type" content="article" />
+<meta property="og:url" content="https://dx.doi.org/10.1093/brain/awl181" />
+<meta property="og:updated_time" content="" />
+<meta property="og:image" content="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/m_awl181f1.gif?Expires=1749343144&Signature=4lB4ZotWO-FPWic77l5nOWfzbr4TxNaGsgkbua-FNayApL8Gp2Tzb4oFycBByBEv8OGKfyLRSMP86VNqx-n5Pg~V5Co6~lue5SIu-JwtG2zK07UOsYFc5sEW4~VuzqrnQHEh3neZZDLLJsHUWrq5SGDoV8QLPAvbwWvZYKYugWfIMPmxD7468WiXhsczWhPnPJMD-7NZjd-dDA3EJBQfgYxVellbtFzBQqPwuePF7-LfHDLFW~0PbGq1Gm1ia~OyPtgDXrKbXSNFvfbpFb4wazqQZZQaIz8BUaAKNX3CbVhV-N7qW4bEq94s6kmsJ2LO-VH~M2e3g7Wb7pv58seJ5Q__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" />
+<meta property="og:image:url" content="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/m_awl181f1.gif?Expires=1749343144&Signature=4lB4ZotWO-FPWic77l5nOWfzbr4TxNaGsgkbua-FNayApL8Gp2Tzb4oFycBByBEv8OGKfyLRSMP86VNqx-n5Pg~V5Co6~lue5SIu-JwtG2zK07UOsYFc5sEW4~VuzqrnQHEh3neZZDLLJsHUWrq5SGDoV8QLPAvbwWvZYKYugWfIMPmxD7468WiXhsczWhPnPJMD-7NZjd-dDA3EJBQfgYxVellbtFzBQqPwuePF7-LfHDLFW~0PbGq1Gm1ia~OyPtgDXrKbXSNFvfbpFb4wazqQZZQaIz8BUaAKNX3CbVhV-N7qW4bEq94s6kmsJ2LO-VH~M2e3g7Wb7pv58seJ5Q__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" />
+<meta property="og:image:secure_url" content="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/m_awl181f1.gif?Expires=1749343144&Signature=4lB4ZotWO-FPWic77l5nOWfzbr4TxNaGsgkbua-FNayApL8Gp2Tzb4oFycBByBEv8OGKfyLRSMP86VNqx-n5Pg~V5Co6~lue5SIu-JwtG2zK07UOsYFc5sEW4~VuzqrnQHEh3neZZDLLJsHUWrq5SGDoV8QLPAvbwWvZYKYugWfIMPmxD7468WiXhsczWhPnPJMD-7NZjd-dDA3EJBQfgYxVellbtFzBQqPwuePF7-LfHDLFW~0PbGq1Gm1ia~OyPtgDXrKbXSNFvfbpFb4wazqQZZQaIz8BUaAKNX3CbVhV-N7qW4bEq94s6kmsJ2LO-VH~M2e3g7Wb7pv58seJ5Q__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" />
+<meta property="og:image:alt" content="Experimental design. Each fMRI session consisted of two alternating 25-s epochs with and without tactile stimulation. During the stimulation blocks an experimenter gently pressed a horizontally or vertically oriented plastic dome onto the pad of the participant's right index finger. In a single block, the same stimulus was repeatedly applied for 1 s every 5 s. After the fifth stimulus, participants were required to indicate the orientation of the gratings by pressing a button with the left index finger (smooth surface), middle finger (vertical orientation) or ring finger (horizontal orientation). We used two domes with a gap value of 0.35 mm and of 3.0 mm and two grating orientations for tactile stimulation (panel marked by the dotted line). Gratings with a gap value of 0.35 mm were below tactile discrimination threshold and perceived as smooth surface. Conversely, gratings with a gap of 3.0 mm were above the tactile discrimination threshold and the horizontal and vertical grating orientations were easily perceived by the participants." />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="citation_author" content="Peller, M." /><meta name="citation_author_institution" content="1Department of Neurology, Christian-Albrechts-University KielKiel, Germany" /><meta name="citation_author_institution" content="2NeuroImageNord Hamburg-Kiel-LübeckLübeck, Germany" /><meta name="citation_author" content="Zeuner, K. E." /><meta name="citation_author_institution" content="1Department of Neurology, Christian-Albrechts-University KielKiel, Germany" /><meta name="citation_author" content="Munchau, A." /><meta name="citation_author_institution" content="3Department of NeurologyHamburg University, Hamburg, Germany" /><meta name="citation_author" content="Quartarone, A." /><meta name="citation_author_institution" content="4Department of Neuroscience, Psychiatric and Anaesthesiological Sciences University of Messina, Messina, Italy" /><meta name="citation_author" content="Weiss, M." /><meta name="citation_author_institution" content="1Department of Neurology, Christian-Albrechts-University KielKiel, Germany" /><meta name="citation_author_institution" content="2NeuroImageNord Hamburg-Kiel-LübeckLübeck, Germany" /><meta name="citation_author" content="Knutzen, A." /><meta name="citation_author_institution" content="1Department of Neurology, Christian-Albrechts-University KielKiel, Germany" /><meta name="citation_author" content="Hallett, M." /><meta name="citation_author_institution" content="5Human Motor Control Section, Medical Neurology BranchNational Institute of Neurological Disorders and Stroke, National Institutes of Health, Bethesda, MD, USA" /><meta name="citation_author" content="Deuschl, G." /><meta name="citation_author_institution" content="1Department of Neurology, Christian-Albrechts-University KielKiel, Germany" /><meta name="citation_author" content="Siebner, H. R." /><meta name="citation_author_institution" content="1Department of Neurology, Christian-Albrechts-University KielKiel, Germany" /><meta name="citation_author_institution" content="2NeuroImageNord Hamburg-Kiel-LübeckLübeck, Germany" /><meta name="citation_title" content="The basal ganglia are hyperactive during the discrimination of tactile stimuli in writer's cramp" /><meta name="citation_firstpage" content="2697" /><meta name="citation_lastpage" content="2708" /><meta name="citation_doi" content="10.1093/brain/awl181" /><meta name="citation_journal_title" content="Brain" /><meta name="citation_journal_abbrev" content="Brain" /><meta name="citation_volume" content="129" /><meta name="citation_issue" content="10" /><meta name="citation_publication_date" content="2006/10/01" /><meta name="citation_issn" content="0006-8950" /><meta name="citation_publisher" content="Oxford Academic" /><meta name="citation_reference" content="citation_title=Abnormalities of sensorimotor integration in focal dystonia: a transcranial magnetic stimulation study; Brain;  citation_year=2001;  citation_volume=124;  citation_pages=537-45; " /><meta name="citation_reference" content="citation_title=Parallel organization of functionally segregated circuits linking basal ganglia and cortex; Annu Rev Neurosci;  citation_year=1986;  citation_volume=9;  citation_pages=357-81; " /><meta name="citation_reference" content="citation_title=Information processing, dimensionality reduction and reinforcement learning in the basal ganglia; Prog Neurobiol;  citation_year=2003;  citation_volume=71;  citation_pages=439-73; " /><meta name="citation_reference" content="citation_title=Abnormal somatosensory homunculus in dystonia of the hand; Ann Neurol;  citation_year=1998;  citation_volume=44;  citation_pages=828-31; " /><meta name="citation_reference" content="citation_title=Spatial discrimination is abnormal in focal hand dystonia; Neurology;  citation_year=2000;  citation_volume=55;  citation_pages=1869-73; " /><meta name="citation_reference" content="citation_title=Sensory discrimination capabilities in patients with focal hand dystonia; Ann Neurol;  citation_year=2000;  citation_volume=47;  citation_pages=377-80; " /><meta name="citation_reference" content="citation_title=The pathophysiology of primary dystonia; Brain;  citation_year=1998;  citation_volume=121;  citation_pages=1195-212; " /><meta name="citation_reference" content="citation_title=Basal ganglia activity remains elevated after movement in focal hand dystonia; Ann Neurol;  citation_year=2004;  citation_volume=55;  citation_pages=744-8; " /><meta name="citation_reference" content="citation_title=Task-specific plasticity of somatosensory cortex in patients with writer's cramp; Neuroimage;  citation_year=2003;  citation_volume=20;  citation_pages=1329-38; " /><meta name="citation_reference" content="citation_title=Abnormal cortical sensory activation in dystonia: an fMRI study; Mov Disord;  citation_year=2003;  citation_volume=18;  citation_pages=673-82; " /><meta name="citation_reference" content="citation_title=A primate genesis model of focal dystonia and repetitive strain injury: I. Learning-induced dedifferentiation of the representation of the hand in the primary somatosensory cortex in adult monkeys; Neurology;  citation_year=1996;  citation_volume=47;  citation_pages=508-20; " /><meta name="citation_reference" content="citation_title=A primate model for studying focal dystonia and repetitive strain injury: effects on the primary somatosensory cortex; Phys Ther;  citation_year=1997;  citation_volume=77;  citation_pages=269-84; " /><meta name="citation_reference" content="citation_title=Botulinum toxin does not reverse the cortical dysfunction associated with writer's cramp. A PET study; Brain;  citation_year=1997;  citation_volume=120;  citation_pages=571-82; " /><meta name="citation_reference" content="citation_title=The basilar pontine nuclei and the nucleus reticularis tegmenti pontis subserve distinct cerebrocerebellar pathways; Prog Brain Res;  citation_year=2005;  citation_volume=148;  citation_pages=259-82; " /><meta name="citation_reference" content="citation_title=Disorganized somatotopy in the putamen of patients with focal hand dystonia; Neurology;  citation_year=2005;  citation_volume=64;  citation_pages=1391-6; " /><meta name="citation_reference" content="citation_title=The metabolic topography of idiopathic torsion dystonia; Brain;  citation_year=1995;  citation_volume=118;  citation_pages=1473-84; " /><meta name="citation_reference" content="citation_title=Functional brain networks in DYT1 dystonia; Ann Neurol;  citation_year=1998;  citation_volume=44;  citation_pages=303-12; " /><meta name="citation_reference" content="citation_title=Alteration of digital representations in somatosensory cortex in focal hand dystonia; Neuroreport;  citation_year=1998;  citation_volume=9;  citation_pages=3571-5; " /><meta name="citation_reference" content="citation_title=Assessment of the primary dystonias; citation_publisher=Butterworths, Boston; The quantification of neurologic deficit;  citation_year=1989;  citation_pages=241-70; " /><meta name="citation_reference" content="citation_title=Temporal processing of visuotactile and tactile stimuli in writer's cramp; Ann Neurol;  citation_year=2003;  citation_volume=53;  citation_pages=630-5; " /><meta name="citation_reference" content="citation_title=Analysis of fMRI time-series revisited; Neuroimage;  citation_year=1995;  citation_volume=2;  citation_pages=45-53; " /><meta name="citation_reference" content="citation_title=Basal ganglia and thalamo-cortical hypermetabolism in patients with spasmodic torticollis; Acta Neurol Scand;  citation_year=1996;  citation_volume=94;  citation_pages=172-6; " /><meta name="citation_reference" content="citation_title=Idiopathic focal dystonia: a disorder of muscle spindle afferent processing?; Brain;  citation_year=1997;  citation_volume=120;  citation_pages=2179-85; " /><meta name="citation_reference" content="citation_title=The neurophysiology of dystonia; Arch Neurol;  citation_year=1998;  citation_volume=55;  citation_pages=601-3; " /><meta name="citation_reference" content="citation_title=The metabolic topography of essential blepharospasm: a focal dystonia with general implications; Neurology;  citation_year=2000;  citation_volume=55;  citation_pages=673-7; " /><meta name="citation_reference" content="citation_title=Deficient activation of the motor cortical network in patients with writer's cramp; Neurology;  citation_year=1999;  citation_volume=53;  citation_pages=96-105; " /><meta name="citation_reference" content="citation_title=Basal ganglia as a sensory gating devise for motor control; J Med Invest;  citation_year=2001;  citation_volume=48;  citation_pages=142-6; " /><meta name="citation_reference" content="citation_title=Contribution of pedunculopontine tegmental nucleus neurons to performance of visually guided saccade tasks in monkeys; J Neurophysiol;  citation_year=2002;  citation_volume=88;  citation_pages=715-31; " /><meta name="citation_reference" content="citation_title=Pedunculo-pontine control of visually guided saccades; Prog Brain Res;  citation_year=2004;  citation_volume=143;  citation_pages=439-45; " /><meta name="citation_reference" content="citation_title=Reorganization in the cutaneous core of the human thalamic principal somatic sensory nucleus (ventral caudal) in patients with dystonia; J Neurophysiol;  citation_year=1999;  citation_volume=82;  citation_pages=3204-12; " /><meta name="citation_reference" content="citation_title=Thalamic single neuron activity in patients with dystonia: dystonia-related activity and somatic sensory reorganization; J Neurophysiol;  citation_year=1999;  citation_volume=82;  citation_pages=2372-92; " /><meta name="citation_reference" content="citation_title=Regional cerebral blood flow correlates of the severity of writer's cramp symptoms; Neuroimage;  citation_year=2004;  citation_volume=21;  citation_pages=904-13; " /><meta name="citation_reference" content="citation_title=The anatomical basis of symptomatic hemidystonia; Brain;  citation_year=1985;  citation_volume=108;  citation_pages=463-83; " /><meta name="citation_reference" content="citation_title=Human brain mapping in dystonia reveals both endophenotypic traits and adaptive reorganization; Ann Neurol;  citation_year=2001;  citation_volume=50;  citation_pages=521-7; " /><meta name="citation_reference" content="citation_title=Dentate output channels: motor and cognitive components; Prog Brain Res;  citation_year=1997;  citation_volume=114;  citation_pages=553-66; " /><meta name="citation_reference" content="citation_title=The basal ganglia: focused selection and inhibition of competing motor programs; Prog Neurobiol;  citation_year=1996;  citation_volume=50;  citation_pages=381-425; " /><meta name="citation_reference" content="citation_title=Abnormalities of spatial discrimination in focal and generalized dystonia; Brain;  citation_year=2003;  citation_volume=126;  citation_pages=2175-82; " /><meta name="citation_reference" content="citation_title=Abnormal premovement gating of somatosensory input in writer's cramp; Brain;  citation_year=2000;  citation_volume=123;  citation_pages=1813-29; " /><meta name="citation_reference" content="citation_title=Cerebral and cerebellar activation in correlation to the action-induced dystonia in writer's cramp; Mov Disord;  citation_year=1998;  citation_volume=13;  citation_pages=497-508; " /><meta name="citation_reference" content="citation_title=Sensory abnormalities in unaffected relatives in familial adult-onset dystonia; Neurology;  citation_year=2005;  citation_volume=65;  citation_pages=938-40; " /><meta name="citation_reference" content="citation_title=Abnormal cortical mechanisms of voluntary muscle relaxation in patients with writer's cramp: an fMRI study; Brain;  citation_year=2002;  citation_volume=125;  citation_pages=895-903; " /><meta name="citation_reference" content="citation_title=The assessment and analysis of handedness: the Edinburgh inventory; Neuropsychologia;  citation_year=1971;  citation_volume=9;  citation_pages=97-113; " /><meta name="citation_reference" content="citation_title=Functional anatomy of the basal ganglia. I. The cortico-basal ganglia-thalamo-cortical loop; Brain Res Brain Res Rev;  citation_year=1995;  citation_volume=20;  citation_pages=91-127; " /><meta name="citation_reference" content="citation_title=Cerebral activation patterns in patients with writer's cramp: a functional magnetic resonance imaging study; J Neurol;  citation_year=2001;  citation_volume=248;  citation_pages=10-7; " /><meta name="citation_reference" content="citation_title=Brain cortical activation during guitar-induced hand dystonia studied by functional MRI; Neuroimage;  citation_year=2000;  citation_volume=12;  citation_pages=257-67; " /><meta name="citation_reference" content="citation_title=Abnormal associative plasticity of the human motor cortex in writer's cramp; Brain;  citation_year=2003;  citation_volume=126;  citation_pages=2586-96; " /><meta name="citation_reference" content="citation_title=Corticospinal excitability during motor imagery of a simple tonic finger movement in patients with writer's cramp; Mov Disord;  citation_year=2005;  citation_volume=20;  citation_pages=1488-95; " /><meta name="citation_reference" content="citation_title=Task-specific hand dystonia: can too much plasticity be bad for you?; Trends Neurosci;  citation_year=2006;  citation_volume=29;  citation_pages=192-9; " /><meta name="citation_reference" content="citation_title=Abnormalities of spatial and temporal sensory discrimination in writer's cramp; Mov Disord;  citation_year=2001;  citation_volume=16;  citation_pages=94-9; " /><meta name="citation_reference" content="citation_title=Feeling with the mind's eye: the role of visual imagery in tactile perception; Optom Vis Sci;  citation_year=2001;  citation_volume=78;  citation_pages=276-81; " /><meta name="citation_reference" content="citation_title=Feeling with the mind's eye: contribution of visual cortex to tactile perception; Behav Brain Res;  citation_year=2002;  citation_volume=135;  citation_pages=127-32; " /><meta name="citation_reference" content="citation_title=Writers' cramp—a focal dystonia; Brain;  citation_year=1982;  citation_volume=105;  citation_pages=461-80; " /><meta name="citation_reference" content="citation_title=Patients with focal arm dystonia have increased sensitivity to slow-frequency repetitive TMS of the dorsal premotor cortex; Brain;  citation_year=2003;  citation_volume=126;  citation_pages=2710-25; " /><meta name="citation_reference" content="citation_title=Disturbed surround inhibition in focal hand dystonia; Ann Neurol;  citation_year=2004;  citation_volume=56;  citation_pages=595-9; " /><meta name="citation_reference" content="citation_title=Role of the cerebellum in visual guidance of movement; Physiol Rev;  citation_year=1992;  citation_volume=72;  citation_pages=967-1017; " /><meta name="citation_reference" content="citation_title=Abnormal cortical responses in patients with writer's cramp; Neurology;  citation_year=1993;  citation_volume=43;  citation_pages=2252-7; " /><meta name="citation_reference" content="citation_title=Abnormal central integration of a dual somatosensory input in dystonia. Evidence for sensory overflow; Brain;  citation_year=2000;  citation_volume=123;  citation_pages=42-50; " /><meta name="citation_reference" content="citation_title=Role of the somatosensory system in primary dystonia; Mov Disord;  citation_year=2003;  citation_volume=18;  citation_pages=605-22; " /><meta name="citation_reference" content="citation_title=Task-specific impairment of motor cortical excitation and inhibition in patients with writer's cramp; Neurosci Lett;  citation_year=2005;  citation_volume=378;  citation_pages=55-8; " /><meta name="citation_reference" content="citation_title=The limit of tactile spatial resolution in humans: grating orientation discrimination at the lip, tongue, and finger; Neurology;  citation_year=1994;  citation_volume=44;  citation_pages=2361-6; " /><meta name="citation_reference" content="citation_title=Tactile form and location processing in the human brain; Proc Natl Acad Sci USA;  citation_year=2005;  citation_volume=102;  citation_pages=12601-5; " /><meta name="citation_reference" content="citation_title=Neuronal activity in the basal ganglia in patients with generalized dystonia and hemiballismus; Ann Neurol;  citation_year=1999;  citation_volume=46;  citation_pages=22-35; " /><meta name="citation_reference" content="citation_title=Involvement of visual cortex in tactile discrimination of orientation; Nature;  citation_year=1999;  citation_volume=401;  citation_pages=587-90; " /><meta name="citation_reference" content="citation_title=Multisensory cortical processing of object shape and its relation to mental imagery; Cogn Affect Behav Neurosci;  citation_year=2004;  citation_volume=4;  citation_pages=251-9; " /><meta name="citation_reference" content="citation_title=Tactile discrimination of grating orientation: fMRI activation patterns; Hum Brain Mapp;  citation_year=2005; " /><meta name="citation_reference" content="citation_title=Neuronal activity in the basal ganglia and thalamus in patients with dystonia; Clin Neurophysiol;  citation_year=2004;  citation_volume=115;  citation_pages=2542-57; " /><meta name="citation_fulltext_world_readable" content="" /><meta name="citation_pdf_url" content="https://academic.oup.com/brain/article-pdf/129/10/2697/818980/awl181.pdf" /><meta name="description" content="Abstract. Writer's cramp is a focal hand dystonia that specifically affects handwriting. Though writer's cramp has been attributed to a dysfunction of the basal" /><meta name="citation_xml_url" content="https://academic.oup.com/brain/article-xml/129/10/2697/290089" />
+
+
+    <link rel="canonical" href="https://academic.oup.com/brain/article-abstract/129/10/2697/290089" />
+
+
+
+
+
+
+
+
+
+
+
+
+    
+
+
+
+<script async="async" src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+<script>
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+</script>
+    
+        <script type='text/javascript'>
+            var gptAdSlots = [];
+            googletag.cmd.push(function() {
+                    
+                    var mapping_ad1 = googletag.sizeMapping()
+                        .addSize([1024, 0], [[970, 90], [728, 90]])
+                        .addSize([768, 0], [728, 90])
+                        .addSize([0, 0], [320, 50])
+                        .build();
+                    gptAdSlots["ad1"] = googletag.defineSlot('/116097782/brain_Behind_Ad1',
+                            [[970, 90], [728, 90], [320, 50]], 'adBlockHeader')
+                        .defineSizeMapping(mapping_ad1)
+                        .addService(googletag.pubads());
+                    
+
+                    
+                    var mapping_ad2 = googletag.sizeMapping()
+                        .addSize([768, 0], [[300, 250], [300, 600], [160, 600]])
+                        .build();
+                    gptAdSlots["ad2"] = googletag.defineSlot('/116097782/brain_Behind_Ad2',
+                            [[300, 250], [160, 600], [300, 600]], 'adBlockMainBodyTop')
+                        .defineSizeMapping(mapping_ad2)
+                        .addService(googletag.pubads());
+                    
+
+                    
+                    var mapping_ad3 = googletag.sizeMapping()
+                        .addSize([768, 0], [[300, 250], [300, 600], [160, 600]])
+                        .build();
+                    gptAdSlots["ad3"] = googletag.defineSlot('/116097782/brain_Behind_Ad3',
+                        [[300, 250], [160, 600], [300, 600]], 'adBlockMainBodyBottom')
+                        .defineSizeMapping(mapping_ad3)
+                        .addService(googletag.pubads());
+                    
+
+                    
+                var mapping_ad4 = googletag.sizeMapping()
+                        .addSize([0,0], [320, 50])
+                        .addSize([768, 0], [728, 90])
+                        .build();
+                    gptAdSlots["ad4"] = googletag.defineSlot('/116097782/brain_Behind_Ad4',
+                        [728, 90], 'adBlockFooter')
+                        .defineSizeMapping(mapping_ad4)
+                        .addService(googletag.pubads());
+                    
+
+                    
+                var mapping_ad6 = googletag.sizeMapping()
+                        .addSize([1024, 0], [[970, 90], [728, 90]])
+                        .addSize([0, 0], [[320, 50], [300, 50]])
+                        .build();
+                    gptAdSlots["ad6"] = googletag.defineSlot('/116097782/brain_Behind_Ad6',
+                        [[728, 90], [970, 90]], 'adBlockStickyFooter')
+                        .defineSizeMapping(mapping_ad6)
+                        .addService(googletag.pubads());
+                    
+
+                    
+                    gptAdSlots["adInterstital"] = googletag.defineOutOfPageSlot('/116097782/brain_Interstitial_Ad',
+                        googletag.enums.OutOfPageFormat.INTERSTITIAL)
+                        .addService(googletag.pubads());
+                                        
+
+                googletag.pubads().addEventListener('slotRenderEnded', function (event) {
+                    if (!event.isEmpty) {
+                        $('.js-' + event.slot.getSlotElementId()).each(function () {
+                            if ($(this).find('iframe').length) {
+                                $(this).removeClass('hide');
+                            }
+                        });
+                    }
+                });
+
+                googletag.pubads().addEventListener('impressionViewable', function (event) {
+                    if (!event.isEmpty) {
+                        $('.js-' + event.slot.getSlotElementId()).each(function () {
+                            var $adblockDiv = $(this).find('.js-adblock');
+                            var $adText = $(this).find('.js-adblock-advertisement-text');
+                            if ($adblockDiv && $adblockDiv.is(':visible') && $adblockDiv.find('*').length > 1) {
+                                $adText.removeClass('hide');
+                                App.CenterAdBlock.Init($adblockDiv, $adText);
+                            }
+                            else {
+                                $adText.addClass('hide');
+                            }
+                        });
+                    }
+                });
+
+                googletag.pubads().setTargeting("jnlspage", "article");
+                googletag.pubads().setTargeting("jnlsurl", "brain/article/129/10/2697/290089");
+                googletag.pubads().enableSingleRequest();
+                googletag.pubads().disableInitialLoad();
+                googletag.pubads().collapseEmptyDivs();
+            });
+        </script>
+    
+<input type="hidden"
+       class="hfInterstitial"
+       data-interstitiallinks="brain/issue,brain/advance-articles,brain/advance-article,brain/supplements,brain/article,brain/article-abstract,brain/pages"
+       data-subdomain="brain"/>
+    
+    
+        <script type="text/javascript">
+                googletag.cmd.push(function () {
+                    
+                    googletag.pubads().setTargeting("jnlsdoi", "10.1093/brain/awl181");
+                    googletag.enableServices();
+                });
+        </script>
+
+
+
+
+    
+
+
+    <script type="text/javascript">
+        var NTPT_PGEXTRA= 'event_type=full-text&supplier_tag=SC_Journals&object_type=Article&taxonomy=taxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aSCI01870%7cnodeLabel%3aNeuroscience%7cnodeLevel%3a2%3btaxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aMED00310%7cnodeLabel%3aNeurology%7cnodeLevel%3a2&siteid=brainj&authentication_method=IP&authzrequired=false&account_id=22482551&account_list=22482551,20003025,20001100,20058187&result_click=true&authnips=136.62.3.74&doi=10.1093/brain/awl181';
+    </script>
+
+
+
+
+    <script src="https://scholar.google.com/scholar_js/casa.js" async></script>
+</head>
+
+<body data-sitename="brain" class="off-canvas pg_Article pg_article   " theme-brain data-sitestyletemplate="Journal" >
+            <noscript>
+                <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W6DD7HV"
+                        height="0" width="0" style="display:none;visibility:hidden"></iframe>
+            </noscript>
+            <a href="#skipNav" class="skipnav">Skip to Main Content</a>
+<input id="hdnSiteID" name="hdnSiteID" type="hidden" value="5367" /><input id="hdnAdDelaySeconds" name="hdnAdDelaySeconds" type="hidden" value="7000" /><input id="hdnAdConfigurationTop" name="hdnAdConfigurationTop" type="hidden" value="scrolldelay" /><input id="hdnAdConfigurationRightRail" name="hdnAdConfigurationRightRail" type="hidden" value="sticky" />
+    
+
+
+
+
+
+
+<div class="master-container js-master-container">
+<section class="master-header row js-master-header vt-site-page-header">
+    <div class="widget widget-SitePageHeader widget-instance-SitePageHeader">
+        
+
+    <div class="ad-banner js-ad-banner-header">
+    <div class="widget widget-AdBlock widget-instance-HeaderAd">
+        <div class="js-adBlock-parent-wrap">    
+    <div class="adBlockHeader-wrap js-adBlockHeader hide">
+    
+        <div id="adBlockHeader" class="js-adblock at-adblock">
+            <script>
+                googletag.cmd.push(function () {
+                    googletag.display('adBlockHeader');
+                });
+            </script>
+        </div>
+        <div class="advertisement-text at-adblock js-adblock-advertisement-text hide">Advertisement</div>
+    </div>
+</div> 
+    </div>
+
+    </div>
+
+    <div class="oup-header sigma ">
+        <div class="center-inner-row">
+
+<div class="oup-header-logo">
+
+        <a href="/">
+            <img src="//oup.silverchair-cdn.com/UI/app/svg/umbrella/oxford-academic-logo.svg" alt="Oxford Academic"
+                 class="oup-header-image at-oup-header-image " />
+        </a>
+
+</div>                <div class="widget widget-CustomNavLinks widget-instance-CustomNavLinksDeskTop">
+            <div class="custom-nav-links-box">
+            <div class="custom-nav-link">
+                <a href="/journals">Journals</a>
+            </div>
+            <div class="custom-nav-link">
+                <a href="/books">Books</a>
+            </div>
+
+    </div>
+ 
+    </div>
+            <ul class="oup-header-menu account-menu sigma-account-menu ">
+
+                
+                <li class="oup-header-menu-item mobile">
+                    <a href="javascript:;" class="mobile-dropdown-toggle mobile-search-toggle">
+                        <i class="icon-menu_search"><span class="screenreader-text">Search Menu</span></i>
+                    </a>
+                </li>
+
+                
+                        <li class="oup-header-menu-item mobile info-icon-menu-item">
+            <a href="/pages/information" target="_blank" class="at-info-button sigma-info-wrapper" role="button">
+            <img class="sigma-info-icon" src="//oup.silverchair-cdn.com/UI/app/svg/i.svg" alt="Information" />
+            </a>
+        </li>
+    <li class="oup-header-menu-item mobile account-icon-menu-item">
+        <a href="javascript:;" class="account-button js-account-button at-account-button "
+                role="button" data-turnawayparams="journal%3dbrain">
+            <img class="sigma-account-icon" src="//oup.silverchair-cdn.com/UI/app/svg/account.svg" alt="Account" />
+        </a>
+    </li>
+
+
+                
+                <li class="oup-header-menu-item mobile">
+                    <a href="javascript:;" class="mobile-dropdown-toggle mobile-nav-toggle">
+                        <i class="icon-menu_hamburger"><span class="screenreader-text">Menu</span></i>
+                    </a>
+                </li>
+            
+                
+               
+                        <li class="oup-header-menu-item desktop info-icon-menu-item">
+            <a href="/pages/information" target="_blank" class="at-info-button sigma-info-wrapper" role="button">
+            <img class="sigma-info-icon" src="//oup.silverchair-cdn.com/UI/app/svg/i.svg" alt="Information" />
+            </a>
+        </li>
+    <li class="oup-header-menu-item desktop account-icon-menu-item">
+        <a href="javascript:;" class="account-button js-account-button at-account-button sigma-logo-wrapper"
+                role="button" data-turnawayparams="journal%3dbrain">
+            <img class="sigma-account-icon" src="//oup.silverchair-cdn.com/UI/app/svg/account.svg" alt="Account" />
+        </a>
+    </li>
+
+
+                
+
+            </ul>
+
+            <div class="login-box-placeholder js-login-box-placeholder hide">
+                <div class="spinner"></div>
+            </div>
+        </div>
+    </div>
+<div class="dropdown-panel-wrap">
+
+    
+    <div class="dropdown-panel mobile-search-dropdown">
+        <div class="mobile-search-inner-wrap">
+
+
+<div class="navbar-search">
+    <div class="mobile-microsite-search">
+            <label for="SitePageHeader-mobile-navbar-search-filter" class="screenreader-text js-mobile-navbar-search-filter-label">
+                Navbar Search Filter
+            </label>
+            <select class="mobile-navbar-search-filter js-mobile-navbar-search-filter at-navbar-search-filter" id="SitePageHeader-mobile-navbar-search-filter">
+
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="">Brain</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Issue">This issue</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Parent">Brain Journals</option>
+                    <optgroup class="navbar-search-optgroup" label="Search across Oxford Academic">
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/MED00310">Neurology</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/SCI01870">Neuroscience</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Books">Books</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Journals">Journals</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Umbrella">Oxford Academic</option>                    </optgroup>
+            </select>
+
+        <label for="SitePageHeader-mobile-microsite-search-term" class="screenreader-text js-mobile-microsite-search-term-label">
+            Mobile Enter search term
+        </label>
+        <input class="mobile-search-input mobile-microsite-search-term js-mobile-microsite-search-term at-microsite-search-term" type="text"
+               maxlength="255" placeholder="Search" id="SitePageHeader-mobile-microsite-search-term">
+
+        <a href="javascript:;" class="mobile-microsite-search-icon mobile-search-submit icon-menu_search">
+            <span class="screenreader-text">Search</span>
+        </a>
+
+    </div>
+</div>
+
+
+        </div>
+    </div>
+   
+    <div class="dropdown-panel mobile-nav-dropdown">
+
+
+    <ul class="site-menu site-menu-lvl-0 at-site-menu">
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1600149">
+
+                <a href="/brain/issue" class="nav-link">
+                    Issues
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1600150">
+
+                    <a href="javascript:;" class="nav-link js-nav-dropdown at-nav-dropdown" role="button" aria-expanded="false">Subject</a>
+
+    <i class="mobile-nav-arrow icon-general_arrow-down"></i>
+    <ul class="site-menu site-menu-lvl-1">
+
+            <li class="site-menu-item site-menu-lvl-1 ">
+                    <a href="/brain/search-results?q=&amp;tax=brainj/1000" class="nav-link">CNS Injury and Stroke</a>
+            </li>
+            <li class="site-menu-item site-menu-lvl-1 ">
+                    <a href="/brain/search-results?q=&amp;tax=brainj/1010" class="nav-link">Dementia</a>
+            </li>
+            <li class="site-menu-item site-menu-lvl-1 ">
+                    <a href="/brain/search-results?q=&amp;tax=brainj/1020" class="nav-link">Epilepsy and Sleep</a>
+            </li>
+            <li class="site-menu-item site-menu-lvl-1 ">
+                    <a href="/brain/search-results?q=&amp;tax=brainj/1030" class="nav-link">Genetics</a>
+            </li>
+            <li class="site-menu-item site-menu-lvl-1 ">
+                    <a href="/brain/search-results?q=&amp;tax=brainj/1040" class="nav-link">Movement Disorders</a>
+            </li>
+            <li class="site-menu-item site-menu-lvl-1 ">
+                    <a href="/brain/search-results?q=&amp;tax=brainj/1050" class="nav-link">Multiple Sclerosis/Neuroinflammation</a>
+            </li>
+            <li class="site-menu-item site-menu-lvl-1 ">
+                    <a href="/brain/search-results?q=&amp;tax=brainj/1080" class="nav-link">Neuro-oncology</a>
+            </li>
+            <li class="site-menu-item site-menu-lvl-1 ">
+                    <a href="/brain/search-results?q=&amp;tax=brainj/1060" class="nav-link">Neurodegeneration - Cellular &amp; Molecular</a>
+            </li>
+            <li class="site-menu-item site-menu-lvl-1 ">
+                    <a href="/brain/search-results?q=&amp;tax=brainj/1070" class="nav-link">Neuromuscular Disease</a>
+            </li>
+            <li class="site-menu-item site-menu-lvl-1 ">
+                    <a href="/brain/search-results?q=&amp;tax=brainj/1090" class="nav-link">Neuropsychiatry</a>
+            </li>
+            <li class="site-menu-item site-menu-lvl-1 ">
+                    <a href="/brain/search-results?q=&amp;tax=brainj/1100" class="nav-link">Pain and Headache</a>
+            </li>
+    </ul>
+
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1600146">
+
+                <a href="javascript:;" class="nav-link js-nav-dropdown at-nav-dropdown" role="button" aria-expanded="false">
+                    More Content
+                    <i class="desktop-nav-arrow icon-general-arrow-filled-down arrow-icon"></i>
+                </a>
+                <i class="mobile-nav-arrow icon-general_arrow-down"></i>
+                <ul class="site-menu site-menu-lvl-1 at-site-menu">
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600151">
+
+                <a href="/brain/advance-articles" class="nav-link">
+                    Advance articles
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600152">
+
+                <a href="https://academic.oup.com/brain/search-results?page=1&amp;f_OUPSeries=Editor%27s+Choice" class="nav-link">
+                    Editor's Choice
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600153">
+
+                <a href="https://www.youtube.com/playlist?list=PL4PJR6NGNj7lCHXVjamUmeBOGm2fZs24x" class="nav-link">
+                    Videos
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600154">
+
+                <a href="/brain/pages/brain_oup_blog" class="nav-link">
+                    Blog Posts
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600155">
+
+                <a href="https://academic.oup.com/brain/pages/podcast" class="nav-link">
+                    Podcasts
+                </a>
+            
+        </li>
+            </ul>
+
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1600147">
+
+                <a href="javascript:;" class="nav-link js-nav-dropdown at-nav-dropdown" role="button" aria-expanded="false">
+                    Submit
+                    <i class="desktop-nav-arrow icon-general-arrow-filled-down arrow-icon"></i>
+                </a>
+                <i class="mobile-nav-arrow icon-general_arrow-down"></i>
+                <ul class="site-menu site-menu-lvl-1 at-site-menu">
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600156">
+
+                <a href="/brain/pages/General_Instructions" class="nav-link">
+                    Author Guidelines
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600157">
+
+                <a href="http://mc.manuscriptcentral.com/brain" class="nav-link">
+                    Submission Site
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600158">
+
+                <a href="https://academic.oup.com/brain/pages/why-publish-with-brain" class="nav-link">
+                    Why publish with this journal?
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600159">
+
+                <a href="https://academic.oup.com/brain/pages/General_Instructions#Open-Access" class="nav-link">
+                    Open Access
+                </a>
+            
+        </li>
+            </ul>
+
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1600160">
+
+                <a href="/brain/subscribe" class="nav-link">
+                    Purchase
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1600148">
+
+                <a href="javascript:;" class="nav-link js-nav-dropdown at-nav-dropdown" role="button" aria-expanded="false">
+                    About
+                    <i class="desktop-nav-arrow icon-general-arrow-filled-down arrow-icon"></i>
+                </a>
+                <i class="mobile-nav-arrow icon-general_arrow-down"></i>
+                <ul class="site-menu site-menu-lvl-1 at-site-menu">
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600161">
+
+                <a href="/brain/pages/About" class="nav-link">
+                    About Brain
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600162">
+
+                <a href="/brain/pages/Editorial_Board" class="nav-link">
+                    Editorial Board
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600163">
+
+                <a href="https://academic.oup.com/advertising-and-corporate-services/pages/brain-media-kit" class="nav-link">
+                    Advertising and Corporate Services
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600164">
+
+                <a href="http://medicine-and-health-careernetwork.oxfordjournals.org" class="nav-link">
+                    Journals Career Network
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600165">
+
+                <a href="/my-account/email-alerts" class="nav-link">
+                    Alerts
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600166">
+
+                <a href="https://academic.oup.com/journals/pages/access_purchase/rights_and_permissions/self_archiving_policy_b" class="nav-link">
+                    Self-Archiving Policy
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600167">
+
+                <a href="http://www.oxfordjournals.org/en/access-purchase/dispatch-dates.html" class="nav-link">
+                    Dispatch Dates
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600168">
+
+                <a href="/brain/pages/Terms_and_Conditions" class="nav-link">
+                    Terms and Conditions
+                </a>
+            
+        </li>
+            </ul>
+
+        </li>
+                <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-custom">
+            <a href="/journals" class="nav-link">Journals on Oxford Academic</a>
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-custom">
+            <a href="/books" class="nav-link">Books on Oxford Academic</a>
+        </li>
+    </ul>
+    </div>
+
+</div>
+
+    <div class="journal-header journal-bg">
+        <div class="center-inner-row">
+                <div class="site-parent-link-wrap">
+                    <a href="//academic.oup.com/brainjournals" class="site-parent-link">Brain Journals</a>
+                </div>
+                            <a href="/brain" class="journal-logo-container">
+                    <img id="logo-Brain" class="journal-logo" src="//oup.silverchair-cdn.com/data/SiteBuilderAssets/Live/Images/brain/brain_title-1836050853.svg" alt="Brain" />
+                </a>
+
+            <div class="society-logo-block">
+            </div> 
+        </div>
+    </div>
+<div class="navbar">
+    <div class="center-inner-row">
+        <nav class="navbar-menu">
+
+
+    <ul class="site-menu site-menu-lvl-0 at-site-menu">
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1600149">
+
+                <a href="/brain/issue" class="nav-link">
+                    Issues
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1600150">
+
+                    <a href="javascript:;" class="nav-link js-nav-dropdown at-nav-dropdown" role="button" aria-expanded="false">
+                        Subject
+                        <i class="desktop-nav-arrow icon-general-arrow-filled-down arrow-icon"></i>
+                    </a>
+                    <i class="mobile-nav-arrow icon-general_arrow-down"></i>
+<div class="site-menu site-menu-lvl-1 tree-browse-wrap js-tree-browse-wrap">
+    <input id="hfMaxRelativeDepth" name="hfMaxRelativeDepth" type="hidden" value="2" />
+    <input id="hfBrowseContentInLinkText" name="hfBrowseContentInLinkText" type="hidden" value="Browse content in " />
+    <div class="animate js-tree-browse-breadcrumb-wrap">
+        <nav class="tree-browse-breadcrumbs js-breadcrumbs">
+            <a href="javascript:;" class="tree-browse-breadcrumb-link js-tree-browse-breadcrumb-link js-root-breadcrumb" data-id="brainj/0">
+                All Subject
+            </a>
+                <a href="javascript:;" class="tree-browse-breadcrumb-link js-tree-browse-breadcrumb-link hide" data-id="">
+                    <span class="screenreader-text">Expand </span>
+                </a>
+                <a href="javascript:;" class="tree-browse-breadcrumb-link js-tree-browse-breadcrumb-link hide" data-id="">
+                    <span class="screenreader-text">Expand </span>
+                </a>
+        </nav>
+    </div>
+    
+    <div class="animate js-tree-browse-nodes-wrap">
+        <nav class="tree-browse js-tree-browse-nodes display-columns">
+                    <div class="tree-node-item js-tree-node-item animate active fade"
+             data-id="brainj/1000"
+             data-parent-id="brainj/0"
+             data-level="1">
+
+                <a href="/brain/search-results?q=&amp;tax=brainj/1000" class="tree-node-link">CNS Injury and Stroke</a>
+
+        </div>
+        <div class="children js-children">
+            
+        </div>
+        <div class="tree-node-item js-tree-node-item animate active fade"
+             data-id="brainj/1010"
+             data-parent-id="brainj/0"
+             data-level="1">
+
+                <a href="/brain/search-results?q=&amp;tax=brainj/1010" class="tree-node-link">Dementia</a>
+
+        </div>
+        <div class="children js-children">
+            
+        </div>
+        <div class="tree-node-item js-tree-node-item animate active fade"
+             data-id="brainj/1020"
+             data-parent-id="brainj/0"
+             data-level="1">
+
+                <a href="/brain/search-results?q=&amp;tax=brainj/1020" class="tree-node-link">Epilepsy and Sleep</a>
+
+        </div>
+        <div class="children js-children">
+            
+        </div>
+        <div class="tree-node-item js-tree-node-item animate active fade"
+             data-id="brainj/1030"
+             data-parent-id="brainj/0"
+             data-level="1">
+
+                <a href="/brain/search-results?q=&amp;tax=brainj/1030" class="tree-node-link">Genetics</a>
+
+        </div>
+        <div class="children js-children">
+            
+        </div>
+        <div class="tree-node-item js-tree-node-item animate active fade"
+             data-id="brainj/1040"
+             data-parent-id="brainj/0"
+             data-level="1">
+
+                <a href="/brain/search-results?q=&amp;tax=brainj/1040" class="tree-node-link">Movement Disorders</a>
+
+        </div>
+        <div class="children js-children">
+            
+        </div>
+        <div class="tree-node-item js-tree-node-item animate active fade"
+             data-id="brainj/1050"
+             data-parent-id="brainj/0"
+             data-level="1">
+
+                <a href="/brain/search-results?q=&amp;tax=brainj/1050" class="tree-node-link">Multiple Sclerosis/Neuroinflammation</a>
+
+        </div>
+        <div class="children js-children">
+            
+        </div>
+        <div class="tree-node-item js-tree-node-item animate active fade"
+             data-id="brainj/1080"
+             data-parent-id="brainj/0"
+             data-level="1">
+
+                <a href="/brain/search-results?q=&amp;tax=brainj/1080" class="tree-node-link">Neuro-oncology</a>
+
+        </div>
+        <div class="children js-children">
+            
+        </div>
+        <div class="tree-node-item js-tree-node-item animate active fade"
+             data-id="brainj/1060"
+             data-parent-id="brainj/0"
+             data-level="1">
+
+                <a href="/brain/search-results?q=&amp;tax=brainj/1060" class="tree-node-link">Neurodegeneration - Cellular &amp; Molecular</a>
+
+        </div>
+        <div class="children js-children">
+            
+        </div>
+        <div class="tree-node-item js-tree-node-item animate active fade"
+             data-id="brainj/1070"
+             data-parent-id="brainj/0"
+             data-level="1">
+
+                <a href="/brain/search-results?q=&amp;tax=brainj/1070" class="tree-node-link">Neuromuscular Disease</a>
+
+        </div>
+        <div class="children js-children">
+            
+        </div>
+        <div class="tree-node-item js-tree-node-item animate active fade"
+             data-id="brainj/1090"
+             data-parent-id="brainj/0"
+             data-level="1">
+
+                <a href="/brain/search-results?q=&amp;tax=brainj/1090" class="tree-node-link">Neuropsychiatry</a>
+
+        </div>
+        <div class="children js-children">
+            
+        </div>
+        <div class="tree-node-item js-tree-node-item animate active fade"
+             data-id="brainj/1100"
+             data-parent-id="brainj/0"
+             data-level="1">
+
+                <a href="/brain/search-results?q=&amp;tax=brainj/1100" class="tree-node-link">Pain and Headache</a>
+
+        </div>
+        <div class="children js-children">
+            
+        </div>
+
+        </nav>
+    </div>
+
+    <div class="tree-browse-link-wrap">
+        <a href="/brain/search-results" class="tree-browse-link js-tree-browse-link-all">Browse all content</a>
+        <a href="/brain/search-results?q=&amp;tax=" class="tree-browse-link js-tree-browse-link-narrowed hide"
+           data-href-template="/brain/search-results?q=&amp;tax=">Browse content in </a>
+    </div>
+</div>
+
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1600146">
+
+                <a href="javascript:;" class="nav-link js-nav-dropdown at-nav-dropdown" role="button" aria-expanded="false">
+                    More Content
+                    <i class="desktop-nav-arrow icon-general-arrow-filled-down arrow-icon"></i>
+                </a>
+                <i class="mobile-nav-arrow icon-general_arrow-down"></i>
+                <ul class="site-menu site-menu-lvl-1 at-site-menu">
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600151">
+
+                <a href="/brain/advance-articles" class="nav-link">
+                    Advance articles
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600152">
+
+                <a href="https://academic.oup.com/brain/search-results?page=1&amp;f_OUPSeries=Editor%27s+Choice" class="nav-link">
+                    Editor's Choice
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600153">
+
+                <a href="https://www.youtube.com/playlist?list=PL4PJR6NGNj7lCHXVjamUmeBOGm2fZs24x" class="nav-link">
+                    Videos
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600154">
+
+                <a href="/brain/pages/brain_oup_blog" class="nav-link">
+                    Blog Posts
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600155">
+
+                <a href="https://academic.oup.com/brain/pages/podcast" class="nav-link">
+                    Podcasts
+                </a>
+            
+        </li>
+            </ul>
+
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1600147">
+
+                <a href="javascript:;" class="nav-link js-nav-dropdown at-nav-dropdown" role="button" aria-expanded="false">
+                    Submit
+                    <i class="desktop-nav-arrow icon-general-arrow-filled-down arrow-icon"></i>
+                </a>
+                <i class="mobile-nav-arrow icon-general_arrow-down"></i>
+                <ul class="site-menu site-menu-lvl-1 at-site-menu">
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600156">
+
+                <a href="/brain/pages/General_Instructions" class="nav-link">
+                    Author Guidelines
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600157">
+
+                <a href="http://mc.manuscriptcentral.com/brain" class="nav-link">
+                    Submission Site
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600158">
+
+                <a href="https://academic.oup.com/brain/pages/why-publish-with-brain" class="nav-link">
+                    Why publish with this journal?
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600159">
+
+                <a href="https://academic.oup.com/brain/pages/General_Instructions#Open-Access" class="nav-link">
+                    Open Access
+                </a>
+            
+        </li>
+            </ul>
+
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1600160">
+
+                <a href="/brain/subscribe" class="nav-link">
+                    Purchase
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1600148">
+
+                <a href="javascript:;" class="nav-link js-nav-dropdown at-nav-dropdown" role="button" aria-expanded="false">
+                    About
+                    <i class="desktop-nav-arrow icon-general-arrow-filled-down arrow-icon"></i>
+                </a>
+                <i class="mobile-nav-arrow icon-general_arrow-down"></i>
+                <ul class="site-menu site-menu-lvl-1 at-site-menu">
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600161">
+
+                <a href="/brain/pages/About" class="nav-link">
+                    About Brain
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600162">
+
+                <a href="/brain/pages/Editorial_Board" class="nav-link">
+                    Editorial Board
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600163">
+
+                <a href="https://academic.oup.com/advertising-and-corporate-services/pages/brain-media-kit" class="nav-link">
+                    Advertising and Corporate Services
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600164">
+
+                <a href="http://medicine-and-health-careernetwork.oxfordjournals.org" class="nav-link">
+                    Journals Career Network
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600165">
+
+                <a href="/my-account/email-alerts" class="nav-link">
+                    Alerts
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600166">
+
+                <a href="https://academic.oup.com/journals/pages/access_purchase/rights_and_permissions/self_archiving_policy_b" class="nav-link">
+                    Self-Archiving Policy
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600167">
+
+                <a href="http://www.oxfordjournals.org/en/access-purchase/dispatch-dates.html" class="nav-link">
+                    Dispatch Dates
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1600168">
+
+                <a href="/brain/pages/Terms_and_Conditions" class="nav-link">
+                    Terms and Conditions
+                </a>
+            
+        </li>
+            </ul>
+
+        </li>
+            </ul>
+        </nav>
+            <div class="navbar-search-container js-navbar-search-container">
+                <a href="javascript:;" class="navbar-search-close js_close-navsearch">Close</a>
+
+
+<div class="navbar-search">
+    <div class="microsite-search">
+            <label for="SitePageHeader-navbar-search-filter" class="screenreader-text js-navbar-search-filter-label">
+                Navbar Search Filter
+            </label>
+            <select class="navbar-search-filter js-navbar-search-filter at-navbar-search-filter" id="SitePageHeader-navbar-search-filter">
+
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="">Brain</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Issue">This issue</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Parent">Brain Journals</option>
+                    <optgroup class="navbar-search-optgroup" label="Search across Oxford Academic">
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/MED00310">Neurology</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/SCI01870">Neuroscience</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Books">Books</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Journals">Journals</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Umbrella">Oxford Academic</option>                    </optgroup>
+            </select>
+
+        <label for="SitePageHeader-microsite-search-term" class="screenreader-text js-microsite-search-term-label">
+            Enter search term
+        </label>
+        <input class="navbar-search-input microsite-search-term js-microsite-search-term at-microsite-search-term" type="text"
+               maxlength="255" placeholder="Search" id="SitePageHeader-microsite-search-term">
+
+        <a href="javascript:;" class="microsite-search-icon navbar-search-submit icon-menu_search">
+            <span class="screenreader-text">Search</span>
+        </a>
+
+    </div>
+</div>
+
+<input id="hfCurrentBookSearch" name="hfCurrentBookSearch" type="hidden" value="" /><input id="hfCurrentBookScope" name="hfCurrentBookScope" type="hidden" value="CurrentBook" /><input id="hfBookSiteScope" name="hfBookSiteScope" type="hidden" value="Books" /><input id="hfSeriesScope" name="hfSeriesScope" type="hidden" value="taxWithOr" /><input id="hfParentSiteName" name="hfParentSiteName" type="hidden" value="Brain Journals" /><input id="hfParentSiteUrl" name="hfParentSiteUrl" type="hidden" value="academic.oup.com/brainjournals" /><input id="hfSiteID" name="hfSiteID" type="hidden" value="5367" /><input id="hfParentSiteID" name="hfParentSiteID" type="hidden" value="6234" /><input id="hfJournalSiteScope" name="hfJournalSiteScope" type="hidden" value="Journals" /><input id="hfParentSiteScope" name="hfParentSiteScope" type="hidden" value="Parent" /><input id="hfDefaultSearchURL" name="hfDefaultSearchURL" type="hidden" value="search-results?page=1&amp;q=" /><input id="hfIssueSearch" name="hfIssueSearch" type="hidden" value="&amp;fl_IssueID=10660" /><input id="hfIssueSiteScope" name="hfIssueSiteScope" type="hidden" value="Issue" /><input id="hfUmbrellaScope" name="hfUmbrellaScope" type="hidden" value="Umbrella" /><input id="hfUmbrellaSiteUrl" name="hfUmbrellaSiteUrl" type="hidden" value="academic.oup.com" /><input id="hfUmbrellaSiteId" name="hfUmbrellaSiteId" type="hidden" value="191" /><input id="hfDefaultAdvancedSearchUrl" name="hfDefaultAdvancedSearchUrl" type="hidden" value="advanced-search?page=1&amp;q=" /><input id="hfTaggedCollectionScope" name="hfTaggedCollectionScope" type="hidden" value="" />                <div class="navbar-search-advanced"><a href="/brain/advanced-search" class="advanced-search js-advanced-search">Advanced Search</a></div>
+            </div>            <div class="navbar-search-collapsed"><a href="javascript:;" class="icon-menu_search js_expand-navsearch"><span class="screenreader-text">Search Menu</span></a></div>
+    </div>
+</div>
+<input id="hfEnableOupOnlineProductsFeatures" name="hfEnableOupOnlineProductsFeatures" type="hidden" value="True" />
+
+    <input type="hidden" name="searchScope" id="hfSolrJournalID" value="" />
+    <input type="hidden" id="hfSolrJournalName" value="" />
+    <input type="hidden" id="hfSolrMaxAllowSearchChar" value="100" />
+    <input type="hidden" id="hfJournalShortName" value="" />
+    <input type="hidden" id="hfSearchPlaceholder" value="" />
+    <input type="hidden" name="hfGlobalSearchSiteURL" id="hfGlobalSearchSiteURL" value="" />
+    <input type="hidden" name="hfSearchSiteURL" id="hfSiteURL" value="academic.oup.com/brain" />
+    <script type="text/javascript">
+        (function () {
+            var hfSiteUrl = document.getElementById('hfSiteURL');
+            var siteUrl = hfSiteUrl.value;
+            var subdomainIndex = siteUrl.indexOf('/');
+
+            hfSiteUrl.value = location.host + (subdomainIndex >= 0 ? siteUrl.substring(subdomainIndex) : '');
+        })();
+    </script>
+<input id="routename" name="RouteName" type="hidden" value="brain" /> 
+    </div>
+
+</section>
+        <div class="widget widget-SitewideBanner widget-instance-">
+        
+
+ 
+    </div>
+
+
+    <div id="main" class="content-main js-main ui-base">
+            <section class="master-main row">
+                <div class="center-inner-row no-overflow">
+                    <div id="skipNav" tabindex="-1"></div>
+                    
+
+
+<div class="page-column-wrap">
+<div id="InfoColumn" class="page-column page-column--left js-left-nav-col">
+    <div class="mobile-content-topbar hide">
+        <button class="toggle-left-col toggle-left-col__article">Article Navigation</button>
+    </div>
+    <div class="info-inner-wrap js-left-nav">
+        <button class="toggle-left-col__close btn-as-icon icon-general-close">
+            <span class="screenreader-text">Close mobile search navigation</span>
+        </button>
+        <div class="responsive-nav-title">Article Navigation</div>
+        <div class="info-widget-wrap">
+    <div class="widget widget-IssueInfo widget-instance-OUP_IssueInfo_Article">
+        
+
+<div id="issueInfo-OUP_IssueInfo_Article" class="article-info-wrap clearfix">
+    <i class="icon-general-close mobile-nav-btn nav-open"></i>
+    <a class="article-issue-link" href="/brain/issue/129/10">
+        <div class="article-issue-img">
+                <img id="issueImage" class="fb-featured-image" src="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/Issue/129/10/0/m_brain129_10.cover.gif?Expires=1689794673&amp;Signature=uZvGSs~3GGkAzr5gMG557sRsEDALyXWAkcbomHRzgKqdPbGXOrr0HPObLH1qPBwz6RIlcFub6SG9eRZdkXADIRG~vFdeWPeMsnm-yKsbQKHml6HHEd2SbXOh56HWhV35ZCwj7hB4OQbTG0UPIo5-SA0btHi1QUZdg3ZwWKj82RZ8lUVktmc08HjK1gOt835qoSAnzITrBSmRB-DXZoY4VJr4MSRQQUlG-XvCeUVppO9jPl~WAHjbeFlKY1tVEuD7zsbxklRkSTFnnY3oLwe-xODfmyt18wbIluZoEoYBeQ9ZkMeRFqPeRqXOysbnemWczZ2bhPZXgJOsJ3RCkQ02YA__&amp;Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" alt="Issue Cover" />
+        </div>
+        <div class="article-issue-info">
+            <div class="volume-issue__wrap">
+
+                        <div class="volume trailing-comma">Volume 129</div>
+                        <div class="issue">Issue 10</div>
+
+
+
+            </div>
+            <div class="ii-pub-date">
+October 2006            </div>
+            
+        </div>
+    </a>
+</div> 
+    </div>
+
+            <div class="content-nav">
+    <div class="widget widget-ArticleJumpLinks widget-instance-OUP_ArticleJumpLinks_Widget">
+        
+
+<h3 class="contents-title" >Article Contents</h3>
+<ul class="jumplink-list js-jumplink-list">
+        <li class="section-jump-link head-1" link-destination="3672155">
+            <div class="section-jump-link__link-wrap">
+
+                <a class="js-jumplink scrollTo" href="#3672155">Abstract</a>
+            </div>
+        </li>
+        <li class="section-jump-link head-1" link-destination="3672159">
+            <div class="section-jump-link__link-wrap">
+
+                <a class="js-jumplink scrollTo" href="#3672159">Introduction</a>
+            </div>
+        </li>
+        <li class="section-jump-link head-1" link-destination="3672165">
+            <div class="section-jump-link__link-wrap">
+
+                <a class="js-jumplink scrollTo" href="#3672165">Material and methods</a>
+            </div>
+        </li>
+        <li class="section-jump-link head-1" link-destination="3672187">
+            <div class="section-jump-link__link-wrap">
+
+                <a class="js-jumplink scrollTo" href="#3672187">Results</a>
+            </div>
+        </li>
+        <li class="section-jump-link head-1" link-destination="3672213">
+            <div class="section-jump-link__link-wrap">
+
+                <a class="js-jumplink scrollTo" href="#3672213">Discussion</a>
+            </div>
+        </li>
+        <li class="section-jump-link head-1 backReferenceLink" link-destination="3672251">
+            <div class="section-jump-link__link-wrap">
+
+                <a class="js-jumplink scrollTo" href="#3672251">References</a>
+            </div>
+        </li>
+</ul>
+ 
+    </div>
+
+            </div>
+    <div class="widget widget-ArticleNavLinks widget-instance-OUP_ArticleNavLinks_Article">
+        <ul class="inline-list">
+        <li class="prev arrow">
+            <a href="/brain/article/129/10/2688/288509">&lt; Previous</a>
+        </li>        
+            <li class="next arrow">
+            <a href="/brain/article/129/10/2709/292098">Next &gt;</a>
+        </li>
+</ul> 
+    </div>
+
+        </div>
+    </div>
+</div>
+<div class="sticky-toolbar js-sticky-toolbar"></div>
+<div id="ContentColumn" class="page-column page-column--center">
+
+    <div class="article-browse-top article-browse-mobile-nav js-mobile-nav">
+    <div class="article-browse-mobile-nav-inner js-mobile-nav-inner">
+        <button class="toggle-left-col toggle-left-col__article btn-as-link">
+            Article Navigation
+        </button>
+    </div>
+</div>
+<div class="article-browse-top article-browse-mobile-nav mobile-sticky-toolbar js-mobile-nav-sticky">
+    <div class="article-browse-mobile-nav-inner">
+        <button class="toggle-left-col toggle-left-col__article btn-as-link">
+            Article Navigation
+        </button>
+    </div>
+</div>
+
+    <div class="content-inner-wrap">
+    <div class="widget widget-ArticleTopInfo widget-instance-OUP_ArticleTop_Info_Widget">
+        <div class="module-widget article-top-widget">
+
+    
+
+    
+        <div class="access-state-logos all-viewports">
+            <span class="journal-info__format-label">Journal Article</span>
+                    </div>
+
+
+    <div class="widget-items">
+                <div class="title-wrap">
+                    <h1 class="wi-article-title article-title-main accessible-content-title at-articleTitle">
+                        The basal ganglia are hyperactive during the discrimination of tactile stimuli in writer's cramp
+<i class='icon-availability_free' title='Free' ></i>                    </h1>
+
+                </div>
+                <div class="wi-authors at-ArticleAuthors">
+                    <div class="al-authors-list">
+                                <span class="al-author-name-more js-flyout-wrap">
+
+
+
+
+
+
+                                    <a class="linked-name js-linked-name-trigger" href="javascript:;">M. Peller</a><span class='delimiter'>, </span>
+
+                                    <span class="al-author-info-wrap arrow-up">
+<div class="info-card-author authorInfo_OUP_ArticleTop_Info_Widget">
+    <div class="name-role-wrap">
+        <div class="info-card-name">
+    M. Peller
+            <span class="info-card-footnote"><span class="xrefLink" id="jumplink-cor1"></span><a href="javascript:;" reveal-id="cor1" data-open="cor1" class="link link-ref link-reveal xref-default"><!----></a></span>
+</div>
+
+    </div>
+
+    <div class="info-card-affilitation">
+        <div class="aff"><span class="label">1</span><sup>1</sup><div class="institution">Department of Neurology, Christian-Albrechts-University Kiel</div><div class="addr-line">Kiel, Germany</div></div><div class="aff"><span class="label">2</span><sup>2</sup><div class="institution">NeuroImageNord Hamburg-Kiel-Lübeck</div><div class="addr-line">Lübeck, Germany</div></div>
+    </div>
+
+    <div class="info-author-correspondence">
+        <div content-id="cor1">Correspondence to: Prof. Dr Hartwig Roman Siebner, Department of Neurology, Christian Albrechts-University Kiel, Schittenhelmstrasse 10, 24105 Kiel, Germany E-mail: <a href="mailto:h.siebner@neurologie.uni-kiel.de" target="_blank">h.siebner@neurologie.uni-kiel.de</a></div>
+    </div>
+    <div class="info-card-search-label">
+        Search for other works by this author on:
+    </div>
+
+<div class="info-card-search info-card-search-internal">
+    <a href="/brain/search-results?f_Authors=M.+Peller" rel="nofollow">Oxford Academic</a>
+</div>
+
+    <div class="info-card-search info-card-search-pubmed">
+        <a href="http://www.ncbi.nlm.nih.gov/pubmed?cmd=search&amp;term=Peller M">PubMed</a>
+    </div>
+    <div class="info-card-search info-card-search-google">
+        <a href="http://scholar.google.com/scholar?q=author:%22Peller M.%22">Google Scholar</a>
+    </div>
+</div>                                    </span>
+                                </span>
+                                <span class="al-author-name-more js-flyout-wrap">
+
+
+
+
+
+
+                                    <a class="linked-name js-linked-name-trigger" href="javascript:;">K. E. Zeuner</a><span class='delimiter'>, </span>
+
+                                    <span class="al-author-info-wrap arrow-up">
+<div class="info-card-author authorInfo_OUP_ArticleTop_Info_Widget">
+    <div class="name-role-wrap">
+        <div class="info-card-name">
+    K. E. Zeuner
+</div>
+
+    </div>
+
+    <div class="info-card-affilitation">
+        <div class="aff"><span class="label">1</span><sup>1</sup><div class="institution">Department of Neurology, Christian-Albrechts-University Kiel</div><div class="addr-line">Kiel, Germany</div></div>
+    </div>
+
+    <div class="info-card-search-label">
+        Search for other works by this author on:
+    </div>
+
+<div class="info-card-search info-card-search-internal">
+    <a href="/brain/search-results?f_Authors=K.+E.+Zeuner" rel="nofollow">Oxford Academic</a>
+</div>
+
+    <div class="info-card-search info-card-search-pubmed">
+        <a href="http://www.ncbi.nlm.nih.gov/pubmed?cmd=search&amp;term=Zeuner K">PubMed</a>
+    </div>
+    <div class="info-card-search info-card-search-google">
+        <a href="http://scholar.google.com/scholar?q=author:%22Zeuner K. E.%22">Google Scholar</a>
+    </div>
+</div>                                    </span>
+                                </span>
+                                <span class="al-author-name-more js-flyout-wrap">
+
+
+
+
+
+
+                                    <a class="linked-name js-linked-name-trigger" href="javascript:;">A. Munchau</a><span class='delimiter'>, </span>
+
+                                    <span class="al-author-info-wrap arrow-up">
+<div class="info-card-author authorInfo_OUP_ArticleTop_Info_Widget">
+    <div class="name-role-wrap">
+        <div class="info-card-name">
+    A. Munchau
+</div>
+
+    </div>
+
+    <div class="info-card-affilitation">
+        <div class="aff"><span class="label">3</span><sup>3</sup><div class="institution">Department of Neurology</div><div class="addr-line">Hamburg University, Hamburg, Germany</div></div>
+    </div>
+
+    <div class="info-card-search-label">
+        Search for other works by this author on:
+    </div>
+
+<div class="info-card-search info-card-search-internal">
+    <a href="/brain/search-results?f_Authors=A.+Munchau" rel="nofollow">Oxford Academic</a>
+</div>
+
+    <div class="info-card-search info-card-search-pubmed">
+        <a href="http://www.ncbi.nlm.nih.gov/pubmed?cmd=search&amp;term=Munchau A">PubMed</a>
+    </div>
+    <div class="info-card-search info-card-search-google">
+        <a href="http://scholar.google.com/scholar?q=author:%22Munchau A.%22">Google Scholar</a>
+    </div>
+</div>                                    </span>
+                                </span>
+                                <span class="al-author-name-more js-flyout-wrap">
+
+
+
+
+
+
+                                    <a class="linked-name js-linked-name-trigger" href="javascript:;">A. Quartarone</a><span class='delimiter'>, </span>
+
+                                    <span class="al-author-info-wrap arrow-up">
+<div class="info-card-author authorInfo_OUP_ArticleTop_Info_Widget">
+    <div class="name-role-wrap">
+        <div class="info-card-name">
+    A. Quartarone
+</div>
+
+    </div>
+
+    <div class="info-card-affilitation">
+        <div class="aff"><span class="label">4</span><sup>4</sup><div class="institution">Department of Neuroscience, Psychiatric and Anaesthesiological Sciences</div><div class="addr-line"> University of Messina, Messina, Italy</div></div>
+    </div>
+
+    <div class="info-card-search-label">
+        Search for other works by this author on:
+    </div>
+
+<div class="info-card-search info-card-search-internal">
+    <a href="/brain/search-results?f_Authors=A.+Quartarone" rel="nofollow">Oxford Academic</a>
+</div>
+
+    <div class="info-card-search info-card-search-pubmed">
+        <a href="http://www.ncbi.nlm.nih.gov/pubmed?cmd=search&amp;term=Quartarone A">PubMed</a>
+    </div>
+    <div class="info-card-search info-card-search-google">
+        <a href="http://scholar.google.com/scholar?q=author:%22Quartarone A.%22">Google Scholar</a>
+    </div>
+</div>                                    </span>
+                                </span>
+                                <span class="al-author-name-more js-flyout-wrap">
+
+
+
+
+
+
+                                    <a class="linked-name js-linked-name-trigger" href="javascript:;">M. Weiss</a><span class='delimiter'>, </span>
+
+                                    <span class="al-author-info-wrap arrow-up">
+<div class="info-card-author authorInfo_OUP_ArticleTop_Info_Widget">
+    <div class="name-role-wrap">
+        <div class="info-card-name">
+    M. Weiss
+</div>
+
+    </div>
+
+    <div class="info-card-affilitation">
+        <div class="aff"><span class="label">1</span><sup>1</sup><div class="institution">Department of Neurology, Christian-Albrechts-University Kiel</div><div class="addr-line">Kiel, Germany</div></div><div class="aff"><span class="label">2</span><sup>2</sup><div class="institution">NeuroImageNord Hamburg-Kiel-Lübeck</div><div class="addr-line">Lübeck, Germany</div></div>
+    </div>
+
+    <div class="info-card-search-label">
+        Search for other works by this author on:
+    </div>
+
+<div class="info-card-search info-card-search-internal">
+    <a href="/brain/search-results?f_Authors=M.+Weiss" rel="nofollow">Oxford Academic</a>
+</div>
+
+    <div class="info-card-search info-card-search-pubmed">
+        <a href="http://www.ncbi.nlm.nih.gov/pubmed?cmd=search&amp;term=Weiss M">PubMed</a>
+    </div>
+    <div class="info-card-search info-card-search-google">
+        <a href="http://scholar.google.com/scholar?q=author:%22Weiss M.%22">Google Scholar</a>
+    </div>
+</div>                                    </span>
+                                </span>
+                                <span class="al-author-name-more js-flyout-wrap">
+
+
+
+
+
+
+                                    <a class="linked-name js-linked-name-trigger" href="javascript:;">A. Knutzen</a><span class='delimiter'>, </span>
+
+                                    <span class="al-author-info-wrap arrow-up">
+<div class="info-card-author authorInfo_OUP_ArticleTop_Info_Widget">
+    <div class="name-role-wrap">
+        <div class="info-card-name">
+    A. Knutzen
+</div>
+
+    </div>
+
+    <div class="info-card-affilitation">
+        <div class="aff"><span class="label">1</span><sup>1</sup><div class="institution">Department of Neurology, Christian-Albrechts-University Kiel</div><div class="addr-line">Kiel, Germany</div></div>
+    </div>
+
+    <div class="info-card-search-label">
+        Search for other works by this author on:
+    </div>
+
+<div class="info-card-search info-card-search-internal">
+    <a href="/brain/search-results?f_Authors=A.+Knutzen" rel="nofollow">Oxford Academic</a>
+</div>
+
+    <div class="info-card-search info-card-search-pubmed">
+        <a href="http://www.ncbi.nlm.nih.gov/pubmed?cmd=search&amp;term=Knutzen A">PubMed</a>
+    </div>
+    <div class="info-card-search info-card-search-google">
+        <a href="http://scholar.google.com/scholar?q=author:%22Knutzen A.%22">Google Scholar</a>
+    </div>
+</div>                                    </span>
+                                </span>
+                                <span class="al-author-name-more js-flyout-wrap">
+
+
+
+
+
+
+                                    <a class="linked-name js-linked-name-trigger" href="javascript:;">M. Hallett</a><span class='delimiter'>, </span>
+
+                                    <span class="al-author-info-wrap arrow-up">
+<div class="info-card-author authorInfo_OUP_ArticleTop_Info_Widget">
+    <div class="name-role-wrap">
+        <div class="info-card-name">
+    M. Hallett
+</div>
+
+    </div>
+
+    <div class="info-card-affilitation">
+        <div class="aff"><span class="label">5</span><sup>5</sup><div class="institution">Human Motor Control Section, Medical Neurology Branch</div><div class="addr-line">National Institute of Neurological Disorders and Stroke, National Institutes of Health, Bethesda, MD, USA</div></div>
+    </div>
+
+    <div class="info-card-search-label">
+        Search for other works by this author on:
+    </div>
+
+<div class="info-card-search info-card-search-internal">
+    <a href="/brain/search-results?f_Authors=M.+Hallett" rel="nofollow">Oxford Academic</a>
+</div>
+
+    <div class="info-card-search info-card-search-pubmed">
+        <a href="http://www.ncbi.nlm.nih.gov/pubmed?cmd=search&amp;term=Hallett M">PubMed</a>
+    </div>
+    <div class="info-card-search info-card-search-google">
+        <a href="http://scholar.google.com/scholar?q=author:%22Hallett M.%22">Google Scholar</a>
+    </div>
+</div>                                    </span>
+                                </span>
+                                <span class="al-author-name-more js-flyout-wrap">
+
+
+
+
+
+
+                                    <a class="linked-name js-linked-name-trigger" href="javascript:;">G. Deuschl</a><span class='delimiter'>, </span>
+
+                                    <span class="al-author-info-wrap arrow-up">
+<div class="info-card-author authorInfo_OUP_ArticleTop_Info_Widget">
+    <div class="name-role-wrap">
+        <div class="info-card-name">
+    G. Deuschl
+</div>
+
+    </div>
+
+    <div class="info-card-affilitation">
+        <div class="aff"><span class="label">1</span><sup>1</sup><div class="institution">Department of Neurology, Christian-Albrechts-University Kiel</div><div class="addr-line">Kiel, Germany</div></div>
+    </div>
+
+    <div class="info-card-search-label">
+        Search for other works by this author on:
+    </div>
+
+<div class="info-card-search info-card-search-internal">
+    <a href="/brain/search-results?f_Authors=G.+Deuschl" rel="nofollow">Oxford Academic</a>
+</div>
+
+    <div class="info-card-search info-card-search-pubmed">
+        <a href="http://www.ncbi.nlm.nih.gov/pubmed?cmd=search&amp;term=Deuschl G">PubMed</a>
+    </div>
+    <div class="info-card-search info-card-search-google">
+        <a href="http://scholar.google.com/scholar?q=author:%22Deuschl G.%22">Google Scholar</a>
+    </div>
+</div>                                    </span>
+                                </span>
+                                <span class="al-author-name-more js-flyout-wrap">
+
+
+
+
+
+
+                                    <a class="linked-name js-linked-name-trigger" href="javascript:;">H. R. Siebner</a><span class='delimiter'></span>
+
+                                    <span class="al-author-info-wrap arrow-up">
+<div class="info-card-author authorInfo_OUP_ArticleTop_Info_Widget">
+    <div class="name-role-wrap">
+        <div class="info-card-name">
+    H. R. Siebner
+</div>
+
+    </div>
+
+    <div class="info-card-affilitation">
+        <div class="aff"><span class="label">1</span><sup>1</sup><div class="institution">Department of Neurology, Christian-Albrechts-University Kiel</div><div class="addr-line">Kiel, Germany</div></div><div class="aff"><span class="label">2</span><sup>2</sup><div class="institution">NeuroImageNord Hamburg-Kiel-Lübeck</div><div class="addr-line">Lübeck, Germany</div></div>
+    </div>
+
+    <div class="info-card-search-label">
+        Search for other works by this author on:
+    </div>
+
+<div class="info-card-search info-card-search-internal">
+    <a href="/brain/search-results?f_Authors=H.+R.+Siebner" rel="nofollow">Oxford Academic</a>
+</div>
+
+    <div class="info-card-search info-card-search-pubmed">
+        <a href="http://www.ncbi.nlm.nih.gov/pubmed?cmd=search&amp;term=Siebner H">PubMed</a>
+    </div>
+    <div class="info-card-search info-card-search-google">
+        <a href="http://scholar.google.com/scholar?q=author:%22Siebner H. R.%22">Google Scholar</a>
+    </div>
+</div>                                    </span>
+                                </span>
+
+                    </div>
+                </div>
+<div class="pub-history-wrap clearfix js-history-dropdown-wrap">
+
+        <div class="pub-history-row clearfix">
+            <div class="ww-citation-primary"><em>Brain</em>, Volume 129, Issue 10, October 2006, Pages 2697–2708, <a href='https://doi.org/10.1093/brain/awl181'>https://doi.org/10.1093/brain/awl181</a></div>
+        </div>
+        <div class="pub-history-row clearfix">
+            <div class="ww-citation-date-wrap">
+                <div class="citation-label">Published:</div>
+                <div class="citation-date">19 July 2006</div>
+            </div>
+                <a href="javascript:;" class="history-label js-history-dropdown-trigger st-article-history at-ArticleHistory">
+                    <span>Article history</span><i class="icon-general-arrow-filled-down arrow-icon"></i>
+                </a>
+        </div>
+            <div class="ww-history js-history-entries-wrap at-history-entries-wrap">
+                <div class="history-entry at-history-entry">
+                    <div class="wi-state">Received:</div>
+                    <div class="wi-date">25 March 2006</div>
+                </div>
+                <div class="history-entry at-history-entry">
+                    <div class="wi-state">Revision received:</div>
+                    <div class="wi-date">02 June 2006</div>
+                </div>
+                <div class="history-entry at-history-entry">
+                    <div class="wi-state">Accepted:</div>
+                    <div class="wi-date">13 June 2006</div>
+                </div>
+                <div class="history-entry at-history-entry">
+                    <div class="wi-state">Published:</div>
+                    <div class="wi-date">19 July 2006</div>
+                </div>
+        </div>
+</div>
+    </div>
+</div>
+
+<script>
+    $(document).ready(function () {
+        $('.article-top-widget').on('click', '.ati-toggle-trigger', function () {
+            $(this).find('.icon-general-add, .icon-minus').toggleClass('icon-minus icon-general-add');
+            $(this).siblings('.ati-toggle-content').toggleClass('hide');
+        });
+
+        // In Chrome, an anchor tag with target="_blank" and a "mailto:" href opens a new tab/window as well as the email client
+        // I suspect this behavior will be corrected in the future
+        // Remove the target="_blank"
+        $('ul.wi-affiliationList').find('a[href^="mailto:"]').each(function () {
+            $(this).removeAttr('target');
+        });
+    });
+</script>
+
+ 
+    </div>
+    <div class="widget widget-ArticleLinks widget-instance-OUP_Article_Links_Widget">
+         
+    </div>
+
+
+        <div class="article-body js-content-body">
+            <div class="toolbar-wrap js-toolbar-wrap">
+                <div class="toolbar-inner-wrap">
+                    <ul id="Toolbar" role="navigation">
+    <li class="toolbar-item item-pdf js-item-pdf">
+        <a class="al-link pdf article-pdfLink" data-article-id="290089" href="/brain/article-pdf/129/10/2697/818980/awl181.pdf">
+            <img src=//oup.silverchair-cdn.com/UI/app/svg/pdf.svg alt="pdf" /><span class="pdf-link-text">PDF</span>
+        </a>
+    </li>
+                                                    <li class="toolbar-item item-link item-split-view">
+                                <a href="javascript:;"
+                                   class="split-view js-split-view st-split-view at-split-view"
+                                   target="">
+                                    <i class="icon-menu-split"></i>
+                                    Split View
+                                </a>
+                            </li>
+
+                        <li class="toolbar-item item-with-dropdown item-views">
+                            <a class="at-views-dropdown drop-trigger" href="javascript:;" data-dropdown="FilterDrop" aria-haspopup="true">
+                                <i class="icon-menu_views"></i>
+                                <div class="toolbar-label">
+                                    <div class="toolbar-text">Views</div>
+                                    <i class="icon-general-arrow-filled-down arrow-icon"></i>
+                                </div>
+                            </a>
+                            <ul id="ViewsDrop" class="f-dropdown" data-dropdown-content aria-label="submenu">
+                                <div class="arrow-up"></div>
+                                <li class="article-content-filter js-article-content-filter" data-content-filter="article-content">
+                                    <a href="javascript:;"><span>Article contents</span></a>
+                                </li>
+                                <li class="at-figures-tables article-content-filter js-article-content-filter" data-content-filter="figures-tables">
+                                    <a href="javascript:;"><span>Figures &amp; tables</span></a>
+                                </li>
+                                <li class="article-content-filter js-article-content-filter" data-content-filter="video">
+                                    <a href="javascript:;"><span>Video</span></a>
+                                </li>
+                                <li class="article-content-filter js-article-content-filter" data-content-filter="audio">
+                                    <a href="javascript:;"><span>Audio</span></a>
+                                </li>
+                                <li class="article-content-filter js-article-content-filter" data-content-filter="supplementary-data">
+                                    <a href="javascript:;"><span>Supplementary Data</span></a>
+                                </li>
+                            </ul>
+                        </li>
+
+
+                        <li class="toolbar-item item-cite js-item-cite">
+    <div class="widget widget-ToolboxGetCitation widget-instance-OUP_Get_Citation">
+        <a href="#" class="js-cite-button at-CiteButton" data-reveal-id="getCitation" data-reveal>
+    <i class="icon-read-more"></i>
+    <span>Cite</span>
+</a>
+
+<div id="getCitation" class="reveal-modal js-citation-modal" data-reveal>
+    <h3 class="modal-title">Cite</h3>
+        <div class="oxford-citation-text">
+            <p>M. Peller <span class='al-author-delim'>and others</span>,  The basal ganglia are hyperactive during the discrimination of tactile stimuli in writer's cramp, <em>Brain</em>, Volume 129, Issue 10, October 2006, Pages 2697–2708, <a href="https://doi.org/10.1093/brain/awl181">https://doi.org/10.1093/brain/awl181</a></p>
+        </div>
+
+    <div class="citation-download-wrap">
+        <form action="/Citation/Download" method="get" id="citationModal">
+            <input type="hidden" name="resourceId" value="290089" />
+            <input type="hidden" name="resourceType" value="3" />
+            <label for="selectFormat" class="hide js-citation-format-label">Select Format</label>
+            <select required name="citationFormat" class="citation-download-format js-citation-format" id="selectFormat">
+                <option selected disabled >Select format</option>
+                        <option value="0" >.ris (Mendeley, Papers, Zotero)</option>
+                        <option value="1" >.enw (EndNote)</option>
+                        <option value="2" >.bibtex (BibTex)</option>
+                        <option value="3" >.txt (Medlars, RefWorks)</option>
+
+            </select>
+            <button class="btn citation-download-link disabled" type="submit">Download citation</button>
+        </form>
+    </div>
+
+    <a class="close-reveal-modal" href="javascript:;"><i class="icon-general-close"></i><span class="screenreader-text">Close</span></a>
+</div>
+ 
+    </div>
+
+                        </li>
+                        <li class="toolbar-item item-tools">
+    <div class="widget widget-ToolboxPermissions widget-instance-OUP_Get_Permissions">
+            <div class="module-widget">
+        <a href="https://s100.copyright.com/AppDispatchServlet?publisherName=OUP&amp;publication=1460-2156&amp;title=The%20basal%20ganglia%20are%20hyperactive%20during%20the%20discrimination%20of%20tactile%20stimuli%20in%20writer%26apos%3Bs%20cramp&amp;publicationDate=2006-07-19&amp;volumeNum=129&amp;issueNum=10&amp;author=Peller%2C%20M.%3B%20Zeuner%2C%20K.%20E.&amp;startPage=2697&amp;endPage=2708&amp;contentId=10.1093%2Fbrain%2Fawl181&amp;oa=&amp;copyright=Oxford%20University%20Press&amp;orderBeanReset=True" id="PermissionsLink" class="" target="_blank">
+            <i class="icon-menu_permissions">
+                <span class="screenreader-text">Permissions Icon</span>
+            </i>
+            Permissions
+        </a>
+    </div>
+ 
+    </div>
+
+                        </li>
+                        
+    <li class="toolbar-item item-with-dropdown item-share">
+        <a href="javascript:;" class="drop-trigger js-toolbar-dropdown at-ShareButton" data-dropdown="ShareDrop">
+            <i class="icon-menu_share"><span class="screenreader-text">Share Icon</span></i>
+            <span class="toolbar-label">
+                <span class="toolbar-text">Share</span>
+                <i class="arrow-icon icon-general-arrow-filled-down js-toolbar-arrow-icon"></i>
+            </span>
+        </a>
+        <ul id="ShareDrop" class="addthis_toolbox addthis_default_style addthis_20x20_style f-dropdown" data-dropdown-content>
+    <li>
+        <a class="st-custom-button addthis_button_facebook"
+           data-network="facebook"
+           data-title="basal ganglia are hyperactive during the discrimination of tactile stimuli in writer&#39;s cramp"
+           data-url="https://academic.oup.com/brain/article/129/10/2697/290089"
+           data-email-subject="basal ganglia are hyperactive during the discrimination of tactile stimuli in writer&#39;s cramp"
+           href="javascript:;"><span>Facebook</span></a>
+    </li>
+    <li>
+        <a class="st-custom-button addthis_button_twitter"
+           data-network="twitter"
+           data-title="basal ganglia are hyperactive during the discrimination of tactile stimuli in writer&#39;s cramp"
+           data-url="https://academic.oup.com/brain/article/129/10/2697/290089"
+           data-email-subject="basal ganglia are hyperactive during the discrimination of tactile stimuli in writer&#39;s cramp"
+           href="javascript:;"><span>Twitter</span></a>
+    </li>
+    <li>
+        <a class="st-custom-button addthis_button_linkedin"
+           data-network="linkedin"
+           data-title="basal ganglia are hyperactive during the discrimination of tactile stimuli in writer&#39;s cramp"
+           data-url="https://academic.oup.com/brain/article/129/10/2697/290089"
+           data-email-subject="basal ganglia are hyperactive during the discrimination of tactile stimuli in writer&#39;s cramp"
+           href="javascript:;"><span>LinkedIn</span></a>
+    </li>
+    <li>
+        <a class="st-custom-button addthis_button_email"
+           data-network="email"
+           data-title="basal ganglia are hyperactive during the discrimination of tactile stimuli in writer&#39;s cramp"
+           data-url="https://academic.oup.com/brain/article/129/10/2697/290089"
+           data-email-subject="basal ganglia are hyperactive during the discrimination of tactile stimuli in writer&#39;s cramp"
+           href="javascript:;"><span>Email</span></a>
+    </li>
+
+
+
+        </ul>
+    </li>
+
+                        
+                    </ul>
+                    <div class="toolbar-search">
+    <div class="widget widget-SitePageHeader widget-instance-OUP_ArticleToolbarSearchBox">
+        
+
+
+
+<div class="dropdown-panel-wrap">
+
+    
+    <div class="dropdown-panel mobile-search-dropdown">
+        <div class="mobile-search-inner-wrap">
+
+
+<div class="navbar-search">
+    <div class="mobile-microsite-search">
+            <label for="OUP_ArticleToolbarSearchBox-mobile-navbar-search-filter" class="screenreader-text js-mobile-navbar-search-filter-label">
+                Navbar Search Filter
+            </label>
+            <select class="mobile-navbar-search-filter js-mobile-navbar-search-filter at-navbar-search-filter" id="OUP_ArticleToolbarSearchBox-mobile-navbar-search-filter">
+
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="">Brain</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Issue">This issue</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Parent">Brain Journals</option>
+                    <optgroup class="navbar-search-optgroup" label="Search across Oxford Academic">
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/MED00310">Neurology</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/SCI01870">Neuroscience</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Books">Books</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Journals">Journals</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Umbrella">Oxford Academic</option>                    </optgroup>
+            </select>
+
+        <label for="OUP_ArticleToolbarSearchBox-mobile-microsite-search-term" class="screenreader-text js-mobile-microsite-search-term-label">
+            Mobile Enter search term
+        </label>
+        <input class="mobile-search-input mobile-microsite-search-term js-mobile-microsite-search-term at-microsite-search-term" type="text"
+               maxlength="255" placeholder="Search" id="OUP_ArticleToolbarSearchBox-mobile-microsite-search-term">
+
+        <a href="javascript:;" class="mobile-microsite-search-icon mobile-search-submit icon-menu_search">
+            <span class="screenreader-text">Search</span>
+        </a>
+
+    </div>
+</div>
+
+
+        </div>
+    </div>
+   
+    <div class="dropdown-panel mobile-nav-dropdown">
+
+    </div>
+
+</div>
+
+
+<div class="navbar">
+    <div class="center-inner-row">
+        <nav class="navbar-menu">
+
+        </nav>
+            <div class="navbar-search-container js-navbar-search-container">
+                <a href="javascript:;" class="navbar-search-close js_close-navsearch">Close</a>
+
+
+<div class="navbar-search">
+    <div class="microsite-search">
+            <label for="OUP_ArticleToolbarSearchBox-navbar-search-filter" class="screenreader-text js-navbar-search-filter-label">
+                Navbar Search Filter
+            </label>
+            <select class="navbar-search-filter js-navbar-search-filter at-navbar-search-filter" id="OUP_ArticleToolbarSearchBox-navbar-search-filter">
+
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="">Brain</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Issue">This issue</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Parent">Brain Journals</option>
+                    <optgroup class="navbar-search-optgroup" label="Search across Oxford Academic">
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/MED00310">Neurology</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/SCI01870">Neuroscience</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Books">Books</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Journals">Journals</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Umbrella">Oxford Academic</option>                    </optgroup>
+            </select>
+
+        <label for="OUP_ArticleToolbarSearchBox-microsite-search-term" class="screenreader-text js-microsite-search-term-label">
+            Enter search term
+        </label>
+        <input class="navbar-search-input microsite-search-term js-microsite-search-term at-microsite-search-term" type="text"
+               maxlength="255" placeholder="Search" id="OUP_ArticleToolbarSearchBox-microsite-search-term">
+
+        <a href="javascript:;" class="microsite-search-icon navbar-search-submit icon-menu_search">
+            <span class="screenreader-text">Search</span>
+        </a>
+
+    </div>
+</div>
+
+                <div class="navbar-search-advanced"><a href="/brain/advanced-search" class="advanced-search js-advanced-search">Advanced Search</a></div>
+            </div>            <div class="navbar-search-collapsed"><a href="javascript:;" class="icon-menu_search js_expand-navsearch"><span class="screenreader-text">Search Menu</span></a></div>
+    </div>
+</div>
+<input id="hfEnableOupOnlineProductsFeatures" name="hfEnableOupOnlineProductsFeatures" type="hidden" value="True" />
+
+<input id="routename" name="RouteName" type="hidden" value="brain" /> 
+    </div>
+
+                    </div>
+                </div>
+            </div>
+            <div id="ContentTab" class="content active">
+    <div class="widget widget-ArticleFulltext widget-instance-OUP_Article_FullText_Widget">
+        <div class="module-widget">
+    <div class="widget-items" data-widgetname="ArticleFulltext">
+
+
+
+
+
+                    <h2 scrollto-destination=3672155 id="3672155" class="abstract-title js-splitscreen-abstract-title" >Abstract</h2>
+<section class="abstract"><p class="chapter-para">Writer's cramp is a focal hand dystonia that specifically affects handwriting. Though writer's cramp has been attributed to a dysfunction of the basal ganglia, the role of the basal ganglia in the pathogenesis of writer's cramp remains to be determined. Seventeen patients with writer's cramp (nine females; age range: 24–71 years) and 17 healthy individuals (six females; age range: 27–68 years) underwent functional MRI (fMRI) while they discriminated the orientation of gratings delivered to the tip of the right index finger. Statistical parametric mapping was used to analyse the fMRI data. The significance level was set at a corrected <em>P</em>-value of 0.05. Relative to healthy controls, patients with writer's cramp showed a widespread bilateral increase in task-related activity in the putamen, caudate nucleus, internal globus pallidus and lateral thalamus. In these areas, hyperactivity was more pronounced in patients who had recently developed writer's cramp. The enhanced response of the basal ganglia to tactile input from the affected hand is compatible with the concept of impaired centre–surround inhibition within the basal ganglia–thalamic circuit and may lead to an excessive activation of sensorimotor cortical areas during skilled movements affected by dystonia. Outside the basal ganglia, dystonic patients showed task-related overactivity in visual cortical areas, left anterior insula and right intraparietal sulcus, but not in the primary or secondary sensory cortex. In addition, task-related activity in the cerebellar nuclei, posterior vermis, right paramedian cerebellar hemisphere and dorsal pons was inversely related with the severity of hand dystonia. Regional activity in these areas may reflect secondary adaptive reorganization at the systems level to compensate for the dysfunction in the basal ganglia–thalamic loop.</p></section>                    <div class="article-metadata-panel clearfix at-ArticleMetadata"></div>
+<div class="kwd-group"><a class="kwd-part kwd-main" href="javascript:;" data-keyword="&quot;basal ganglia&quot;">basal ganglia</a>, <a class="kwd-part kwd-main" href="javascript:;" data-keyword="&quot;focal hand dystonia&quot;">focal hand dystonia</a>, <a class="kwd-part kwd-main" href="javascript:;" data-keyword="&quot;functional MRI&quot;">functional MRI</a>, <a class="kwd-part kwd-main" href="javascript:;" data-keyword="&quot;tactile discrimination&quot;">tactile discrimination</a>, <a class="kwd-part kwd-main" href="javascript:;" data-keyword="thalamus">thalamus</a>, <a class="kwd-part kwd-main" href="javascript:;" data-keyword="&quot;writer's cramp&quot;">writer's cramp</a></div>                    <h3 scrollto-destination=3672158 id="3672158" class="definitionlist-title js-splitscreen-definitionlist-title" >Abbreviations</h3>
+<ul class="def-list"><div class="title">Abbreviations</div><a id="" class="jumplink-placeholder"> </a><li class="def-item"><div class="term" content-id="">ADDS</div><div class="def-wrap"><div class="def"><p class="chapter-para">Arm Dystonia Disability Scale</p></div></div></li><a id="" class="jumplink-placeholder"> </a><li class="def-item"><div class="term" content-id="">BOLD</div><div class="def-wrap"><div class="def"><p class="chapter-para">blood oxygen level-dependent</p></div></div></li><a id="" class="jumplink-placeholder"> </a><li class="def-item"><div class="term" content-id="">fMRI</div><div class="def-wrap"><div class="def"><p class="chapter-para">functional MRI</p></div></div></li><a id="" class="jumplink-placeholder"> </a><li class="def-item"><div class="term" content-id="">SPM</div><div class="def-wrap"><div class="def"><p class="chapter-para">statistical parametric map</p></div></div></li></ul>                    <h2 scrollto-destination=3672159 id="3672159" class="section-title js-splitscreen-section-title" >Introduction</h2>
+<p class="chapter-para">Writer's cramp is a task-specific dystonia of the hand (<span class="xrefLink" id="jumplink-b52"></span><a href="javascript:;" reveal-id="b52" data-open="b52" class="link link-ref link-reveal xref-bibr">Sheehy and Marsden, 1982</a>). Affected patients show co-contractions of agonist and antagonist muscles and an overflow of muscular activity spreading to more proximal muscles during handwriting (<span class="xrefLink" id="jumplink-b52"></span><a href="javascript:;" reveal-id="b52" data-open="b52" class="link link-ref link-reveal xref-bibr">Sheehy and Marsden, 1982</a>). Like other focal dystonias, writer's cramp is commonly attributed to a dysfunction of the basal ganglia (<span class="xrefLink" id="jumplink-b7"></span><a href="javascript:;" reveal-id="b7" data-open="b7" class="link link-ref link-reveal xref-bibr">Berardelli <em>et al</em>., 1998</a>). Evidence for a critical involvement of the basal ganglia–thalamic circuit in the pathogenesis of dystonia stems from clinicopathological studies in patients with symptomatic dystonia (<span class="xrefLink" id="jumplink-b33"></span><a href="javascript:;" reveal-id="b33" data-open="b33" class="link link-ref link-reveal xref-bibr">Marsden <em>et al</em>., 1985</a>) and intracerebral recordings from the globus pallidus and thalamus in patients who received surgery to treat dystonia (<span class="xrefLink" id="jumplink-b62"></span><a href="javascript:;" reveal-id="b62" data-open="b62" class="link link-ref link-reveal xref-bibr">Vitek, 1999</a>; <span class="xrefLink" id="jumplink-b66"></span><a href="javascript:;" reveal-id="b66" data-open="b66" class="link link-ref link-reveal xref-bibr">Zhuang <em>et al</em>., 2004</a>). Intraoperative recordings demonstrated an alteration of neuronal activity in the basal ganglia thalamocortical motor circuits, including changes in mean discharge rate, firing pattern and responsiveness to sensory stimuli (<span class="xrefLink" id="jumplink-b62"></span><a href="javascript:;" reveal-id="b62" data-open="b62" class="link link-ref link-reveal xref-bibr">Vitek, 1999</a>). PET of resting glucose metabolism disclosed an abnormal topographic metabolic profile characterized by co-varying increases in metabolic activity in the lentiform nucleus and other components of the motor system in patients with idiopathic dystonia (<span class="xrefLink" id="jumplink-b16"></span><a href="javascript:;" reveal-id="b16" data-open="b16" class="link link-ref link-reveal xref-bibr">Eidelberg <em>et al</em>., 1995</a>) and carriers of the DYT1 gene mutation (<span class="xrefLink" id="jumplink-b17"></span><a href="javascript:;" reveal-id="b17" data-open="b17" class="link link-ref link-reveal xref-bibr">Eidelberg <em>et al</em>., 1998</a>). PET of regional cerebral blood flow demonstrated an increased modifiability of the cortico-basal ganglia–thalamocortical loops after low-frequency transcranial magnetic stimulation (TMS) over the dorsal premotor cortex (<span class="xrefLink" id="jumplink-b53"></span><a href="javascript:;" reveal-id="b53" data-open="b53" class="link link-ref link-reveal xref-bibr">Siebner <em>et al</em>., 2003</a>).</p><p class="chapter-para">A putative role of the cortico-basal ganglia–thalamocortical loops is to focus and tune the motor output to a specific group of muscles by opening the sensory channel for the expected sensory feedback afferents during movement (<span class="xrefLink" id="jumplink-b27"></span><a href="javascript:;" reveal-id="b27" data-open="b27" class="link link-ref link-reveal xref-bibr">Kaji, 2001</a>). This concept is supported by the functional neuroanatomy of the basal ganglia (<span class="xrefLink" id="jumplink-b36"></span><a href="javascript:;" reveal-id="b36" data-open="b36" class="link link-ref link-reveal xref-bibr">Mink, 1996</a>). The direct pathway in the basal ganglia reduces the inhibitory drive from the output structures of the basal ganglia onto the thalamic ventrolateral nuclei and, thus, facilitates the thalamocortical output to the motor cortex, whereas the indirect pathway exerts an inhibitory effect on the output structures of the basal ganglia, causing a disfacilitation of the thalamocortical output (<span class="xrefLink" id="jumplink-b36"></span><a href="javascript:;" reveal-id="b36" data-open="b36" class="link link-ref link-reveal xref-bibr">Mink, 1996</a>). Concurrent activation of both pathways provides an efficient centre (excitatory) and surround (inhibitory) mechanism for motor control. The direct pathway facilitates the recruitment of a population of cortical neurons that subserve the intended movement, while the indirect pathway inhibits neuronal populations that are related to unwanted movements (<span class="xrefLink" id="jumplink-b36"></span><a href="javascript:;" reveal-id="b36" data-open="b36" class="link link-ref link-reveal xref-bibr">Mink, 1996</a>). It has been proposed that the focusing function of the basal ganglia is faulty in patients with dystonia (<span class="xrefLink" id="jumplink-b27"></span><a href="javascript:;" reveal-id="b27" data-open="b27" class="link link-ref link-reveal xref-bibr">Kaji, 2001</a>). This concept has been corroborated by recent studies that applied TMS to the primary motor cortex and showed deficient centre excitation and surround inhibition during the performance (<span class="xrefLink" id="jumplink-b54"></span><a href="javascript:;" reveal-id="b54" data-open="b54" class="link link-ref link-reveal xref-bibr">Sohn and Hallett, 2004</a>) and imagery (<span class="xrefLink" id="jumplink-b47"></span><a href="javascript:;" reveal-id="b47" data-open="b47" class="link link-ref link-reveal xref-bibr">Quartarone <em>et al</em>., 2005</a>) of simple finger movements in writer's cramp.</p><p class="chapter-para">Another line of research has revealed that central sensory processing is altered in patients with writer's cramp. (<span class="xrefLink" id="jumplink-b24"></span><a href="javascript:;" reveal-id="b24" data-open="b24" class="link link-ref link-reveal xref-bibr">Hallett, 1998</a>; <span class="xrefLink" id="jumplink-b58"></span><a href="javascript:;" reveal-id="b58" data-open="b58" class="link link-ref link-reveal xref-bibr">Tinazzi <em>et al</em>., 2003</a>). Quantitative testing of temporal (<span class="xrefLink" id="jumplink-b6"></span><a href="javascript:;" reveal-id="b6" data-open="b6" class="link link-ref link-reveal xref-bibr">Bara-Jimenez <em>et al</em>., 2000<em>b</em></a>; <span class="xrefLink" id="jumplink-b49"></span><a href="javascript:;" reveal-id="b49" data-open="b49" class="link link-ref link-reveal xref-bibr">Sanger <em>et al</em>., 2001</a>; <span class="xrefLink" id="jumplink-b20"></span><a href="javascript:;" reveal-id="b20" data-open="b20" class="link link-ref link-reveal xref-bibr">Fiorio <em>et al</em>., 2003</a>) and spatial (Bara-Jimenez <em>et al</em>., 2000<em>a</em>; <span class="xrefLink" id="jumplink-b49"></span><a href="javascript:;" reveal-id="b49" data-open="b49" class="link link-ref link-reveal xref-bibr">Sanger <em>et al</em>., 2001</a>; <span class="xrefLink" id="jumplink-b37"></span><a href="javascript:;" reveal-id="b37" data-open="b37" class="link link-ref link-reveal xref-bibr">Molloy <em>et al</em>., 2003</a>) tactile discrimination as well as kinaesthetic perception (<span class="xrefLink" id="jumplink-b23"></span><a href="javascript:;" reveal-id="b23" data-open="b23" class="link link-ref link-reveal xref-bibr">Grunewald <em>et al</em>., 1997</a>) revealed deficits in patients with writer's cramp relative to healthy age-matched controls. Spatial discrimination thresholds were significantly increased in both hands (<span class="xrefLink" id="jumplink-b49"></span><a href="javascript:;" reveal-id="b49" data-open="b49" class="link link-ref link-reveal xref-bibr">Sanger <em>et al</em>., 2001</a>; <span class="xrefLink" id="jumplink-b37"></span><a href="javascript:;" reveal-id="b37" data-open="b37" class="link link-ref link-reveal xref-bibr">Molloy <em>et al</em>., 2003</a>) but showed no correlation with the severity or duration of dystonic symptoms (<span class="xrefLink" id="jumplink-b37"></span><a href="javascript:;" reveal-id="b37" data-open="b37" class="link link-ref link-reveal xref-bibr">Molloy <em>et al</em>., 2003</a>). These psychophysiological abnormalities are paralleled by dysfunctional processing of sensory inputs in writer's cramp, including deficient sensorimotor inhibition (<span class="xrefLink" id="jumplink-b1"></span><a href="javascript:;" reveal-id="b1" data-open="b1" class="link link-ref link-reveal xref-bibr">Abbruzzese <em>et al</em>., 2001</a>; <span class="xrefLink" id="jumplink-b59"></span><a href="javascript:;" reveal-id="b59" data-open="b59" class="link link-ref link-reveal xref-bibr">Tinazzi <em>et al</em>., 2005</a>), disturbances of sensory gating (<span class="xrefLink" id="jumplink-b38"></span><a href="javascript:;" reveal-id="b38" data-open="b38" class="link link-ref link-reveal xref-bibr">Murase <em>et al</em>., 2000</a>) and abnormal integration of dual somatosensory input (<span class="xrefLink" id="jumplink-b57"></span><a href="javascript:;" reveal-id="b57" data-open="b57" class="link link-ref link-reveal xref-bibr">Tinazzi <em>et al</em>., 2000</a>).</p><p class="chapter-para">Using magnetoencephalography (MEG) (<span class="xrefLink" id="jumplink-b4"></span><a href="javascript:;" reveal-id="b4" data-open="b4" class="link link-ref link-reveal xref-bibr">Bara-Jimenez <em>et al</em>., 1998</a>; <span class="xrefLink" id="jumplink-b18"></span><a href="javascript:;" reveal-id="b18" data-open="b18" class="link link-ref link-reveal xref-bibr">Elbert <em>et al</em>., 1998</a>; <span class="xrefLink" id="jumplink-b34"></span><a href="javascript:;" reveal-id="b34" data-open="b34" class="link link-ref link-reveal xref-bibr">Meunier <em>et al</em>., 2001</a>; <span class="xrefLink" id="jumplink-b9"></span><a href="javascript:;" reveal-id="b9" data-open="b9" class="link link-ref link-reveal xref-bibr">Braun <em>et al</em>., 2003</a>) or functional MRI (fMRI) (<span class="xrefLink" id="jumplink-b10"></span><a href="javascript:;" reveal-id="b10" data-open="b10" class="link link-ref link-reveal xref-bibr">Butterworth <em>et al</em>., 2003</a>), several groups demonstrated distorted somatotopic representations of individual digits in the primary somatosensory cortex in patients with task-specific hand dystonia. These findings tie in with the dedifferentiation of cortical sensory maps in a non-human primate model of hand dystonia. In New World owl monkeys, prolonged training of rapid, repetitive, highly stereotypic movements led to a marked degradation of somatosensory cortical representations and the manifestation of hand dystonia (<span class="xrefLink" id="jumplink-b11"></span><a href="javascript:;" reveal-id="b11" data-open="b11" class="link link-ref link-reveal xref-bibr">Byl <em>et al</em>., 1996</a>, <span class="xrefLink" id="jumplink-b12"></span><a href="javascript:;" reveal-id="b12" data-open="b12" class="link link-ref link-reveal xref-bibr">1997</a>). A similar somatosensory dedifferentiation was demonstrated in the human thalamus with intraoperative recordings in dystonic patients who underwent thalamotomy (<span class="xrefLink" id="jumplink-b30"></span><a href="javascript:;" reveal-id="b30" data-open="b30" class="link link-ref link-reveal xref-bibr">Lenz and Byl, 1999<em>a</em></a>; <span class="xrefLink" id="jumplink-b31"></span><a href="javascript:;" reveal-id="b31" data-open="b31" class="link link-ref link-reveal xref-bibr">Lenz <em>et al</em>., 1999<em>b</em></a>)</p><p class="chapter-para">Here, we used blood oxygen level-dependent (BOLD) fMRI while participants had to discriminate the grating orientation of a plastic dome that was gently pressed on the tip of the right index finger. The study was designed to test the hypothesis that dysfunctional processing of tactile inputs from the affected hand would lead to an excessive activation of the basal ganglia and somatosensory cortex in writer's cramp relative to healthy controls. Since previous studies showed that patients with writer's cramp are significantly impaired on this task (<span class="xrefLink" id="jumplink-b5"></span><a href="javascript:;" reveal-id="b5" data-open="b5" class="link link-ref link-reveal xref-bibr">Bara-Jimenez <em>et al</em>., 2000<em>a</em></a>; <span class="xrefLink" id="jumplink-b49"></span><a href="javascript:;" reveal-id="b49" data-open="b49" class="link link-ref link-reveal xref-bibr">Sanger <em>et al</em>., 2001</a>;<span class="xrefLink" id="jumplink-b37"></span><a href="javascript:;" reveal-id="b37" data-open="b37" class="link link-ref link-reveal xref-bibr"> Molloy <em>et al</em>., 2003</a>), we reasoned that this task would be particularly suited to reveal dysfunctional processing in the sensory cortex and basal ganglia. We further predicted that patients with writer's cramp would recruit additional cortical and subcortical areas such as occipitoparietal cortex and the cerebellum to compensate for impaired processing in the somatosensory system.</p>                    <h2 scrollto-destination=3672165 id="3672165" class="section-title js-splitscreen-section-title" >Material and methods</h2>
+                    <h3 scrollto-destination=3672166 id="3672166" class="section-title js-splitscreen-section-title" >Participants</h3>
+<p class="chapter-para">We studied 17 patients with writer's cramp (nine females; 50.6 ± 12.2 years; range: 24–71 years) and 17 healthy individuals (six females; age = 49.8 ± 13.8; range: 27–68 years). Participants were consistent right-handers according to the Edinburgh handedness inventory (<span class="xrefLink" id="jumplink-b42"></span><a href="javascript:;" reveal-id="b42" data-open="b42" class="link link-ref link-reveal xref-bibr">Oldfield, 1971</a>). Before participating in the experiment, subjects gave written informed consent according to the Declaration of Helsinki. The experimental protocol was approved by the local ethics committee.</p><p class="chapter-para">In patients, the diagnosis of writer's cramp was based on medical history and standard clinical examination. The clinical course was compatible with primary dystonia, with no features to suggest secondary dystonia. Other inclusion criteria were (i) no cause for dystonia disclosed by investigation, including MRI and biochemical tests; (ii) no peripheral neuropathy of the right median or ulnar nerve as revealed by standard neurography; (iii) no history of neuroleptic medication; (iv) no history of other neurological or psychiatric disease; and (v) a tactile discrimination threshold of at least 3.0 mm (for details, <em>see</em> below).</p><p class="chapter-para">We screened 22 patients with writer's cramp who had a history of at least 2 years of impaired handwriting. Five patients were excluded from the study because neurography revealed a carpal tunnel syndrome (<em>n</em> = 2) or tactile discrimination threshold was &gt;3.0 mm (<em>n</em> = 3). The remaining 17 patients had a mean disease duration of 10.0 ± 7.3 years, ranging from 2 to 25 years. Writer's cramp was defined as simple if dystonia was present only during writing and as dystonic if dystonia was also present during other manual motor tasks (<span class="xrefLink" id="jumplink-b52"></span><a href="javascript:;" reveal-id="b52" data-open="b52" class="link link-ref link-reveal xref-bibr">Sheehy and Marsden, 1982</a>). Five patients had simple writer's cramp, whereas 12 patients had dystonic writer's cramp. In the group presenting with dystonic writer's cramp, five patients reported additional difficulties only when using a PC-mouse. Seven patients noted dystonic symptoms during other manual tasks. No patient presented with dystonia at rest. Fourteen patients had been previously treated with botulinum toxin injections. Those patients were studied at least 3 months after the last injections, and any drug effect had fully worn off at the time of the experiment. None of the participants was taking medication known to modulate the function of the CNS, including anticholinergic drugs.</p><p class="chapter-para">We used the Arm Dystonia Disability Scale (ADDS) according to Fahn to assess the functional impairment of manual activity in each patient (<span class="xrefLink" id="jumplink-b19"></span><a href="javascript:;" reveal-id="b19" data-open="b19" class="link link-ref link-reveal xref-bibr">Fahn, 1989</a>). A score of 100% indicated that arm dystonia did not affect motor function. At a score of 90%, manual motor activities were not affected, but the patient was socially affected by dystonia. Patients who reported any limitations of functional activities had to answer seven questions that referred to daily manual activities, using a score from 0 to 3. The total points scored were divided by the maximum possible points and multiplied by 90. The result was then subtracted from 90%. The final score presents the percentage of normal manual activity (i.e. the lower the ADDS score the more severe the functional impairment). The patients who participated in the fMRI study had a mean ADDS score of 58.1 ± 15.5% (range: 17.1–77.1%).</p>                    <h3 scrollto-destination=3672171 id="3672171" class="section-title js-splitscreen-section-title" >Psychophysiological measurements</h3>
+<p class="chapter-para">Before the fMRI experiment, tactile spatial acuity was evaluated at the tip of the right and left index finger using a set of eight hemispheric plastic domes (Stoelting, Wood Dale, IL, USA). Testing was performed according to the procedure reported by <span class="xrefLink" id="jumplink-b60"></span><a href="javascript:;" reveal-id="b60" data-open="b60" class="link link-ref link-reveal xref-bibr">Van Boven and Johnson (1994</a>). Participants were seated comfortably in a chair with their eyes closed and the arm held in a supine position. These domes had gratings of different gap values (mm): 3.0, 2.0, 1.5, 1.2, 1.0, 0.75, 0.50 and 0.35. Domes were applied in decreasing order of gap values. During testing, a dome was gently pressed for ∼1 s on the tip of the right index finger. For each gap value, a random sequence of horizontal and vertical grating orientations were applied and participants were required to identify the orientation. If participants were unsure, they were asked to guess in order to obtain an answer for all 20 applications. The grating discrimination threshold was defined as the gap value at which the participant identified 75% of the orientations correctly. Only individuals with a tactile discrimination threshold of at least 3.0 mm were included in the study.</p><p class="chapter-para">Differences in mean grating discrimination threshold between groups were assessed using a two-sample <em>t</em>-test. Because the grating discrimination threshold increases with age (<span class="xrefLink" id="jumplink-b40"></span><a href="javascript:;" reveal-id="b40" data-open="b40" class="link link-ref link-reveal xref-bibr">O'Dwyer <em>et al</em>., 2005</a>), simple linear regression was used to characterize the age-related decrease of sensory thresholds in both groups. Group data are presented as means ± 1-fold SD.</p>                    <h3 scrollto-destination=3672174 id="3672174" class="section-title js-splitscreen-section-title" >Experimental paradigm</h3>
+<p class="chapter-para">We employed an epoch-related fMRI design to map regional changes in BOLD signal while participants discriminated the orientation of gratings delivered to the tip of the right index finger. In contrast to previous studies that mapped regional neuronal activity during tonic vibration (<span class="xrefLink" id="jumplink-b56"></span><a href="javascript:;" reveal-id="b56" data-open="b56" class="link link-ref link-reveal xref-bibr">Tempel and Perlmutter, 1993</a>;<span class="xrefLink" id="jumplink-b10"></span><a href="javascript:;" reveal-id="b10" data-open="b10" class="link link-ref link-reveal xref-bibr"> Butterworth <em>et al</em>., 2003</a>), we chose a tactile discrimination task because the task required active processing of the sensory stimuli.</p><p class="chapter-para">Each fMRI session consisted of two alternating 25-s epochs of rest and task (<span class="xrefLink" id="jumplink-fig1"></span><a href="javascript:;" data-modal-source-id="fig1" class="link xref-fig">Fig. 1</a>). Participants kept their eyes open fixating a central cross presented on the screen. During the rest condition, subjects were instructed to look straight ahead and rest. During the grating orientation task, the examiner (H.R.S. or M.P.) repeatedly applied a horizontally or vertically oriented plastic dome (Johnson-Van Boven-Phillips domes, Stoelting, Wood Dale, IL, USA) to the tip of the participant's right index finger for ∼1 s (<span class="xrefLink" id="jumplink-b60"></span><a href="javascript:;" reveal-id="b60" data-open="b60" class="link link-ref link-reveal xref-bibr">Van Boven and Johnson, 1994</a>). Tactile stimulation was repeated five times every 5 s with the same dome without changing the orientation (<span class="xrefLink" id="jumplink-fig1"></span><a href="javascript:;" data-modal-source-id="fig1" class="link xref-fig">Fig. 1</a>). The examiner wore fMRI-compatible headphones connected via a plastic tube to the room outside the magnet. An instruction alerted the examiner to the next trial. The onset and duration of sensory stimulation were indicated by a tone to standardize sensory stimulation across trials and sessions. Two seconds before tactile stimulation, a visual warning cue was presented to alert the participants to the first tactile stimulus. After the application of the fifth stimulus, participants were prompted by a visual cue to judge the orientation of the gratings by pressing a button with the left index finger (smooth surface), middle finger (vertical orientation) or ring finger (horizontal orientation). Participants were asked to make their responses during a 2 s period after the visual cue. Button presses were recorded using an fMRI-compatible response box.</p>                    <a id="3672177" scrollto-destination="3672177"></a>
+<div data-id="fig1" data-content-id="fig1" class="fig fig-section js-fig-section" swap-content-for-modal="true"><div class="label fig-label"><strong>Fig. 1</strong></div><div class="graphic-wrap"><img class="content-image" src="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/m_awl181f1.gif?Expires=1689794673&amp;Signature=tS6rruUHYfjU7YKRI10XAYnjPkf8On6MeI~pI7yyr~20dEjPfAW5bObRgm2GLS6-P9CENK4D2QVxE06ZT-YSTMFq05rqTyI3phv~9gyhPvHfsx-3YTy5pknClb5E8XqNU2n9OCT~7uOUu6PuPRmuW2H6xQeE5i~jzWeSofA3FYByxiepXo3cOf9mgEtqDXDzw5qK3S31aHHOXsiAIxC3LdSF1wU-rgCt5DzxyZaLAuNOS64uP1UW4v82C0hxp~6aPj9fihk4gGJQjLF8F9rBWsmxYNNMcTgzWQuUjuxNbv6An4~83d8AwXZct6T8I~pe6D3Mii4q3drOT37kdctXSQ__&amp;Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" alt="Experimental design. Each fMRI session consisted of two alternating 25-s epochs with and without tactile stimulation. During the stimulation blocks an experimenter gently pressed a horizontally or vertically oriented plastic dome onto the pad of the participant's right index finger. In a single block, the same stimulus was repeatedly applied for 1 s every 5 s. After the fifth stimulus, participants were required to indicate the orientation of the gratings by pressing a button with the left index finger (smooth surface), middle finger (vertical orientation) or ring finger (horizontal orientation). We used two domes with a gap value of 0.35 mm and of 3.0 mm and two grating orientations for tactile stimulation (panel marked by the dotted line). Gratings with a gap value of 0.35 mm were below tactile discrimination threshold and perceived as smooth surface. Conversely, gratings with a gap of 3.0 mm were above the tactile discrimination threshold and the horizontal and vertical grating orientations were easily perceived by the participants." data-path-from-xml="awl181f1.gif" /><div class="fig-orig original-slide"><a class="fig-view-orig js-view-large at-figureViewLarge openInAnotherWindow" href="/view-large/figure/3672177/awl181f1.gif" data-path-from-xml="awl181f1.gif" target="_blank">Open in new tab</a><a data-section="3672177" href="/DownloadFile/DownloadImage.aspx?image=https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/awl181f1.gif?Expires=1689794673&Signature=qUag2wLx3inQoZhzB58DbElDn-UkaWak-HCN7pssLTK-JnY3~yiivJNWkVmKlKm2s9sFEeZNATZ7Hvq3NWaTIOIgpJoUQu5tZ4TEqfWk4ztq3J-~Um2BThaxWU-wW0BMLiSuQlRKScutBwi3DIR9oz2~sm7nqorsuaWb8sGXplwkg1qlVj6JEu1LyN4xw-Ih9XzGpSn2ojzj-gLnKExj0x3ojauAoWsVH6hiONvAMHkckKHhoJI5WnGlTv2uq8fe-LXER8lBU0EfXem1xXRbwnJ4zkHLIEtYtnu71HpAzgyGiu1pR2kyvB3roIwoHUK3C-ilSoKGt5nmAUlPBW4Bwg__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA&sec=3672177&ar=290089&xsltPath=~/UI/app/XSLT&imagename=&siteId=5367" class="download-slide" data-path-from-xml="awl181f1.gif">Download slide</a></div></div><div class="caption fig-caption"><p class="chapter-para">Experimental design. Each fMRI session consisted of two alternating 25-s epochs with and without tactile stimulation. During the stimulation blocks an experimenter gently pressed a horizontally or vertically oriented plastic dome onto the pad of the participant's right index finger. In a single block, the same stimulus was repeatedly applied for 1 s every 5 s. After the fifth stimulus, participants were required to indicate the orientation of the gratings by pressing a button with the left index finger (smooth surface), middle finger (vertical orientation) or ring finger (horizontal orientation). We used two domes with a gap value of 0.35 mm and of 3.0 mm and two grating orientations for tactile stimulation (panel marked by the dotted line). Gratings with a gap value of 0.35 mm were below tactile discrimination threshold and perceived as smooth surface. Conversely, gratings with a gap of 3.0 mm were above the tactile discrimination threshold and the horizontal and vertical grating orientations were easily perceived by the participants.</p></div></div><p class="chapter-para">Because sensory stimulation and response preparation were separated in time, it was possible to dissociate neuronal processes related to sensory processing from those implicated in response generation.</p><p class="chapter-para">Since previous studies showed an increase in the discrimination threshold of grating orientation in patients with focal hand dystonia (<span class="xrefLink" id="jumplink-b5"></span><a href="javascript:;" reveal-id="b5" data-open="b5" class="link link-ref link-reveal xref-bibr">Bara-Jimenez <em>et al</em>., 2000<em>a</em></a>; <span class="xrefLink" id="jumplink-b49"></span><a href="javascript:;" reveal-id="b49" data-open="b49" class="link link-ref link-reveal xref-bibr">Sanger <em>et al</em>., 2001</a>;<span class="xrefLink" id="jumplink-b37"></span><a href="javascript:;" reveal-id="b37" data-open="b37" class="link link-ref link-reveal xref-bibr"> Molloy <em>et al</em>., 2003</a>), we were concerned that differences in task-related changes in BOLD signal might be confounded by between-group differences in task difficulty or task performance. To avoid this confound, we designed a grating orientation task that could be easily performed by the patients. During fMRI, we applied domes with gap values of 3.0 and 0.35 mm. Each dome was gently pressed on to the tip of the right index finger using a horizontal or vertical grating orientation. The grating orientation of the dome with the large gap value (3.0 mm) could be easily perceived by all participants. Conversely, the gratings of the dome with the small gap value (0.35 mm) were clearly below the tactile perception threshold of all participants and consistently perceived as having a smooth surface. The grating orientation task was repeated 12 times per fMRI session. The four stimuli (0.35 mm gap/horizontal orientation; 0.35 mm gap/vertical orientation; 3.0 mm gap/horizontal orientation; 3.0 mm gap/vertical orientation) were presented three times per fMRI session in a pseudorandom order. It should be noted that we only included individuals with a tactile discrimination threshold of at least 3.0 mm. This selection criterion ensured that patients and controls could easily perform the task.</p>                    <h3 scrollto-destination=3672180 id="3672180" class="section-title js-splitscreen-section-title" >Functional magnetic resonance imaging</h3>
+<p class="chapter-para">Structural and fMRI were conducted with an MR scanner at 3 T (Trio, Siemens, Erlangen) while participants performed a grating orientation task. A T<sub>1</sub>-weighted FLASH 3D sequence was used for structural MRI of the whole brain [repetition time (TR) = 15 ms, echo time (TE) = 4.92 ms, flip angle = 25°, 192 slices, slice thickness = 1 mm, gap: 20%, matrix: 256 × 256 mm]. fMRI was performed using single-shot gradient-echo echo-planar imaging (TR = 2670 ms, TE = 25 ms, flip angle = 80°) to measure task-related changes in BOLD signal as an index of regional synaptic activity. fMRI measurements covered the whole brain (35 transverse slices, slice thickness = 3 mm, gap: 0%, matrix: 64 × 64 voxels, in-plane resolution = 3 × 3 mm). The position of the head was stabilized with foam to minimize head movements. The fMRI experiment consisted of a single session lasting ∼13 min (300 brain volumes per session).</p><p class="chapter-para">The Presentation software package (Neurobehavioural Systems, Inc., Albany, CA, USA) was used for presentation of the visual (participant) and auditory (examiner) instruction cues as well as synchronization of stimulus presentation, image pulse acquisition and recordings of motor responses during fMRI. Visual stimuli were projected with a video-projector on a screen that was positioned in the magnet's bore. Participants viewed the stimuli via a mirror that reflected the image displayed on the screen.</p><p class="chapter-para">fMRI data were analysed using SPM2 (<a class="link link-uri openInAnotherWindow" href="http://www.fil.ion.ucl.ac.uk/spm" target="_blank">Author Webpage</a>). The first three scans of each session were excluded from data analysis because of the non-equilibrium state of magnetization. The effect of head motion across time was corrected for by realigning all scans to the first scan of the first session. Realigned images were spatially normalized to a standard echo-planar imaging template and spatially smoothed using an isotropic Gaussian kernel at 8-mm full width at half-maximum.</p><p class="chapter-para">For individual subject analysis (first level), a general linear model was specified using multiple regression analysis (<span class="xrefLink" id="jumplink-b21"></span><a href="javascript:;" reveal-id="b21" data-open="b21" class="link link-ref link-reveal xref-bibr">Friston <em>et al</em>., 1995</a>). Task-related changes in BOLD signal were estimated at each voxel by modelling the onsets of each event (e.g. application of the dome) as delta functions convolved with a haemodynamic response function (HRF). For tactile stimulation, we specified two separate regressors that modelled the time of stimulus application for the dome with small and large gap value separately. Two additional regressors were included to model event-related BOLD signal changes induced by the visual warning cue and the motor response, respectively. Regression coefficients for all regressors were estimated using least squares within SPM2 (<span class="xrefLink" id="jumplink-b21"></span><a href="javascript:;" reveal-id="b21" data-open="b21" class="link link-ref link-reveal xref-bibr">Friston <em>et al</em>., 1995</a>). Condition-specific effects were tested using the appropriate linear contrasts of the parameter estimates for the HRF regressors of all trial types, resulting in a <em>t</em>-statistic for each voxel. These <em>t</em>-statistics constitute a statistical parametric map (SPM). For each participant, we generated separate SPMs that estimated relative BOLD signal increases elicited by tactile stimulation with 3.0- and 0.35-mm gratings as well as relative differences in BOLD signal between the two types of tactile stimulation (stimulation with 3.0-mm gratings versus stimulation with 0.35-mm gratings).</p><p class="chapter-para">At a group level (second level), random-effects models were used to test for between-group differences in task-related brain activations. For each contrast, the contrast images from the first level were entered into a second-level <em>t</em>-test, to create SPM<em><sub>t</sub></em>. We used a one-sample <em>t</em>-test for within-group comparisons and a two-sample <em>t</em>-test for between-groups comparisons. In patients with writer's cramp, we additionally performed within-group regression analyses to identify areas in which task-related changes in BOLD signal showed a linear relationship with disease severity (as indexed by the ADDS score), disease duration or grating discrimination threshold. The individual age of each patient was entered in the statistical model as additional regressor of no interest to account for possible age effects.</p><p class="chapter-para">SPMs were interpreted by referring to the probabilistic behaviour of Gaussian random fields. A statistical threshold of <em>P</em> &lt; 0.05 was applied for all analyses. <em>P</em>-values were corrected for multiple non-independent comparisons across the entire brain volume. Correction for multiple testing was performed at a cluster level using the family-wise-error method and an extent threshold of <em>P</em> &lt; 0.01. For each cluster, stereotactic coordinates (<em>x</em>, <em>y</em>, <em>z</em> in millimetres) refer to local maxima and <em>Z</em><sub>max</sub>, to the corresponding <em>Z</em>-score. The areas showing significant changes in BOLD signal were characterized in terms of cluster size (number of voxels per cluster) and the voxel showing peak difference (<em>Z</em>-score and stereotactic coordinates).</p>                    <h2 scrollto-destination=3672187 id="3672187" class="section-title js-splitscreen-section-title" >Results</h2>
+<p class="chapter-para">All participants found the discrimination task easy to perform. Two patients and two controls made a single false response; the remaining participants committed no errors during the fMRI session. The examiner who was continuously present in the MR suite to apply the plastic domes to the right index finger did not notice movements of the right hand or dystonic symptoms in any of the participants.</p>                    <h3 scrollto-destination=3672189 id="3672189" class="section-title js-splitscreen-section-title" >Grating orientation discrimination</h3>
+<p class="chapter-para">Between-group comparison revealed no differences in grating discrimination threshold between patients and controls who participated in the fMRI study (<em>P</em> &gt; 0.4). In patients, the mean discrimination threshold was 1.60 ± 0.70 and 1.74 ± 0.68 mm for the right or left index finger. Healthy controls showed comparable thresholds of 1.68 ± 0.74 and 1.38 ± 0.84 mm for the right or left index finger. While healthy controls showed a linear increase of the discrimination threshold with age (<em>r</em><sup>2</sup> = 0.57; β = 0.775; <em>P</em> &lt; 0.001), patients only showed a trend towards a linear increase in discrimination threshold with age (<em>r</em><sup>2</sup> = 0.11; β = 0.407; <em>P</em> = 0.105).</p>                    <h3 scrollto-destination=3672191 id="3672191" class="section-title js-splitscreen-section-title" >BOLD responses to tactile stimulation common to both groups</h3>
+<p class="chapter-para">In patients and controls, tactile stimulation of the right index finger activated a widespread set of cortical and subcortical sensorimotor areas relative to rest baseline (<span class="xrefLink" id="jumplink-fig2"></span><a href="javascript:;" data-modal-source-id="fig2" class="link xref-fig">Fig. 2</a>). Regional increases in BOLD signal were found in a large bilateral cluster covering lateral and mesial areas of the frontoparietal cortex, including the primary and secondary somatosensory cortices, parietal opercular cortex, intraparietal sulcus, angular and supramarginal gyri, caudal SMA, anterior cingulate cortex, lateral prefrontal cortex, and dorsal and ventral premotor cortices (<span class="xrefLink" id="jumplink-fig2"></span><a href="javascript:;" data-modal-source-id="fig2" class="link xref-fig">Fig. 2</a>). Additional bilateral activations were observed in the anterior insular cortex and superior temporal gyrus. While we found some task-related activation in the left primary motor cortex, the right primary motor cortex was relatively spared (<span class="xrefLink" id="jumplink-fig2"></span><a href="javascript:;" data-modal-source-id="fig2" class="link xref-fig">Fig. 2</a>). Only patients with writer's cramp showed a consistent activation of occipital visual areas. Subcortical increases in BOLD signal comprised the upper part of the cerebellar hemispheres, putamen, internal globus pallidus, the body of the caudate nucleus, thalamus, substantia nigra and the subthalamic region bilaterally (<span class="xrefLink" id="jumplink-fig2"></span><a href="javascript:;" data-modal-source-id="fig2" class="link xref-fig">Fig. 2</a>).</p>                    <a id="3672193" scrollto-destination="3672193"></a>
+<div data-id="fig2" data-content-id="fig2" class="fig fig-section js-fig-section" swap-content-for-modal="true"><div class="label fig-label"><strong>Fig. 2</strong></div><div class="graphic-wrap"><img class="content-image" src="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/m_awl181f2.gif?Expires=1689794673&amp;Signature=mj5qldpZXZQ6iYFo2HieBKvR0NpX2ZCNl7T2ZrvPRMq740Kf82sHqwD~ClUV4iORzjFbGLblzZjtrP6zQVnZA12n2UkWaG-v76Tu7mZz2N9Jn1A818O5ZURwFRvbC9c9-l0t1pxLeIAttKMUEtkEKO9oHunUf-uQAoSTQ14VUMQ0fyRWsJTbq8CWoUoUZJQL3bqUbU~lyjOtsVBiI71ZdKb-zNn5kRyqtCMiMQRP5sL-iX9Ogn543IYuI6vBqm~cmOezrp43mMb4d-hnCLCo3cWYV7K~gJiNhwGEDe3YXx8M6AQzBOEc4lYYqO-R~FDrEnHMwR2RIluUJ42jP8zv8Q__&amp;Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" alt="Regional increases in BOLD signal during grating orientation discrimination in patients with writer's cramp and healthy controls. The sagittal, coronal and axial Z-score maps show brain regions with increased activity during tactile stimulation regardless of the gap width of the domes (extent threshold: P &lt; 0.01, uncorrected). Z-score maps are superimposed on the T1-weighted MRI template implemented in SPM2. The corresponding stereotactic coordinate (z-value in millimetres) is given for each axial slice. L = left; R = right." data-path-from-xml="awl181f2.gif" /><div class="fig-orig original-slide"><a class="fig-view-orig js-view-large at-figureViewLarge openInAnotherWindow" href="/view-large/figure/3672193/awl181f2.gif" data-path-from-xml="awl181f2.gif" target="_blank">Open in new tab</a><a data-section="3672193" href="/DownloadFile/DownloadImage.aspx?image=https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/awl181f2.gif?Expires=1689794673&Signature=GUMlI0OR~ZF4oSi0yhuwBdBJsTYjVVgz42L7w4PfOTDGNWSm1XCObqqq~JabQU9UStKd1TUSDBRm7ehSfumVPgk~KcqIcTls~9eRUbIJYdWJ3yskzEipca49bXCYGI~WJfqH2co8WWKEtT~Uf-xL7MfvmQ~7tL784ihgZgvkpebvxwhtk~Ay4i3gy7qpjJrikP7TRqR0qygbLaFtE1h-tnBTwO3r6ssk-SkDfHtosgxHQitLJZV7F-Zh-~WKKlRnebcQUBtb5PM3dS~yCN7vy8hzvKANAr86BHIW3iGL5wCYlb8H8rBJ4FfXrMXJ0a11WCyeQeXNMwiNYcMxIu8dRg__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA&sec=3672193&ar=290089&xsltPath=~/UI/app/XSLT&imagename=&siteId=5367" class="download-slide" data-path-from-xml="awl181f2.gif">Download slide</a></div></div><div class="caption fig-caption"><p class="chapter-para">Regional increases in BOLD signal during grating orientation discrimination in patients with writer's cramp and healthy controls. The sagittal, coronal and axial <em>Z</em>-score maps show brain regions with increased activity during tactile stimulation regardless of the gap width of the domes (extent threshold: <em>P</em> &lt; 0.01, uncorrected). <em>Z</em>-score maps are superimposed on the T<sub>1</sub>-weighted MRI template implemented in SPM2. The corresponding stereotactic coordinate (<em>z-</em>value in millimetres) is given for each axial slice. L = left; R = right.</p></div></div><p class="chapter-para">Only gratings with a groove width of 3.0 mm resulted in the perception of grating orientation, whereas gratings with a small groove width of 0.35 mm were perceived as smooth surface. Considering both groups together, we compared the activation patterns elicited by the two types of domes (<span class="xrefLink" id="jumplink-fig3"></span><a href="javascript:;" data-modal-source-id="fig3" class="link xref-fig">Fig. 3</a> and <span class="xrefLink" id="jumplink-tbl1"></span><a href="javascript:;" reveal-id="tbl1" data-open="tbl1" class="link link-reveal link-table xref-fig">Table 1</a>). Tactile stimulation with a groove width of 3.0 mm (i.e. being perceived as oriented gratings) led to bilateral increases in BOLD signal in the intraparietal sulcus and frontal eye fields relative to tactile stimulation with a groove width of 0.35 mm (i.e. being perceived as a smooth surface). The parietal cluster spanned the entire intraparietal sulcus (<span class="xrefLink" id="jumplink-fig3"></span><a href="javascript:;" data-modal-source-id="fig3" class="link xref-fig">Fig. 3</a>). At the interhemispheric surface, the percept of a grating orientation elicited greater activation in the rostral cingulate motor area and rostral supplementary motor area (<span class="xrefLink" id="jumplink-fig3"></span><a href="javascript:;" data-modal-source-id="fig3" class="link xref-fig">Fig. 3</a>; <span class="xrefLink" id="jumplink-tbl1"></span><a href="javascript:;" reveal-id="tbl1" data-open="tbl1" class="link link-reveal link-table xref-fig">Table 1</a>). No brain region showed a relative increase in BOLD signal during tactile stimulation with a groove width of 0.35 mm relative to tactile stimulation with a groove width of 3.0 mm.</p>                    <a id="3672195" scrollto-destination="3672195"></a>
+<div data-id="fig3" data-content-id="fig3" class="fig fig-section js-fig-section" swap-content-for-modal="true"><div class="label fig-label"><strong>Fig. 3</strong></div><div class="graphic-wrap"><img class="content-image" src="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/m_awl181f3.gif?Expires=1689794673&amp;Signature=RIJh3agAg1XIixsmuMmMF~ngw2qUVCicHSr2hEiijxAdJlZiIkRbm5iqG6Ag7wNZxeTNBQ5PH-ZSs7jd9oZPwTurMRbczb8YyInYlgMSPDfJD~gzD~7K4IAORPgxucgJffKgxxddGbkn-s7qsbQgGOVHJmh6HPDD5123N1e5s7bfdz4nFwm5VgKOsmftg5nUs1kONlwmwMuAgOZsuAL00dQGY8pDYc1p6PFYBVs7g6gZLnHf5X2Uua~Z4mYeHQVpOUGaRjKYu9ZiORX7CC~ZX444k88NBtq-G73pq~h2y61X8MbtujQLUVD0XoC4JEEqw1lC-e9wurCsJNDZu-at8Q__&amp;Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" alt="Regional increases in BOLD signal evoked by the perception of grating orientation in dystonic patients and controls. The sagittal, coronal and axial Z-score maps highlight cortical increases in BOLD signal during tactile stimulation with 3.0-mm domes relative to tactile stimulation with 0.35-mm domes (extent threshold: P &lt; 0.01, uncorrected). In this comparison, dystonic patients and controls were pooled together. Only gratings with a gap value of 3.0 mm induced a percept of grating orientation, whereas gratings with a gap value of 0.35 mm were perceived as smooth surface. Z-score maps are superimposed on the T1-weighted MRI template implemented in SPM2. The corresponding stereotactic coordinate (z-value in millimetres) is given for each axial slice. L = left; R = right." data-path-from-xml="awl181f3.gif" /><div class="fig-orig original-slide"><a class="fig-view-orig js-view-large at-figureViewLarge openInAnotherWindow" href="/view-large/figure/3672195/awl181f3.gif" data-path-from-xml="awl181f3.gif" target="_blank">Open in new tab</a><a data-section="3672195" href="/DownloadFile/DownloadImage.aspx?image=https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/awl181f3.gif?Expires=1689794673&Signature=4ObZ75Gq5h3CPhouGgUXC-d0XX7Hgl1oryKFmL0D79A7CZUYcNKF2osPR0-k0FONChAXlqCrOhPT8lUmoxwrERwp3AS8~p7LtI1U7OrcbXZDEvoxKl6l~FwtmwzSYgaVrbujs-DFqHpP3TQ8KKMoHahxBkJE1pDaBZjBRKairHI8-Rh-APPurxFOXOSFOlCySATcV88sFzrLc98QwcMd~n758ovT6PsWCxHKAjdqDxnouwcp7oc03R6jkvGbRTtuHdaHdDYSYzEEYsyy1jQUjKopAd~Y6MHj36pgl7Aaeo7vEd965hXmbAkif1dNbkaaEoXTwkoiiF9GlxYnLFcnoA__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA&sec=3672195&ar=290089&xsltPath=~/UI/app/XSLT&imagename=&siteId=5367" class="download-slide" data-path-from-xml="awl181f3.gif">Download slide</a></div></div><div class="caption fig-caption"><p class="chapter-para">Regional increases in BOLD signal evoked by the perception of grating orientation in dystonic patients and controls. The sagittal, coronal and axial <em>Z</em>-score maps highlight cortical increases in BOLD signal during tactile stimulation with 3.0-mm domes relative to tactile stimulation with 0.35-mm domes (extent threshold: <em>P</em> &lt; 0.01, uncorrected). In this comparison, dystonic patients and controls were pooled together. Only gratings with a gap value of 3.0 mm induced a percept of grating orientation, whereas gratings with a gap value of 0.35 mm were perceived as smooth surface. <em>Z</em>-score maps are superimposed on the T<sub>1</sub>-weighted MRI template implemented in SPM2. The corresponding stereotactic coordinate (<em>z-</em>value in millimetres) is given for each axial slice. L = left; R = right.</p></div></div>                    <a id="3672196" scrollto-destination="3672196"></a>
+<div content-id="tbl1" class="table-modal table-full-width-wrap"><div class="table-wrap table-wide"><div class="table-wrap-title" id="tbl1" data-id="tbl1"><span class="label"><strong>Table 1</strong></span><div class="caption"><p class="chapter-para">Main effect of the grating orientation task</p></div> </div><div class="table-overflow"><table role="table"><thead><tr><th>Anatomical location<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Side<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Cluster extent<span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4">Peak difference in BOLD signal<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3">MNI coordinates<span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>Z</em>-value<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>x</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>y</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>z</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr></thead><tbody><tr><td>Post-central sulcus </td><td>L </td><td>495 </td><td>−45 </td><td>−42 </td><td>63 </td><td>4.59 </td></tr><tr><td>Anterior intraparietal sulcus </td><td> </td><td> </td><td>−39 </td><td>−42 </td><td>48 </td><td>4.49 </td></tr><tr><td>Superior parietal lobule </td><td> </td><td> </td><td>−27 </td><td>−57 </td><td>63 </td><td>4.29 </td></tr><tr><td>Superior parietal lobule </td><td>L </td><td>489 </td><td>21 </td><td>−63 </td><td>66 </td><td>4.09 </td></tr><tr><td>Anterior intraparietal sulcus </td><td> </td><td> </td><td>42 </td><td>−36 </td><td>48 </td><td>4.09 </td></tr><tr><td>Superior parietal lobule </td><td> </td><td> </td><td>24 </td><td>−54 </td><td>57 </td><td>4.06 </td></tr><tr><td>Frontal eye field </td><td>R </td><td>124 </td><td>33 </td><td>0 </td><td>51 </td><td>4.39 </td></tr><tr><td>Dorsal premotor cortex </td><td> </td><td> </td><td>33 </td><td>−9 </td><td>60 </td><td>3.66 </td></tr><tr><td>Dorsal premotor cortex </td><td>L </td><td>144 </td><td>−27 </td><td>−9 </td><td>57 </td><td>4.21 </td></tr><tr><td>Dorsal premotor cortex </td><td> </td><td> </td><td>−33 </td><td>−24 </td><td>57 </td><td>3.57 </td></tr><tr><td>Anterior cingulate motor area </td><td>L </td><td>153 </td><td>−6 </td><td>21 </td><td>42 </td><td>4.41 </td></tr><tr><td> </td><td>R </td><td> </td><td>15 </td><td>15 </td><td>39 </td><td>3.69 </td></tr><tr><td>Anterior insular cortex </td><td>L </td><td>42 </td><td>−45 </td><td>15 </td><td>−3 </td><td>4.49 </td></tr><tr><td>Ventral premotor cortex </td><td>L </td><td>41 </td><td>−57 </td><td>6 </td><td>33 </td><td>3.38<sup>*</sup> </td></tr></tbody></table></div><div class="table-modal"><table><thead><tr><th>Anatomical location<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Side<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Cluster extent<span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4">Peak difference in BOLD signal<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3">MNI coordinates<span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>Z</em>-value<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>x</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>y</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>z</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr></thead><tbody><tr><td>Post-central sulcus </td><td>L </td><td>495 </td><td>−45 </td><td>−42 </td><td>63 </td><td>4.59 </td></tr><tr><td>Anterior intraparietal sulcus </td><td> </td><td> </td><td>−39 </td><td>−42 </td><td>48 </td><td>4.49 </td></tr><tr><td>Superior parietal lobule </td><td> </td><td> </td><td>−27 </td><td>−57 </td><td>63 </td><td>4.29 </td></tr><tr><td>Superior parietal lobule </td><td>L </td><td>489 </td><td>21 </td><td>−63 </td><td>66 </td><td>4.09 </td></tr><tr><td>Anterior intraparietal sulcus </td><td> </td><td> </td><td>42 </td><td>−36 </td><td>48 </td><td>4.09 </td></tr><tr><td>Superior parietal lobule </td><td> </td><td> </td><td>24 </td><td>−54 </td><td>57 </td><td>4.06 </td></tr><tr><td>Frontal eye field </td><td>R </td><td>124 </td><td>33 </td><td>0 </td><td>51 </td><td>4.39 </td></tr><tr><td>Dorsal premotor cortex </td><td> </td><td> </td><td>33 </td><td>−9 </td><td>60 </td><td>3.66 </td></tr><tr><td>Dorsal premotor cortex </td><td>L </td><td>144 </td><td>−27 </td><td>−9 </td><td>57 </td><td>4.21 </td></tr><tr><td>Dorsal premotor cortex </td><td> </td><td> </td><td>−33 </td><td>−24 </td><td>57 </td><td>3.57 </td></tr><tr><td>Anterior cingulate motor area </td><td>L </td><td>153 </td><td>−6 </td><td>21 </td><td>42 </td><td>4.41 </td></tr><tr><td> </td><td>R </td><td> </td><td>15 </td><td>15 </td><td>39 </td><td>3.69 </td></tr><tr><td>Anterior insular cortex </td><td>L </td><td>42 </td><td>−45 </td><td>15 </td><td>−3 </td><td>4.49 </td></tr><tr><td>Ventral premotor cortex </td><td>L </td><td>41 </td><td>−57 </td><td>6 </td><td>33 </td><td>3.38<sup>*</sup> </td></tr></tbody></table></div><div class="table-wrap-foot"><span id="fn-"></span><div content-id="" class="footnote"><span class="fn"><p class="chapter-para">The table lists brain regions that showed task-related increases in BOLD signal during the perception of grating orientation (<em>P</em> &lt; 0.05, corrected at the cluster level); dystonic patients and controls are considered together; R = right; L = left; M = mesial; asterisk marks a cluster that showed a trend activation (<em>P</em> &lt; 0.001, uncorrected) but failed to survive correction for multiple comparisons.</p></span></div></div><div class="&#xA;          graphic-wrap&#xA;          "><a class="fig-view-orig at-tableViewLarge openInAnotherWindow btn js-view-large" target="_blank" href="/view-large/3672196">
+          Open in new tab
+        </a></div></div></div><div class="table-full-width-wrap"><div class="table-wrap table-wide"><div class="table-wrap-title" id="tbl1" data-id="tbl1"><span class="label"><strong>Table 1</strong></span><div class="caption"><p class="chapter-para">Main effect of the grating orientation task</p></div> </div><div class="table-overflow"><table role="table"><thead><tr><th>Anatomical location<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Side<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Cluster extent<span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4">Peak difference in BOLD signal<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3">MNI coordinates<span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>Z</em>-value<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>x</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>y</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>z</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr></thead><tbody><tr><td>Post-central sulcus </td><td>L </td><td>495 </td><td>−45 </td><td>−42 </td><td>63 </td><td>4.59 </td></tr><tr><td>Anterior intraparietal sulcus </td><td> </td><td> </td><td>−39 </td><td>−42 </td><td>48 </td><td>4.49 </td></tr><tr><td>Superior parietal lobule </td><td> </td><td> </td><td>−27 </td><td>−57 </td><td>63 </td><td>4.29 </td></tr><tr><td>Superior parietal lobule </td><td>L </td><td>489 </td><td>21 </td><td>−63 </td><td>66 </td><td>4.09 </td></tr><tr><td>Anterior intraparietal sulcus </td><td> </td><td> </td><td>42 </td><td>−36 </td><td>48 </td><td>4.09 </td></tr><tr><td>Superior parietal lobule </td><td> </td><td> </td><td>24 </td><td>−54 </td><td>57 </td><td>4.06 </td></tr><tr><td>Frontal eye field </td><td>R </td><td>124 </td><td>33 </td><td>0 </td><td>51 </td><td>4.39 </td></tr><tr><td>Dorsal premotor cortex </td><td> </td><td> </td><td>33 </td><td>−9 </td><td>60 </td><td>3.66 </td></tr><tr><td>Dorsal premotor cortex </td><td>L </td><td>144 </td><td>−27 </td><td>−9 </td><td>57 </td><td>4.21 </td></tr><tr><td>Dorsal premotor cortex </td><td> </td><td> </td><td>−33 </td><td>−24 </td><td>57 </td><td>3.57 </td></tr><tr><td>Anterior cingulate motor area </td><td>L </td><td>153 </td><td>−6 </td><td>21 </td><td>42 </td><td>4.41 </td></tr><tr><td> </td><td>R </td><td> </td><td>15 </td><td>15 </td><td>39 </td><td>3.69 </td></tr><tr><td>Anterior insular cortex </td><td>L </td><td>42 </td><td>−45 </td><td>15 </td><td>−3 </td><td>4.49 </td></tr><tr><td>Ventral premotor cortex </td><td>L </td><td>41 </td><td>−57 </td><td>6 </td><td>33 </td><td>3.38<sup>*</sup> </td></tr></tbody></table></div><div class="table-modal"><table><thead><tr><th>Anatomical location<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Side<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Cluster extent<span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4">Peak difference in BOLD signal<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3">MNI coordinates<span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>Z</em>-value<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>x</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>y</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>z</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr></thead><tbody><tr><td>Post-central sulcus </td><td>L </td><td>495 </td><td>−45 </td><td>−42 </td><td>63 </td><td>4.59 </td></tr><tr><td>Anterior intraparietal sulcus </td><td> </td><td> </td><td>−39 </td><td>−42 </td><td>48 </td><td>4.49 </td></tr><tr><td>Superior parietal lobule </td><td> </td><td> </td><td>−27 </td><td>−57 </td><td>63 </td><td>4.29 </td></tr><tr><td>Superior parietal lobule </td><td>L </td><td>489 </td><td>21 </td><td>−63 </td><td>66 </td><td>4.09 </td></tr><tr><td>Anterior intraparietal sulcus </td><td> </td><td> </td><td>42 </td><td>−36 </td><td>48 </td><td>4.09 </td></tr><tr><td>Superior parietal lobule </td><td> </td><td> </td><td>24 </td><td>−54 </td><td>57 </td><td>4.06 </td></tr><tr><td>Frontal eye field </td><td>R </td><td>124 </td><td>33 </td><td>0 </td><td>51 </td><td>4.39 </td></tr><tr><td>Dorsal premotor cortex </td><td> </td><td> </td><td>33 </td><td>−9 </td><td>60 </td><td>3.66 </td></tr><tr><td>Dorsal premotor cortex </td><td>L </td><td>144 </td><td>−27 </td><td>−9 </td><td>57 </td><td>4.21 </td></tr><tr><td>Dorsal premotor cortex </td><td> </td><td> </td><td>−33 </td><td>−24 </td><td>57 </td><td>3.57 </td></tr><tr><td>Anterior cingulate motor area </td><td>L </td><td>153 </td><td>−6 </td><td>21 </td><td>42 </td><td>4.41 </td></tr><tr><td> </td><td>R </td><td> </td><td>15 </td><td>15 </td><td>39 </td><td>3.69 </td></tr><tr><td>Anterior insular cortex </td><td>L </td><td>42 </td><td>−45 </td><td>15 </td><td>−3 </td><td>4.49 </td></tr><tr><td>Ventral premotor cortex </td><td>L </td><td>41 </td><td>−57 </td><td>6 </td><td>33 </td><td>3.38<sup>*</sup> </td></tr></tbody></table></div><div class="table-wrap-foot"><span id="fn-"></span><div content-id="" class="footnote"><span class="fn"><p class="chapter-para">The table lists brain regions that showed task-related increases in BOLD signal during the perception of grating orientation (<em>P</em> &lt; 0.05, corrected at the cluster level); dystonic patients and controls are considered together; R = right; L = left; M = mesial; asterisk marks a cluster that showed a trend activation (<em>P</em> &lt; 0.001, uncorrected) but failed to survive correction for multiple comparisons.</p></span></div></div><div class="&#xA;          graphic-wrap&#xA;          "><a class="fig-view-orig at-tableViewLarge openInAnotherWindow btn js-view-large" target="_blank" href="/view-large/3672196">
+          Open in new tab
+        </a></div></div></div>                    <h3 scrollto-destination=3672197 id="3672197" class="section-title js-splitscreen-section-title" >Differences in task-related BOLD responses between patients and controls</h3>
+<p class="chapter-para">In patients with writer's cramp, tactile stimulation of the right index finger produced stronger increases in BOLD signal in the basal ganglia and thalamus relative to healthy controls (<span class="xrefLink" id="jumplink-tbl2"></span><a href="javascript:;" reveal-id="tbl2" data-open="tbl2" class="link link-reveal link-table xref-fig">Table 2</a>). Focal increases in task-related activity were located in the left posterior putamen, right and left anterior putamen, the body of caudate nucleus and lateral thalamus (<span class="xrefLink" id="jumplink-fig4"></span><a href="javascript:;" data-modal-source-id="fig4" class="link xref-fig">Fig. 4</a>). Significant increases in BOLD signal were also found in posterior visual areas, left frontal opercular cortex, left anterior insula and right anterior parietal cortex (<span class="xrefLink" id="jumplink-tbl2"></span><a href="javascript:;" reveal-id="tbl2" data-open="tbl2" class="link link-reveal link-table xref-fig">Table 2</a>), but there were no differences in the post-central gyrus or parietal opercular cortex even when using a liberal statistical threshold (i.e. <em>P</em> &lt; 0.01, uncorrected). In healthy controls, no brain region showed a stronger BOLD response to tactile discrimination relative to patients with writer's cramp.</p>                    <a id="3672199" scrollto-destination="3672199"></a>
+<div data-id="fig4" data-content-id="fig4" class="fig fig-section js-fig-section" swap-content-for-modal="true"><div class="label fig-label"><strong>Fig. 4</strong></div><div class="graphic-wrap"><img class="content-image" src="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/m_awl181f4.gif?Expires=1689794673&amp;Signature=d-GZ1MGlBSeu5zVUCkYf3IKZcTkeaTdx~LYwCFtKhLaK64UQSf2Q6qopLSq-~BDj-X2-upXwCUEnRAsOmmlEYIVLOFRkStwuoAMeMWw0j7AVER~8b9EgIb0Cecs87zJDfvQNAZQzFw7FQ8-SOk~l-POiiPUm6AcWdNdDkPAArM9OKBL7gdh9UtnmFQBSVb3WERtG5sawAMR-kec5BDQB0Pd4bk89rpZt1E9oP7UTKoT3PEfE~nQIJhZAvJxdJjDCc6UHYHu4iCmrm8NBAGBaL3uFqKYDPZX~8ELkVklj336v57JgD9V4YGxTwOXN132-i-qYhTAICLTUZaMW3uJuqA__&amp;Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" alt="Relative overactivity during the grating orientation task in patients with writer's cramp. The colour-coded Z-score maps delineate voxels showing stronger increases in BOLD signal in the basal ganglia and lateral thalamus during sensory processing of tactile stimuli in patients relative to healthy volunteers (extent threshold: P &lt; 0.01, uncorrected). Sagittal, coronal and axial Z-score maps are superimposed on the T1-weighted MRI template implemented in SPM2, and the corresponding stereotactic coordinate (in millimetres) is given for each slice. L = left; R = right." data-path-from-xml="awl181f4.gif" /><div class="fig-orig original-slide"><a class="fig-view-orig js-view-large at-figureViewLarge openInAnotherWindow" href="/view-large/figure/3672199/awl181f4.gif" data-path-from-xml="awl181f4.gif" target="_blank">Open in new tab</a><a data-section="3672199" href="/DownloadFile/DownloadImage.aspx?image=https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/awl181f4.gif?Expires=1689794673&Signature=HRtyoR2GFr1vfOy2J5aYBUQAH7R59naCuQniHgctmy77-zy3mU-O5VHdfqyemtKW0UbKRZr9i5RY1MRNulLbHBX4ePWmex57m5oBfSsExY3QsphNYy64BUqqdB9NtpDGPOnxEJP0czk6~Rv419vDREBxIJHFoOifzTlnuhsOuUeoDV1BVpbK0GpJIzZnr5AG8NbItzPkOO30AsSGK9fMX-j6p4iFqbzcxfrxupy71e~dKvcqTqt9HPzQVUgWEPS9G0uAI5Wo-St9tSOiGKkjLbDEetbFyBwRNGJFWpV8cR-pmZj0VmeHiXS5yF04wEKzwGEgWa6qB7hViv93gFZUGg__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA&sec=3672199&ar=290089&xsltPath=~/UI/app/XSLT&imagename=&siteId=5367" class="download-slide" data-path-from-xml="awl181f4.gif">Download slide</a></div></div><div class="caption fig-caption"><p class="chapter-para">Relative overactivity during the grating orientation task in patients with writer's cramp. The colour-coded <em>Z</em>-score maps delineate voxels showing stronger increases in BOLD signal in the basal ganglia and lateral thalamus during sensory processing of tactile stimuli in patients relative to healthy volunteers (extent threshold: <em>P</em> &lt; 0.01, uncorrected). Sagittal, coronal and axial <em>Z</em>-score maps are superimposed on the T<sub>1</sub>-weighted MRI template implemented in SPM2, and the corresponding stereotactic coordinate (in millimetres) is given for each slice. L = left; R = right.</p></div></div>                    <a id="3672200" scrollto-destination="3672200"></a>
+<div content-id="tbl2" class="table-modal table-full-width-wrap"><div class="table-wrap table-wide"><div class="table-wrap-title" id="tbl2" data-id="tbl2"><span class="label"><strong>Table 2</strong></span><div class="caption"><p class="chapter-para">Between-groups difference in activation during the grating orientation task</p></div> </div><div class="table-overflow"><table role="table"><thead><tr><th>Anatomical location<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Side<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Cluster extent<span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4">Peak difference in BOLD signal<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3">MNI coordinates<span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>Z</em>-value<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>x</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>y</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>z</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr></thead><tbody><tr><td>Posterior putamen </td><td>L </td><td>249 </td><td>−33 </td><td>−12 </td><td>0 </td><td>3.84 </td></tr><tr><td>Anterior putamen </td><td> </td><td> </td><td>−27 </td><td>9 </td><td>6 </td><td>3.74 </td></tr><tr><td>Caudate nucleus (body) </td><td> </td><td> </td><td>−12 </td><td>6 </td><td>6 </td><td>3.68 </td></tr><tr><td>Lateral thalamus </td><td> </td><td> </td><td>−21 </td><td>−21 </td><td>6 </td><td>3.32 </td></tr><tr><td>Anterior putamen </td><td>R </td><td>115 </td><td>30 </td><td>3 </td><td>6 </td><td>3.86 </td></tr><tr><td>Lateral thalamus </td><td> </td><td> </td><td>18 </td><td>−18 </td><td>9 </td><td>3.70 </td></tr><tr><td>Globus pallidus </td><td> </td><td> </td><td>18 </td><td>−6 </td><td>6 </td><td>3.33 </td></tr><tr><td>Lingual gyrus </td><td>R </td><td>148 </td><td>15 </td><td>−51 </td><td>−3 </td><td>4.57 </td></tr><tr><td>Calcarine sulcus </td><td> </td><td> </td><td>15 </td><td>−69 </td><td>12 </td><td>3.13 </td></tr><tr><td>Lingual gyrus </td><td>L </td><td>302 </td><td>−15 </td><td>−42 </td><td>−3 </td><td>3.96 </td></tr><tr><td> </td><td> </td><td> </td><td>−24 </td><td>−57 </td><td>3 </td><td>3.52 </td></tr><tr><td>Anterior insular cortex </td><td>L </td><td>118 </td><td>−48 </td><td>15 </td><td>−6 </td><td>3.90 </td></tr><tr><td>Anterior insular cortex </td><td> </td><td> </td><td>−48 </td><td>6 </td><td>−9 </td><td>3.30 </td></tr><tr><td>Intraparietal sulcus </td><td>R </td><td>106 </td><td>24 </td><td>−63 </td><td>48 </td><td>3.57 </td></tr><tr><td>Post-central gyrus </td><td> </td><td> </td><td>24 </td><td>−45 </td><td>54 </td><td>3.11 </td></tr><tr><td>Temporo-occipital junction </td><td>L </td><td>32 </td><td>−51 </td><td>−69 </td><td>3 </td><td>3.83<sup>*</sup> </td></tr><tr><td>Pregenual cingulate cortex </td><td>M </td><td>31 </td><td>9 </td><td>36 </td><td>3 </td><td>3.70<sup>*</sup> </td></tr><tr><td>Lateral cerebellum (crus 1) </td><td>L </td><td>39 </td><td>−45 </td><td>−63 </td><td>−33 </td><td>3.65<sup>*</sup> </td></tr><tr><td>Anterior insular cortex </td><td>R </td><td>36 </td><td>54 </td><td>0 </td><td>0 </td><td>3.66<sup>*</sup> </td></tr><tr><td>Anterior cingulate </td><td>M </td><td>66 </td><td>−3 </td><td>6 </td><td>39 </td><td>3.62<sup>*</sup> </td></tr><tr><td>motor area </td><td> </td><td> </td><td>0 </td><td>33 </td><td>30 </td><td>3.07<sup>*</sup> </td></tr><tr><td>Precuneus </td><td>L </td><td>44 </td><td>−12 </td><td>−48 </td><td>57 </td><td>3.52<sup>*</sup> </td></tr><tr><td>Dorsolateral prefrontal cortex </td><td>R </td><td>47 </td><td>33 </td><td>24 </td><td>30 </td><td>3.38<sup>*</sup> </td></tr></tbody></table></div><div class="table-modal"><table><thead><tr><th>Anatomical location<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Side<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Cluster extent<span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4">Peak difference in BOLD signal<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3">MNI coordinates<span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>Z</em>-value<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>x</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>y</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>z</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr></thead><tbody><tr><td>Posterior putamen </td><td>L </td><td>249 </td><td>−33 </td><td>−12 </td><td>0 </td><td>3.84 </td></tr><tr><td>Anterior putamen </td><td> </td><td> </td><td>−27 </td><td>9 </td><td>6 </td><td>3.74 </td></tr><tr><td>Caudate nucleus (body) </td><td> </td><td> </td><td>−12 </td><td>6 </td><td>6 </td><td>3.68 </td></tr><tr><td>Lateral thalamus </td><td> </td><td> </td><td>−21 </td><td>−21 </td><td>6 </td><td>3.32 </td></tr><tr><td>Anterior putamen </td><td>R </td><td>115 </td><td>30 </td><td>3 </td><td>6 </td><td>3.86 </td></tr><tr><td>Lateral thalamus </td><td> </td><td> </td><td>18 </td><td>−18 </td><td>9 </td><td>3.70 </td></tr><tr><td>Globus pallidus </td><td> </td><td> </td><td>18 </td><td>−6 </td><td>6 </td><td>3.33 </td></tr><tr><td>Lingual gyrus </td><td>R </td><td>148 </td><td>15 </td><td>−51 </td><td>−3 </td><td>4.57 </td></tr><tr><td>Calcarine sulcus </td><td> </td><td> </td><td>15 </td><td>−69 </td><td>12 </td><td>3.13 </td></tr><tr><td>Lingual gyrus </td><td>L </td><td>302 </td><td>−15 </td><td>−42 </td><td>−3 </td><td>3.96 </td></tr><tr><td> </td><td> </td><td> </td><td>−24 </td><td>−57 </td><td>3 </td><td>3.52 </td></tr><tr><td>Anterior insular cortex </td><td>L </td><td>118 </td><td>−48 </td><td>15 </td><td>−6 </td><td>3.90 </td></tr><tr><td>Anterior insular cortex </td><td> </td><td> </td><td>−48 </td><td>6 </td><td>−9 </td><td>3.30 </td></tr><tr><td>Intraparietal sulcus </td><td>R </td><td>106 </td><td>24 </td><td>−63 </td><td>48 </td><td>3.57 </td></tr><tr><td>Post-central gyrus </td><td> </td><td> </td><td>24 </td><td>−45 </td><td>54 </td><td>3.11 </td></tr><tr><td>Temporo-occipital junction </td><td>L </td><td>32 </td><td>−51 </td><td>−69 </td><td>3 </td><td>3.83<sup>*</sup> </td></tr><tr><td>Pregenual cingulate cortex </td><td>M </td><td>31 </td><td>9 </td><td>36 </td><td>3 </td><td>3.70<sup>*</sup> </td></tr><tr><td>Lateral cerebellum (crus 1) </td><td>L </td><td>39 </td><td>−45 </td><td>−63 </td><td>−33 </td><td>3.65<sup>*</sup> </td></tr><tr><td>Anterior insular cortex </td><td>R </td><td>36 </td><td>54 </td><td>0 </td><td>0 </td><td>3.66<sup>*</sup> </td></tr><tr><td>Anterior cingulate </td><td>M </td><td>66 </td><td>−3 </td><td>6 </td><td>39 </td><td>3.62<sup>*</sup> </td></tr><tr><td>motor area </td><td> </td><td> </td><td>0 </td><td>33 </td><td>30 </td><td>3.07<sup>*</sup> </td></tr><tr><td>Precuneus </td><td>L </td><td>44 </td><td>−12 </td><td>−48 </td><td>57 </td><td>3.52<sup>*</sup> </td></tr><tr><td>Dorsolateral prefrontal cortex </td><td>R </td><td>47 </td><td>33 </td><td>24 </td><td>30 </td><td>3.38<sup>*</sup> </td></tr></tbody></table></div><div class="table-wrap-foot"><span id="fn-"></span><div content-id="" class="footnote"><span class="fn"><p class="chapter-para">The table lists brain regions in which patients with writer's cramp showed greater task-related activation than healthy controls (both groups; <em>P</em> &lt; 0.05, corrected at the cluster level); R = right; L = left; M = mesial; asterisks mark clusters that showed a trend to activation (<em>P</em> &lt; 0.001, uncorrected) but failed to survive correction for multiple comparisons.</p></span></div></div><div class="&#xA;          graphic-wrap&#xA;          "><a class="fig-view-orig at-tableViewLarge openInAnotherWindow btn js-view-large" target="_blank" href="/view-large/3672200">
+          Open in new tab
+        </a></div></div></div><div class="table-full-width-wrap"><div class="table-wrap table-wide"><div class="table-wrap-title" id="tbl2" data-id="tbl2"><span class="label"><strong>Table 2</strong></span><div class="caption"><p class="chapter-para">Between-groups difference in activation during the grating orientation task</p></div> </div><div class="table-overflow"><table role="table"><thead><tr><th>Anatomical location<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Side<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Cluster extent<span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4">Peak difference in BOLD signal<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3">MNI coordinates<span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>Z</em>-value<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>x</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>y</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>z</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr></thead><tbody><tr><td>Posterior putamen </td><td>L </td><td>249 </td><td>−33 </td><td>−12 </td><td>0 </td><td>3.84 </td></tr><tr><td>Anterior putamen </td><td> </td><td> </td><td>−27 </td><td>9 </td><td>6 </td><td>3.74 </td></tr><tr><td>Caudate nucleus (body) </td><td> </td><td> </td><td>−12 </td><td>6 </td><td>6 </td><td>3.68 </td></tr><tr><td>Lateral thalamus </td><td> </td><td> </td><td>−21 </td><td>−21 </td><td>6 </td><td>3.32 </td></tr><tr><td>Anterior putamen </td><td>R </td><td>115 </td><td>30 </td><td>3 </td><td>6 </td><td>3.86 </td></tr><tr><td>Lateral thalamus </td><td> </td><td> </td><td>18 </td><td>−18 </td><td>9 </td><td>3.70 </td></tr><tr><td>Globus pallidus </td><td> </td><td> </td><td>18 </td><td>−6 </td><td>6 </td><td>3.33 </td></tr><tr><td>Lingual gyrus </td><td>R </td><td>148 </td><td>15 </td><td>−51 </td><td>−3 </td><td>4.57 </td></tr><tr><td>Calcarine sulcus </td><td> </td><td> </td><td>15 </td><td>−69 </td><td>12 </td><td>3.13 </td></tr><tr><td>Lingual gyrus </td><td>L </td><td>302 </td><td>−15 </td><td>−42 </td><td>−3 </td><td>3.96 </td></tr><tr><td> </td><td> </td><td> </td><td>−24 </td><td>−57 </td><td>3 </td><td>3.52 </td></tr><tr><td>Anterior insular cortex </td><td>L </td><td>118 </td><td>−48 </td><td>15 </td><td>−6 </td><td>3.90 </td></tr><tr><td>Anterior insular cortex </td><td> </td><td> </td><td>−48 </td><td>6 </td><td>−9 </td><td>3.30 </td></tr><tr><td>Intraparietal sulcus </td><td>R </td><td>106 </td><td>24 </td><td>−63 </td><td>48 </td><td>3.57 </td></tr><tr><td>Post-central gyrus </td><td> </td><td> </td><td>24 </td><td>−45 </td><td>54 </td><td>3.11 </td></tr><tr><td>Temporo-occipital junction </td><td>L </td><td>32 </td><td>−51 </td><td>−69 </td><td>3 </td><td>3.83<sup>*</sup> </td></tr><tr><td>Pregenual cingulate cortex </td><td>M </td><td>31 </td><td>9 </td><td>36 </td><td>3 </td><td>3.70<sup>*</sup> </td></tr><tr><td>Lateral cerebellum (crus 1) </td><td>L </td><td>39 </td><td>−45 </td><td>−63 </td><td>−33 </td><td>3.65<sup>*</sup> </td></tr><tr><td>Anterior insular cortex </td><td>R </td><td>36 </td><td>54 </td><td>0 </td><td>0 </td><td>3.66<sup>*</sup> </td></tr><tr><td>Anterior cingulate </td><td>M </td><td>66 </td><td>−3 </td><td>6 </td><td>39 </td><td>3.62<sup>*</sup> </td></tr><tr><td>motor area </td><td> </td><td> </td><td>0 </td><td>33 </td><td>30 </td><td>3.07<sup>*</sup> </td></tr><tr><td>Precuneus </td><td>L </td><td>44 </td><td>−12 </td><td>−48 </td><td>57 </td><td>3.52<sup>*</sup> </td></tr><tr><td>Dorsolateral prefrontal cortex </td><td>R </td><td>47 </td><td>33 </td><td>24 </td><td>30 </td><td>3.38<sup>*</sup> </td></tr></tbody></table></div><div class="table-modal"><table><thead><tr><th>Anatomical location<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Side<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Cluster extent<span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4">Peak difference in BOLD signal<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3">MNI coordinates<span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>Z</em>-value<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>x</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>y</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>z</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr></thead><tbody><tr><td>Posterior putamen </td><td>L </td><td>249 </td><td>−33 </td><td>−12 </td><td>0 </td><td>3.84 </td></tr><tr><td>Anterior putamen </td><td> </td><td> </td><td>−27 </td><td>9 </td><td>6 </td><td>3.74 </td></tr><tr><td>Caudate nucleus (body) </td><td> </td><td> </td><td>−12 </td><td>6 </td><td>6 </td><td>3.68 </td></tr><tr><td>Lateral thalamus </td><td> </td><td> </td><td>−21 </td><td>−21 </td><td>6 </td><td>3.32 </td></tr><tr><td>Anterior putamen </td><td>R </td><td>115 </td><td>30 </td><td>3 </td><td>6 </td><td>3.86 </td></tr><tr><td>Lateral thalamus </td><td> </td><td> </td><td>18 </td><td>−18 </td><td>9 </td><td>3.70 </td></tr><tr><td>Globus pallidus </td><td> </td><td> </td><td>18 </td><td>−6 </td><td>6 </td><td>3.33 </td></tr><tr><td>Lingual gyrus </td><td>R </td><td>148 </td><td>15 </td><td>−51 </td><td>−3 </td><td>4.57 </td></tr><tr><td>Calcarine sulcus </td><td> </td><td> </td><td>15 </td><td>−69 </td><td>12 </td><td>3.13 </td></tr><tr><td>Lingual gyrus </td><td>L </td><td>302 </td><td>−15 </td><td>−42 </td><td>−3 </td><td>3.96 </td></tr><tr><td> </td><td> </td><td> </td><td>−24 </td><td>−57 </td><td>3 </td><td>3.52 </td></tr><tr><td>Anterior insular cortex </td><td>L </td><td>118 </td><td>−48 </td><td>15 </td><td>−6 </td><td>3.90 </td></tr><tr><td>Anterior insular cortex </td><td> </td><td> </td><td>−48 </td><td>6 </td><td>−9 </td><td>3.30 </td></tr><tr><td>Intraparietal sulcus </td><td>R </td><td>106 </td><td>24 </td><td>−63 </td><td>48 </td><td>3.57 </td></tr><tr><td>Post-central gyrus </td><td> </td><td> </td><td>24 </td><td>−45 </td><td>54 </td><td>3.11 </td></tr><tr><td>Temporo-occipital junction </td><td>L </td><td>32 </td><td>−51 </td><td>−69 </td><td>3 </td><td>3.83<sup>*</sup> </td></tr><tr><td>Pregenual cingulate cortex </td><td>M </td><td>31 </td><td>9 </td><td>36 </td><td>3 </td><td>3.70<sup>*</sup> </td></tr><tr><td>Lateral cerebellum (crus 1) </td><td>L </td><td>39 </td><td>−45 </td><td>−63 </td><td>−33 </td><td>3.65<sup>*</sup> </td></tr><tr><td>Anterior insular cortex </td><td>R </td><td>36 </td><td>54 </td><td>0 </td><td>0 </td><td>3.66<sup>*</sup> </td></tr><tr><td>Anterior cingulate </td><td>M </td><td>66 </td><td>−3 </td><td>6 </td><td>39 </td><td>3.62<sup>*</sup> </td></tr><tr><td>motor area </td><td> </td><td> </td><td>0 </td><td>33 </td><td>30 </td><td>3.07<sup>*</sup> </td></tr><tr><td>Precuneus </td><td>L </td><td>44 </td><td>−12 </td><td>−48 </td><td>57 </td><td>3.52<sup>*</sup> </td></tr><tr><td>Dorsolateral prefrontal cortex </td><td>R </td><td>47 </td><td>33 </td><td>24 </td><td>30 </td><td>3.38<sup>*</sup> </td></tr></tbody></table></div><div class="table-wrap-foot"><span id="fn-"></span><div content-id="" class="footnote"><span class="fn"><p class="chapter-para">The table lists brain regions in which patients with writer's cramp showed greater task-related activation than healthy controls (both groups; <em>P</em> &lt; 0.05, corrected at the cluster level); R = right; L = left; M = mesial; asterisks mark clusters that showed a trend to activation (<em>P</em> &lt; 0.001, uncorrected) but failed to survive correction for multiple comparisons.</p></span></div></div><div class="&#xA;          graphic-wrap&#xA;          "><a class="fig-view-orig at-tableViewLarge openInAnotherWindow btn js-view-large" target="_blank" href="/view-large/3672200">
+          Open in new tab
+        </a></div></div></div><p class="chapter-para">Analysis of regional BOLD signal changes revealed no interaction between group (i.e. patients versus controls) and the groove width of the domes (gap value of 0.35 mm versus 3.0 mm). Taken together, a distinct set of subcortical and cortical areas showed greater responsiveness to tactile stimulation with dome-shaped plastic gratings in patients with writer's cramp relative to healthy controls. However, the overactivity elicited by tactile stimulation was independent of the groove width and thus was not related to the percept of grating orientation.</p>                    <h3 scrollto-destination=3672202 id="3672202" class="section-title js-splitscreen-section-title" >Within-group regression analyses in patients with writer's cramp</h3>
+<p class="chapter-para">In patients with writer's cramp, we performed an additional regression analysis to examine whether task-related increases in BOLD signal were influenced by disease severity or duration. Since the age of the patients was included in the analysis as a separate regressor of no interest, these results cannot be attributed to simple age effects. There was no brain area where the BOLD signal increase during tactile stimulation co-varied positively with disease duration. However, several brain regions showed an inverse linear relation between regional neuronal activity and disease duration. In the right posterior putamen and caudate nucleus, disease duration was associated with a gradual decrease in BOLD signal during tactile discrimination (<span class="xrefLink" id="jumplink-fig5"></span><a href="javascript:;" data-modal-source-id="fig5" class="link xref-fig">Fig. 5</a>; <span class="xrefLink" id="jumplink-tbl3"></span><a href="javascript:;" reveal-id="tbl3" data-open="tbl3" class="link link-reveal link-table xref-fig">Table 3</a>). A similar trend was found in the left posterior putamen (<span class="xrefLink" id="jumplink-fig5"></span><a href="javascript:;" data-modal-source-id="fig5" class="link xref-fig">Fig. 5</a>; <span class="xrefLink" id="jumplink-tbl3"></span><a href="javascript:;" reveal-id="tbl3" data-open="tbl3" class="link link-reveal link-table xref-fig">Table 3</a>). This finding indicates that the enhanced responsiveness of the basal ganglia to tactile stimulation gradually tapers off with disease duration. Within the cerebral cortex, only the frontal opercular cortex showed a bilateral trend towards an inverse relation between the regional BOLD signal and the duration of dystonia (<span class="xrefLink" id="jumplink-fig5"></span><a href="javascript:;" data-modal-source-id="fig5" class="link xref-fig">Fig. 5</a>; <span class="xrefLink" id="jumplink-tbl3"></span><a href="javascript:;" reveal-id="tbl3" data-open="tbl3" class="link link-reveal link-table xref-fig">Table 3</a>).</p>                    <a id="3672205" scrollto-destination="3672205"></a>
+<div data-id="fig5" data-content-id="fig5" class="fig fig-section js-fig-section" swap-content-for-modal="true"><div class="label fig-label"><strong>Fig. 5</strong></div><div class="graphic-wrap"><img class="content-image" src="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/m_awl181f5.gif?Expires=1689794673&amp;Signature=XdbX4DmcO9gPYuh7uaevQi2WqmRAOh7uUPoZW1ryKwspPE0U882GlZPKdObd8nf3KNuh~NVGoqUik9y3ElYPN1J7tMNPCFFqeat7qPRZYTFzEXzwulG-8UWNp1VU1P9raEYJkdMEZ-ficnWW1wY5KhYVpUVKX66Yl2lsQoyCTiBEm7rBu3wz9kd8Qf~BfA8s3lMpiKhpob0cPWz2leJXIG5VyMEV3BqGKnTkVDb0PrznNh5mKS~4OCcAA77yPpwR4zAqKo2sJchTTat8gOdcz8luFPF77hkRhp9UjOqw0RsXq3t3c2axgjK47OeYRDDIXajg7mlLb1lAlVAU-YkwNQ__&amp;Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" alt="Relationship between clinical features and phenotype and increases in BOLD signal during tactile discrimination. Upper panel: The voxels coded in red represent voxels that showed an inverse linear relationship between task-related increases in BOLD signal and disease duration, whereas the voxels coded in green denote voxels that showed an inverse linear relationship between task-related increases in BOLD signal and disease severity (extent threshold: P &lt; 0.01, uncorrected). Sagittal and axial Z-score maps are superimposed on the T1-weighted MRI template implemented in SPM2, and the corresponding stereotactic coordinate (in mm) is given for each slice. L = left; R = right. Lower left panel: The graph plots the individual effect size of task-related neuronal activity (y-axis) against disease duration (x-axis) for the voxel in the right putamen showing the strongest linear decrease in regional task-related activity with disease duration. Lower right panel: The graph plots the individual effect size of task-related neuronal activity (y-axis) against the individual scores of the ADDS (x-axis) for the cerebellar voxel that showed the strongest linear increase in regional task-related activity with the ADDS score. Note that the lower the ADDS score the more severe is the functional impairment. In both scatter plots, the line indicates the estimated linear relationship between the clinical measure and the task-related change in regional BOLD signal." data-path-from-xml="awl181f5.gif" /><div class="fig-orig original-slide"><a class="fig-view-orig js-view-large at-figureViewLarge openInAnotherWindow" href="/view-large/figure/3672205/awl181f5.gif" data-path-from-xml="awl181f5.gif" target="_blank">Open in new tab</a><a data-section="3672205" href="/DownloadFile/DownloadImage.aspx?image=https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/brain/129/10/10.1093/brain/awl181/2/awl181f5.gif?Expires=1689794673&Signature=tygOORSQF7aotl8NmliuOl0nZ48s11w-FHiZfDwpILMydzCSkIBY6qJqM-UTcNgvBrf0Gx727f9GqKs6l5EO2H9mAp5RcfrUEZtVWEI3Uo~XJFO1h7eXuuuJBBVGAnfRofqSjRLr8AfZo84yt8WXqJmyDpXtWYx~chp1VQtgcQQr08MsFsycYma5S-mK9o3W0XE-C8azjKVcNw0njSsRecPmXYgjZtv9f06jdjrKV3Rag~goEfJGLsEYNJyDoLDauBqRzDzgM35RnJaw-jiB4HP8DBqJddw4u80TXnTO6c-RN7QVU~oVVr1Fzl4BF2XGrDeB0C4UkbR8p8IjPtWWxQ__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA&sec=3672205&ar=290089&xsltPath=~/UI/app/XSLT&imagename=&siteId=5367" class="download-slide" data-path-from-xml="awl181f5.gif">Download slide</a></div></div><div class="caption fig-caption"><p class="chapter-para">Relationship between clinical features and phenotype and increases in BOLD signal during tactile discrimination. Upper panel: The voxels coded in red represent voxels that showed an inverse linear relationship between task-related increases in BOLD signal and disease duration, whereas the voxels coded in green denote voxels that showed an inverse linear relationship between task-related increases in BOLD signal and disease severity (extent threshold: <em>P</em> &lt; 0.01, uncorrected). Sagittal and axial <em>Z</em>-score maps are superimposed on the T<sub>1</sub>-weighted MRI template implemented in SPM2, and the corresponding stereotactic coordinate (in mm) is given for each slice. L = left; R = right. Lower left panel: The graph plots the individual effect size of task-related neuronal activity (<em>y</em>-axis) against disease duration (<em>x</em>-axis) for the voxel in the right putamen showing the strongest linear decrease in regional task-related activity with disease duration. Lower right panel: The graph plots the individual effect size of task-related neuronal activity (<em>y</em>-axis) against the individual scores of the ADDS (<em>x</em>-axis) for the cerebellar voxel that showed the strongest linear increase in regional task-related activity with the ADDS score. Note that the lower the ADDS score the more severe is the functional impairment. In both scatter plots, the line indicates the estimated linear relationship between the clinical measure and the task-related change in regional BOLD signal.</p></div></div>                    <a id="3672209" scrollto-destination="3672209"></a>
+<div content-id="tbl3" class="table-modal table-full-width-wrap"><div class="table-wrap table-wide"><div class="table-wrap-title" id="tbl3" data-id="tbl3"><span class="label"><strong>Table 3</strong></span><div class="caption"><p class="chapter-para">Within-group regression analyses in patients</p></div> </div><div class="table-overflow"><table role="table"><thead><tr><th>Anatomical location<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Side<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Cluster extent<span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4">Linear changes in BOLD signal<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3">MNI coordinates<span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>Z</em>-value<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>x</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>y</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>z</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr></thead><tbody><tr><td colspan="7">Linear decreases in BOLD signal with disease duration </td></tr><tr><td>    Posterior putamen </td><td>R </td><td>213 </td><td>30 </td><td>−18 </td><td>0 </td><td>3.67 </td></tr><tr><td>    Caudate nucleus (head) </td><td>R </td><td> </td><td>12 </td><td>9 </td><td>12 </td><td>3.57 </td></tr><tr><td>    Posterior putamen </td><td>L </td><td>40 </td><td>−27 </td><td>−12 </td><td>12 </td><td>3.60<sup>*</sup> </td></tr><tr><td>    Frontal opercular cortex </td><td>L </td><td>25 </td><td>−54 </td><td>21 </td><td>9 </td><td>3.40<sup>*</sup> </td></tr><tr><td>    Frontal opercular cortex </td><td>R </td><td>36 </td><td>60 </td><td>24 </td><td>6 </td><td>3.32<sup>*</sup> </td></tr><tr><td colspan="7">Linear increases in BOLD signal with the ADDS score </td></tr><tr><td>    Paramedian cerebellar cortex     (Lobulus VI); dentate nucleus </td><td>L </td><td>1199 </td><td>−24 </td><td>−57 </td><td>−27 </td><td>4.11 </td></tr><tr><td>    Tegmentum pontis </td><td>R </td><td> </td><td>6 </td><td>−33 </td><td>−39 </td><td>3.99 </td></tr><tr><td>    Dentate nucleus; paramedian     cerebellar cortex (Lobulus VI) </td><td>R </td><td> </td><td>18 </td><td>−54 </td><td>−36 </td><td>3.88 </td></tr><tr><td>    Inferior temporal gyrus </td><td>L </td><td>90 </td><td>−45 </td><td>−3 </td><td>−39 </td><td>3.79<sup>*</sup> </td></tr></tbody></table></div><div class="table-modal"><table><thead><tr><th>Anatomical location<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Side<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Cluster extent<span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4">Linear changes in BOLD signal<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3">MNI coordinates<span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>Z</em>-value<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>x</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>y</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>z</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr></thead><tbody><tr><td colspan="7">Linear decreases in BOLD signal with disease duration </td></tr><tr><td>    Posterior putamen </td><td>R </td><td>213 </td><td>30 </td><td>−18 </td><td>0 </td><td>3.67 </td></tr><tr><td>    Caudate nucleus (head) </td><td>R </td><td> </td><td>12 </td><td>9 </td><td>12 </td><td>3.57 </td></tr><tr><td>    Posterior putamen </td><td>L </td><td>40 </td><td>−27 </td><td>−12 </td><td>12 </td><td>3.60<sup>*</sup> </td></tr><tr><td>    Frontal opercular cortex </td><td>L </td><td>25 </td><td>−54 </td><td>21 </td><td>9 </td><td>3.40<sup>*</sup> </td></tr><tr><td>    Frontal opercular cortex </td><td>R </td><td>36 </td><td>60 </td><td>24 </td><td>6 </td><td>3.32<sup>*</sup> </td></tr><tr><td colspan="7">Linear increases in BOLD signal with the ADDS score </td></tr><tr><td>    Paramedian cerebellar cortex     (Lobulus VI); dentate nucleus </td><td>L </td><td>1199 </td><td>−24 </td><td>−57 </td><td>−27 </td><td>4.11 </td></tr><tr><td>    Tegmentum pontis </td><td>R </td><td> </td><td>6 </td><td>−33 </td><td>−39 </td><td>3.99 </td></tr><tr><td>    Dentate nucleus; paramedian     cerebellar cortex (Lobulus VI) </td><td>R </td><td> </td><td>18 </td><td>−54 </td><td>−36 </td><td>3.88 </td></tr><tr><td>    Inferior temporal gyrus </td><td>L </td><td>90 </td><td>−45 </td><td>−3 </td><td>−39 </td><td>3.79<sup>*</sup> </td></tr></tbody></table></div><div class="table-wrap-foot"><span id="fn-"></span><div content-id="" class="footnote"><span class="fn"><p class="chapter-para">The table lists brain regions where task-related increases in BOLD signal showed a linear relation with clinical features of dystonia (<em>P</em> &lt; 0.05, corrected at the cluster level); R = right; L = left; asterisks mark clusters that showed a trend activation (<em>P</em> &lt; 0.001, uncorrected) but failed to survive correction for multiple comparisons.</p></span></div></div><div class="&#xA;          graphic-wrap&#xA;          "><a class="fig-view-orig at-tableViewLarge openInAnotherWindow btn js-view-large" target="_blank" href="/view-large/3672209">
+          Open in new tab
+        </a></div></div></div><div class="table-full-width-wrap"><div class="table-wrap table-wide"><div class="table-wrap-title" id="tbl3" data-id="tbl3"><span class="label"><strong>Table 3</strong></span><div class="caption"><p class="chapter-para">Within-group regression analyses in patients</p></div> </div><div class="table-overflow"><table role="table"><thead><tr><th>Anatomical location<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Side<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Cluster extent<span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4">Linear changes in BOLD signal<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3">MNI coordinates<span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>Z</em>-value<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>x</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>y</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>z</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr></thead><tbody><tr><td colspan="7">Linear decreases in BOLD signal with disease duration </td></tr><tr><td>    Posterior putamen </td><td>R </td><td>213 </td><td>30 </td><td>−18 </td><td>0 </td><td>3.67 </td></tr><tr><td>    Caudate nucleus (head) </td><td>R </td><td> </td><td>12 </td><td>9 </td><td>12 </td><td>3.57 </td></tr><tr><td>    Posterior putamen </td><td>L </td><td>40 </td><td>−27 </td><td>−12 </td><td>12 </td><td>3.60<sup>*</sup> </td></tr><tr><td>    Frontal opercular cortex </td><td>L </td><td>25 </td><td>−54 </td><td>21 </td><td>9 </td><td>3.40<sup>*</sup> </td></tr><tr><td>    Frontal opercular cortex </td><td>R </td><td>36 </td><td>60 </td><td>24 </td><td>6 </td><td>3.32<sup>*</sup> </td></tr><tr><td colspan="7">Linear increases in BOLD signal with the ADDS score </td></tr><tr><td>    Paramedian cerebellar cortex     (Lobulus VI); dentate nucleus </td><td>L </td><td>1199 </td><td>−24 </td><td>−57 </td><td>−27 </td><td>4.11 </td></tr><tr><td>    Tegmentum pontis </td><td>R </td><td> </td><td>6 </td><td>−33 </td><td>−39 </td><td>3.99 </td></tr><tr><td>    Dentate nucleus; paramedian     cerebellar cortex (Lobulus VI) </td><td>R </td><td> </td><td>18 </td><td>−54 </td><td>−36 </td><td>3.88 </td></tr><tr><td>    Inferior temporal gyrus </td><td>L </td><td>90 </td><td>−45 </td><td>−3 </td><td>−39 </td><td>3.79<sup>*</sup> </td></tr></tbody></table></div><div class="table-modal"><table><thead><tr><th>Anatomical location<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Side<span aria-hidden="true" style="display: none;">
+            . </span></th><th>Cluster extent<span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4">Linear changes in BOLD signal<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="4"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3">MNI coordinates<span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>Z</em>-value<span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th colspan="3"><hr /><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr><tr><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>x</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>y</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><em>z</em><span aria-hidden="true" style="display: none;">
+            . </span></th><th><span aria-hidden="true" style="display: none;">
+            . </span></th></tr></thead><tbody><tr><td colspan="7">Linear decreases in BOLD signal with disease duration </td></tr><tr><td>    Posterior putamen </td><td>R </td><td>213 </td><td>30 </td><td>−18 </td><td>0 </td><td>3.67 </td></tr><tr><td>    Caudate nucleus (head) </td><td>R </td><td> </td><td>12 </td><td>9 </td><td>12 </td><td>3.57 </td></tr><tr><td>    Posterior putamen </td><td>L </td><td>40 </td><td>−27 </td><td>−12 </td><td>12 </td><td>3.60<sup>*</sup> </td></tr><tr><td>    Frontal opercular cortex </td><td>L </td><td>25 </td><td>−54 </td><td>21 </td><td>9 </td><td>3.40<sup>*</sup> </td></tr><tr><td>    Frontal opercular cortex </td><td>R </td><td>36 </td><td>60 </td><td>24 </td><td>6 </td><td>3.32<sup>*</sup> </td></tr><tr><td colspan="7">Linear increases in BOLD signal with the ADDS score </td></tr><tr><td>    Paramedian cerebellar cortex     (Lobulus VI); dentate nucleus </td><td>L </td><td>1199 </td><td>−24 </td><td>−57 </td><td>−27 </td><td>4.11 </td></tr><tr><td>    Tegmentum pontis </td><td>R </td><td> </td><td>6 </td><td>−33 </td><td>−39 </td><td>3.99 </td></tr><tr><td>    Dentate nucleus; paramedian     cerebellar cortex (Lobulus VI) </td><td>R </td><td> </td><td>18 </td><td>−54 </td><td>−36 </td><td>3.88 </td></tr><tr><td>    Inferior temporal gyrus </td><td>L </td><td>90 </td><td>−45 </td><td>−3 </td><td>−39 </td><td>3.79<sup>*</sup> </td></tr></tbody></table></div><div class="table-wrap-foot"><span id="fn-"></span><div content-id="" class="footnote"><span class="fn"><p class="chapter-para">The table lists brain regions where task-related increases in BOLD signal showed a linear relation with clinical features of dystonia (<em>P</em> &lt; 0.05, corrected at the cluster level); R = right; L = left; asterisks mark clusters that showed a trend activation (<em>P</em> &lt; 0.001, uncorrected) but failed to survive correction for multiple comparisons.</p></span></div></div><div class="&#xA;          graphic-wrap&#xA;          "><a class="fig-view-orig at-tableViewLarge openInAnotherWindow btn js-view-large" target="_blank" href="/view-large/3672209">
+          Open in new tab
+        </a></div></div></div><p class="chapter-para">A large bilateral cluster in the cerebellum and pons showed a positive linear relation between the BOLD response to tactile stimulation and the ADDS score (<span class="xrefLink" id="jumplink-tbl3"></span><a href="javascript:;" reveal-id="tbl3" data-open="tbl3" class="link link-reveal link-table xref-fig">Table 3</a>). As outlined above, the lower the ADDS score the more severely the hand function was affected by dystonia. Therefore, the gradual increase in regional BOLD signal with the ADDS score indicates that tactile stimulation elicited stronger activation in patients who were less affected by dystonia. The pontocerebellar cluster included the tegmentum pontis, the cerebellar nuclei and the middle part of the vermis, and extended into the right cerebellar hemisphere (<span class="xrefLink" id="jumplink-fig5"></span><a href="javascript:;" data-modal-source-id="fig5" class="link xref-fig">Fig. 5</a>). No cluster in the brain exhibited a negative linear relation between the BOLD response to tactile stimulation and the ADDS score (i.e. a gradual increase in activation depending on disease severity). No brain region showed a linear increase or decrease in task-related BOLD signal change depending on the grating discrimination threshold.</p>                    <h2 scrollto-destination=3672213 id="3672213" class="section-title js-splitscreen-section-title" >Discussion</h2>
+<p class="chapter-para">To our knowledge, this is the first study to demonstrate that the discrimination of tactile input from the affected limb is associated with a widespread overactivation of the basal ganglia and lateral thalamus in patients with writer's cramp. Increased activity in the basal ganglia was not specifically linked to the perception of grating orientation and was less prominent in patients who had long-standing writer's cramp. Task-related activity was also found to be altered in other brain regions. At a cortical level, tactile processing was associated with a relative overactivity in posterior visual areas, left anterior insula and right intraparietal sulcus but not in the primary or secondary sensory cortex. A bilateral pontocerebellar cluster showed a linear decrease in task-related activity with increasing severity of dystonia. We discuss the implications of these results in terms of our understanding of the pathophysiology of focal task-specific hand dystonia.</p>                    <h3 scrollto-destination=3672217 id="3672217" class="section-title js-splitscreen-section-title" >Basal ganglia</h3>
+<p class="chapter-para">The majority of neuroimaging studies in focal hand dystonia reported changes in activation at the cortical level without concurrent functional alterations in the basal ganglia (<span class="xrefLink" id="jumplink-b13"></span><a href="javascript:;" reveal-id="b13" data-open="b13" class="link link-ref link-reveal xref-bibr">Ceballos-Baumann <em>et al</em>., 1997</a>; <span class="xrefLink" id="jumplink-b39"></span><a href="javascript:;" reveal-id="b39" data-open="b39" class="link link-ref link-reveal xref-bibr">Odergren <em>et al</em>., 1998</a>; <span class="xrefLink" id="jumplink-b26"></span><a href="javascript:;" reveal-id="b26" data-open="b26" class="link link-ref link-reveal xref-bibr">Ibanez <em>et al</em>., 1999</a>; <span class="xrefLink" id="jumplink-b45"></span><a href="javascript:;" reveal-id="b45" data-open="b45" class="link link-ref link-reveal xref-bibr">Pujol <em>et al</em>., 2000</a>; <span class="xrefLink" id="jumplink-b41"></span><a href="javascript:;" reveal-id="b41" data-open="b41" class="link link-ref link-reveal xref-bibr">Oga <em>et al</em>., 2002</a>; <span class="xrefLink" id="jumplink-b11"></span><a href="javascript:;" reveal-id="b11" data-open="b11" class="link link-ref link-reveal xref-bibr">Butterworth <em>et al</em>., 2003</a>; <span class="xrefLink" id="jumplink-b32"></span><a href="javascript:;" reveal-id="b32" data-open="b32" class="link link-ref link-reveal xref-bibr">Lerner <em>et al</em>., 2004</a>). Extending these findings, two recent fMRI studies also disclosed abnormal movement-related activity in the basal ganglia. Patients with task-specific hand dystonia showed a distorted somatotopic representation of finger, toe or lip movements in the putamen, which may contribute to the loss of functional selectivity of muscle activity in dystonia (<span class="xrefLink" id="jumplink-b15"></span><a href="javascript:;" reveal-id="b15" data-open="b15" class="link link-ref link-reveal xref-bibr">Delmaire <em>et al</em>., 2005</a>). Another fMRI study reported an abnormal persistence of neuronal activity of the basal ganglia after the end of a finger-tapping task in patients with focal hand dystonia (<span class="xrefLink" id="jumplink-b8"></span><a href="javascript:;" reveal-id="b8" data-open="b8" class="link link-ref link-reveal xref-bibr">Blood <em>et al</em>., 2004</a>). This was interpreted as a functional correlate of faulty inhibitory control of the basal ganglia in focal hand dystonia (<span class="xrefLink" id="jumplink-b8"></span><a href="javascript:;" reveal-id="b8" data-open="b8" class="link link-ref link-reveal xref-bibr">Blood <em>et al</em>., 2004</a>).</p><p class="chapter-para">We found excessive activation of the basal ganglia and lateral thalamus during discrimination of tactile input from the affected hand. Dystonic patients displayed task-related overactivity not only in the left posterior putamen but also in the anterior putamen and the rostral body of the caudate nucleus, that is, increased activity in the basal ganglia was not restricted to the sensorimotor cortico-basal ganglia–thalamocortical loop (i.e. posterior putamen) but involved additional cognitive or limbic loops that support sensorimotor control in these patients (<span class="xrefLink" id="jumplink-b2"></span><a href="javascript:;" reveal-id="b2" data-open="b2" class="link link-ref link-reveal xref-bibr">Alexander <em>et al</em>., 1986</a>; <span class="xrefLink" id="jumplink-b43"></span><a href="javascript:;" reveal-id="b43" data-open="b43" class="link link-ref link-reveal xref-bibr">Parent and Hazrati, 1995</a>).</p><p class="chapter-para">The overactivity in the basal ganglia and thalamus cannot be explained by differences in task difficulty or task performance between groups because we used a grating discrimination task that patients could easily perform. For tactile stimulation, we used domes with a groove width that was clearly below or above individual discrimination threshold and thus caused an unequivocal perception of a smooth (i.e. groove width of 0.35 mm) or grooved surface (i.e. groove width of 3.00 mm) in all participants. Therefore, we attribute the hyperactivity in the basal ganglia to excessive neuronal processing of tactile input from the affected limb. Increased responsiveness of the basal ganglia to tactile stimuli may reflect the failure of the basal ganglia to efficiently process the incoming sensory information and may contribute to an abnormal activity pattern in the basal ganglia during motor tasks (<span class="xrefLink" id="jumplink-b8"></span><a href="javascript:;" reveal-id="b8" data-open="b8" class="link link-ref link-reveal xref-bibr">Blood <em>et al</em>., 2004</a>).</p><p class="chapter-para">The enhanced responsiveness of the basal ganglia may constitute an abnormal neuronal signal resulting in excessive reinforcement learning in the basal ganglia–thalamocortical loops during repetitive manual skills (<span class="xrefLink" id="jumplink-b3"></span><a href="javascript:;" reveal-id="b3" data-open="b3" class="link link-ref link-reveal xref-bibr">Bar-Gad <em>et al</em>., 2003</a>). This may result in excessive reinforcement learning and contribute to maladaptive plastic changes such as the formation of excessive sensorimotor associations and progressive degradation of sensorimotor representations. In line with this hypothesis, several conditioning protocols that used transcranial cortex stimulation revealed an excessive modifiability of the sensorimotor system in patients with writer's cramp (<span class="xrefLink" id="jumplink-b46"></span><a href="javascript:;" reveal-id="b46" data-open="b46" class="link link-ref link-reveal xref-bibr">Quartarone <em>et al</em>., 2003</a>; <span class="xrefLink" id="jumplink-b53"></span><a href="javascript:;" reveal-id="b53" data-open="b53" class="link link-ref link-reveal xref-bibr">Siebner <em>et al</em>., 2003</a>; <span class="xrefLink" id="jumplink-b48"></span><a href="javascript:;" reveal-id="b48" data-open="b48" class="link link-ref link-reveal xref-bibr">Quartarone <em>et al</em>., 2006</a>). According to a recent computational model, the basal ganglia conduct a dimensionality reduction that takes input from multiple sensory, motor, affective and cognitive cortical areas and relays a compressed encoding of this information into areas of the brain involved in the execution, planning and selection of actions (<span class="xrefLink" id="jumplink-b3"></span><a href="javascript:;" reveal-id="b3" data-open="b3" class="link link-ref link-reveal xref-bibr">Bar-Gad <em>et al</em>., 2003</a>). Within this framework, the overactivity of the basal ganglia and lateral thalamus during tactile processing may indicate an inefficient ‘compression’ of the relevant information conveyed by the tactile stimulus within the basal ganglia, resulting in an impaired ‘funneling’ function of the basal ganglia. The increased responsiveness of the basal ganglia and lateral thalamus also supports the concept of impaired centre–surround inhibition within the cortico-striato-thalamocortical loops in focal dystonia (<span class="xrefLink" id="jumplink-b54"></span><a href="javascript:;" reveal-id="b54" data-open="b54" class="link link-ref link-reveal xref-bibr">Sohn and Hallett, 2004</a>). Defective centre–surround inhibition of sensory input within the basal ganglia may lead to an excessive activation of motor cortical areas, ultimately resulting in muscular overflow and co-contractions during handwriting.</p><p class="chapter-para">In patients and healthy controls, tactile discrimination led to a bilateral activation in the anterior and posterior putamen as well as the caudate nucleus. While the posterior putamen receives major corticostriatal inputs from sensorimotor cortical areas, premotor and prefrontal areas project onto the anterior putamen and caudate nucleus (<span class="xrefLink" id="jumplink-b43"></span><a href="javascript:;" reveal-id="b43" data-open="b43" class="link link-ref link-reveal xref-bibr">Parent and Hazrati, 1995</a>). This pattern of activation indicates that tactile discrimination caused a concurrent activation of cortico-basal ganglia–thalamocortical loops involved in sensorimotor and cognitive evaluation of the tactile input (<span class="xrefLink" id="jumplink-b2"></span><a href="javascript:;" reveal-id="b2" data-open="b2" class="link link-ref link-reveal xref-bibr">Alexander <em>et al</em>., 1986</a>). The bilateral overactivity of the basal ganglia after unilateral tactile stimulation also suggests a more generalized problem in tactile processing involving both hemispheres.</p><p class="chapter-para">An important question is whether the overactivity of the basal ganglia can also be evoked by tactile stimulation of unaffected body parts. Since we only studied central processing of tactile stimuli from the clinically affected hand, this issue remains to be addressed in a future study. However, several lines of evidence suggest that the abnormal activation of the basal ganglia can also be elicited by tactile stimulation of non-affected body parts. Patients with focal hand dystonia show abnormalities of temporal (<span class="xrefLink" id="jumplink-b20"></span><a href="javascript:;" reveal-id="b20" data-open="b20" class="link link-ref link-reveal xref-bibr">Fiorio <em>et al</em>., 2003</a>) and spatial (<span class="xrefLink" id="jumplink-b49"></span><a href="javascript:;" reveal-id="b49" data-open="b49" class="link link-ref link-reveal xref-bibr">Sanger <em>et al</em>., 2001</a>; <span class="xrefLink" id="jumplink-b37"></span><a href="javascript:;" reveal-id="b37" data-open="b37" class="link link-ref link-reveal xref-bibr">Molloy <em>et al</em>., 2003</a>) tactile discrimination of the unaffected side. Patients with writer's cramp also showed a bilateral reduction in kinaesthetic perception when they were asked to match the arm flexion induced by tonic vibration of the biceps tendons with their contralateral non-stimulated arm (<span class="xrefLink" id="jumplink-b23"></span><a href="javascript:;" reveal-id="b23" data-open="b23" class="link link-ref link-reveal xref-bibr">Grunewald <em>et al</em>., 1997</a>). <span class="xrefLink" id="jumplink-b34"></span><a href="javascript:;" reveal-id="b34" data-open="b34" class="link link-ref link-reveal xref-bibr">Meunier <em>et al</em>. (2001</a>) used MEG to demonstrate severe somatotopic disorganization in the sensory cortex coding the representations of the non-dystonic upper limb (<span class="xrefLink" id="jumplink-b34"></span><a href="javascript:;" reveal-id="b34" data-open="b34" class="link link-ref link-reveal xref-bibr">Meunier <em>et al</em>., 2001</a>).</p><p class="chapter-para">The amount of overactivity within the basal ganglia did not correlate with the severity of dystonic symptoms or individual discrimination thresholds. Hence, enhanced sensory processing in the basal ganglia may represent an endophenotypic trait that predisposes to focal task-specific hand dystonia. Interestingly, the increased neuronal response to tactile stimuli in the basal ganglia was most pronounced in patients who had a relatively short history of writer's cramp. If the relative overactivity of the basal ganglia represents a sensory dysfunction, this finding may indicate a long-term compensatory reorganization within the basal ganglia leading to a gradual attenuation of the overactivity in the basal ganglia. Alternatively, the initial overactivity in the basal ganglia may represent a compensatory effort that exists in the beginning of the disease but wears off with persisting disease.</p>                    <h3 scrollto-destination=3672231 id="3672231" class="section-title js-splitscreen-section-title" >Cerebellum</h3>
+<p class="chapter-para">Previous neuroimaging studies reported an overactivation of the cerebellum during handwriting in patients with focal hand dystonia (<span class="xrefLink" id="jumplink-b39"></span><a href="javascript:;" reveal-id="b39" data-open="b39" class="link link-ref link-reveal xref-bibr">Odergren <em>et al</em>., 1998</a>; <span class="xrefLink" id="jumplink-b44"></span><a href="javascript:;" reveal-id="b44" data-open="b44" class="link link-ref link-reveal xref-bibr">Preibisch <em>et al</em>., 2001</a>), spasmodic torticollis (<span class="xrefLink" id="jumplink-b22"></span><a href="javascript:;" reveal-id="b22" data-open="b22" class="link link-ref link-reveal xref-bibr">Galardi <em>et al</em>., 1996</a>) and essential blepharospasm (<span class="xrefLink" id="jumplink-b25"></span><a href="javascript:;" reveal-id="b25" data-open="b25" class="link link-ref link-reveal xref-bibr">Hutchinson <em>et al</em>., 2000</a>). The cerebellar hemisphere showed a trend towards an increase in movement-related activity during freely selected movements as well as an increased responsiveness to premotor TMS conditioning in patients with focal hand dystonia (<span class="xrefLink" id="jumplink-b53"></span><a href="javascript:;" reveal-id="b53" data-open="b53" class="link link-ref link-reveal xref-bibr">Siebner <em>et al</em>., 2003</a>). Finally, treatment with botulinum toxin injections was found to reduce activation in the upper part of the ipsilateral cerebellar hemisphere and the vermis during handwriting in patients with writer's cramp (<span class="xrefLink" id="jumplink-b13"></span><a href="javascript:;" reveal-id="b13" data-open="b13" class="link link-ref link-reveal xref-bibr">Ceballos-Baumann <em>et al</em>., 1997</a>). Though these studies have shown functional reorganization of the cerebellum in focal dystonia, the pathophysiological significance of such reorganization is unclear. These findings may indicate a functional impairment of the cerebellum or constitute a neuronal substrate for functional compensation.</p><p class="chapter-para">In this study, a cluster in the left lateral cerebellum showed a trend towards increased activity during tactile discrimination in patients. More importantly, patients who were clinically less affected showed greater bilateral activation of the dorsal pons and cerebellum during tactile discrimination. Since the age of the patients was modelled as separate regressor, the inverse relation between pontocerebellar activation and the severity of dystonia cannot be accounted for by the age of the patients. The areas showing a linear decrease in task-related activity with increasing disease severity included the dorsal pontine nuclei, cerebellar nuclei, posterior vermis and the intermediate part of the right cerebellar hemisphere. The dorsolateral pontine nuclei serve as an integrative interface between the various sensory signals required for performing intentional behaviours (<span class="xrefLink" id="jumplink-b28"></span><a href="javascript:;" reveal-id="b28" data-open="b28" class="link link-ref link-reveal xref-bibr">Kobayashi <em>et al</em>., 2002</a>, <span class="xrefLink" id="jumplink-b29"></span><a href="javascript:;" reveal-id="b29" data-open="b29" class="link link-ref link-reveal xref-bibr">2004</a>) and represent an important input channel to the cerebellar cortex and nuclei (<span class="xrefLink" id="jumplink-b55"></span><a href="javascript:;" reveal-id="b55" data-open="b55" class="link link-ref link-reveal xref-bibr">Stein and Glickstein, 1992</a>; <span class="xrefLink" id="jumplink-b14"></span><a href="javascript:;" reveal-id="b14" data-open="b14" class="link link-ref link-reveal xref-bibr">Cicirata <em>et al</em>., 2005</a>). The cerebellar nuclei represent in turn the main output channel of the cerebellum to the thalamus and receive inhibitory input from the cerebellar cortex via Purkinje cells (<span class="xrefLink" id="jumplink-b35"></span><a href="javascript:;" reveal-id="b35" data-open="b35" class="link link-ref link-reveal xref-bibr">Middleton and Strick, 1997</a>). We therefore hypothesize that loops linking the dorsal pontine nuclei with the cerebellar cortex and cerebellar nuclei were recruited to compensate for dysfunctional processing in the cortico-basal ganglia–thalamocortical loop. However, this hypothesis needs to be confirmed in future studies.</p>                    <h3 scrollto-destination=3672237 id="3672237" class="section-title js-splitscreen-section-title" >Thalamocortical processing</h3>
+<p class="chapter-para">In agreement with previous neuroimaging studies (<span class="xrefLink" id="jumplink-b63"></span><a href="javascript:;" reveal-id="b63" data-open="b63" class="link link-ref link-reveal xref-bibr">Zangaladze <em>et al</em>., 1999</a>; <span class="xrefLink" id="jumplink-b61"></span><a href="javascript:;" reveal-id="b61" data-open="b61" class="link link-ref link-reveal xref-bibr">Van Boven <em>et al</em>., 2005</a>; <span class="xrefLink" id="jumplink-b65"></span><a href="javascript:;" reveal-id="b65" data-open="b65" class="link link-ref link-reveal xref-bibr">Zhang <em>et al</em>., 2005</a>), a bilateral set of dorsal frontoparietal areas was activated when dystonic patients and controls perceived a grating orientation relative to the perception of a smooth surface. This network comprised the post-central gyrus, intraparietal sulcus, parietal operculum, dorsal premotor cortex/frontal eye field and the anterior cingulate cortex.</p><p class="chapter-para">In contrast to our prediction, the perception of a grating orientation produced a comparable activation of the primary and secondary sensory cortices in dystonic patients and healthy controls. However, patients did show a hyperactivity of the lateral thalamus, indicating that sensory processing was abnormal at the thalamic but not at the cortical level. In patients with generalized dystonia or hemidystonia who underwent thalamotomy, intraoperative recordings of neuronal responses to innocuous cutaneous stimuli revealed a sensory disorganization of thalamic receptive fields (<span class="xrefLink" id="jumplink-b30"></span><a href="javascript:;" reveal-id="b30" data-open="b30" class="link link-ref link-reveal xref-bibr">Lenz and Byl, 1999<em>a</em></a>). This raises the possibility that the increased thalamic BOLD response to tactile stimulation was due to a degradation of thalamic cutaneous representations of the index finger in patients with writer's cramp.</p><p class="chapter-para">Regardless of the groove width of the dome, tactile discrimination was associated with increased activity in the left anterior insula and right intraparietal sulcus in patients with writer's cramp relative to healthy controls. Several other cortical areas showed a trend towards increased activity in patients, including the right anterior insula, anterior cingulate areas, left precuneus and right dorsolateral prefrontal cortex. This regional overactivity suggests increased attentional monitoring of the tactile input in patients with writer's cramp.</p><p class="chapter-para">Finally, patients with writer's cramp showed increased activation of posterior visual areas during grating discrimination. Since visual imagery has been shown to be implicated in tactile discrimination of object properties (<span class="xrefLink" id="jumplink-b50"></span><a href="javascript:;" reveal-id="b50" data-open="b50" class="link link-ref link-reveal xref-bibr">Sathian and Zangaladze, 2001</a>; <span class="xrefLink" id="jumplink-b51"></span><a href="javascript:;" reveal-id="b51" data-open="b51" class="link link-ref link-reveal xref-bibr">Sathian and Zangaladze, 2002</a>; <span class="xrefLink" id="jumplink-b64"></span><a href="javascript:;" reveal-id="b64" data-open="b64" class="link link-ref link-reveal xref-bibr">Zhang <em>et al</em>., 2004</a>), our finding suggests that patients relied more strongly on visual imagery during tactile discrimination. The increased recruitment of visual areas may thus constitute another adaptive mechanism at the systems level to compensate for impaired sensory processing within cortico-basal ganglia–thalamocortical sensorimotor loops.</p><p class="chapter-para">In conclusion, this is the first demonstration of a widespread overactivity of the basal ganglia and lateral thalamus during active processing of tactile input from the affected hand in focal dystonia. The excessive responsiveness of the basal ganglia to tactile stimulation may contribute to motor dysfunction in affected patients. Sensory overactivity of the basal ganglia input may also constitute a predisposing factor for maladaptive sensorimotor plasticity in focal task-specific dystonia (<span class="xrefLink" id="jumplink-b48"></span><a href="javascript:;" reveal-id="b48" data-open="b48" class="link link-ref link-reveal xref-bibr">Quartarone <em>et al</em>., 2006</a>).</p><p class="chapter-para">We would like to thank Dirk Dressler, MD, PhD, Department of Neurology at the University of Rostock, and Lars Timmermann, MD, Department of Neurology, University of Düsseldorf, for referring patients to us. This work was supported by a structural grant from the BMBF to NeuroImageNord (01GO0511) and a project grant from the DFG (DE 438/7) to G.D. and H.R.S.</p>                    <h2 scrollto-destination=3672251 id="3672251" class="backreferences-title js-splitscreen-backreferences-title" >References</h2>
+<div class="ref-list js-splitview-ref-list"><div content-id="b1" class="js-splitview-ref-item" data-legacy-id="b1"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b1" href="javascript:;" aria-label="jumplink-b1" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b1" class="ref-content " data-id="b1"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Abbruzzese</div> <div class="given-names">G</div></div>,  <div class="name"><div class="surname">Marchese</div> <div class="given-names">R</div></div>,  <div class="name"><div class="surname">Buccolieri</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Gasparetto</div> <div class="given-names">B</div></div>,  <div class="name"><div class="surname">Trompetto</div> <div class="given-names">C</div></div>. </span><div class="article-title">Abnormalities of sensorimotor integration in focal dystonia: a transcranial magnetic stimulation study</div>, <div class="source ">Brain</div>, <div class="year">2001</div>, vol. <div class="volume">124</div> (pg. <div class="fpage">537</div>-<div class="lpage">45</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Abnormalities%20of%20sensorimotor%20integration%20in%20focal%20dystonia%3A%20a%20transcranial%20magnetic%20stimulation%20study&amp;author=G%20Abbruzzese&amp;author=R%20Marchese&amp;author=A%20Buccolieri&amp;author=B%20Gasparetto&amp;author=C%20Trompetto&amp;publication_year=2001&amp;journal=Brain&amp;volume=124&amp;pages=537-45" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1093/brain/124.3.537" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1093%2Fbrain%2F124.3.537" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1093%2Fbrain%2F124.3.537"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/11222454" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Abnormalities%20of%20sensorimotor%20integration%20in%20focal%20dystonia%3A%20a%20transcranial%20magnetic%20stimulation%20study&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b2" class="js-splitview-ref-item" data-legacy-id="b2"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b2" href="javascript:;" aria-label="jumplink-b2" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b2" class="ref-content " data-id="b2"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Alexander</div> <div class="given-names">GE</div></div>,  <div class="name"><div class="surname">DeLong</div> <div class="given-names">MR</div></div>,  <div class="name"><div class="surname">Strick</div> <div class="given-names">PL</div></div>. </span><div class="article-title">Parallel organization of functionally segregated circuits linking basal ganglia and cortex</div>, <div class="source ">Annu Rev Neurosci</div>, <div class="year">1986</div>, vol. <div class="volume">9</div> (pg. <div class="fpage">357</div>-<div class="lpage">81</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Parallel%20organization%20of%20functionally%20segregated%20circuits%20linking%20basal%20ganglia%20and%20cortex&amp;author=GE%20Alexander&amp;author=MR%20DeLong&amp;author=PL%20Strick&amp;publication_year=1986&amp;journal=Annu%20Rev%20Neurosci&amp;volume=9&amp;pages=357-81" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1146/annurev.ne.09.030186.002041" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1146%2Fannurev.ne.09.030186.002041" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1146%2Fannurev.ne.09.030186.002041"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/3085570" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Parallel%20organization%20of%20functionally%20segregated%20circuits%20linking%20basal%20ganglia%20and%20cortex&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b3" class="js-splitview-ref-item" data-legacy-id="b3"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b3" href="javascript:;" aria-label="jumplink-b3" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b3" class="ref-content " data-id="b3"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Bar-Gad</div> <div class="given-names">I</div></div>,  <div class="name"><div class="surname">Morris</div> <div class="given-names">G</div></div>,  <div class="name"><div class="surname">Bergman</div> <div class="given-names">H</div></div>. </span><div class="article-title">Information processing, dimensionality reduction and reinforcement learning in the basal ganglia</div>, <div class="source ">Prog Neurobiol</div>, <div class="year">2003</div>, vol. <div class="volume">71</div> (pg. <div class="fpage">439</div>-<div class="lpage">73</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Information%20processing%2C%20dimensionality%20reduction%20and%20reinforcement%20learning%20in%20the%20basal%20ganglia&amp;author=I%20Bar-Gad&amp;author=G%20Morris&amp;author=H%20Bergman&amp;publication_year=2003&amp;journal=Prog%20Neurobiol&amp;volume=71&amp;pages=439-73" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/j.pneurobio.2003.12.001" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2Fj.pneurobio.2003.12.001" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2Fj.pneurobio.2003.12.001"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15013228" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Information%20processing%2C%20dimensionality%20reduction%20and%20reinforcement%20learning%20in%20the%20basal%20ganglia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b4" class="js-splitview-ref-item" data-legacy-id="b4"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b4" href="javascript:;" aria-label="jumplink-b4" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b4" class="ref-content " data-id="b4"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Bara-Jimenez</div> <div class="given-names">W</div></div>,  <div class="name"><div class="surname">Catalan</div> <div class="given-names">MJ</div></div>,  <div class="name"><div class="surname">Hallett</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Gerloff</div> <div class="given-names">C</div></div>. </span><div class="article-title">Abnormal somatosensory homunculus in dystonia of the hand</div>, <div class="source ">Ann Neurol</div>, <div class="year">1998</div>, vol. <div class="volume">44</div> (pg. <div class="fpage">828</div>-<div class="lpage">31</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Abnormal%20somatosensory%20homunculus%20in%20dystonia%20of%20the%20hand&amp;author=W%20Bara-Jimenez&amp;author=MJ%20Catalan&amp;author=M%20Hallett&amp;author=C%20Gerloff&amp;publication_year=1998&amp;journal=Ann%20Neurol&amp;volume=44&amp;pages=828-31" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1002/(ISSN)1531-8249" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1002%2F(ISSN)1531-8249" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1002%2F(ISSN)1531-8249"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/9818942" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Abnormal%20somatosensory%20homunculus%20in%20dystonia%20of%20the%20hand&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b5" class="js-splitview-ref-item" data-legacy-id="b5"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b5" href="javascript:;" aria-label="jumplink-b5" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b5" class="ref-content " data-id="b5"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Bara-Jimenez</div> <div class="given-names">W</div></div>,  <div class="name"><div class="surname">Shelton</div> <div class="given-names">P</div></div>,  <div class="name"><div class="surname">Hallett</div> <div class="given-names">M</div></div>. </span><div class="article-title">Spatial discrimination is abnormal in focal hand dystonia</div>, <div class="source ">Neurology</div>, <div class="year">2000</div>, vol. <div class="volume">55</div> (pg. <div class="fpage">1869</div>-<div class="lpage">73</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Spatial%20discrimination%20is%20abnormal%20in%20focal%20hand%20dystonia&amp;author=W%20Bara-Jimenez&amp;author=P%20Shelton&amp;author=M%20Hallett&amp;publication_year=2000&amp;journal=Neurology&amp;volume=55&amp;pages=1869-73" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1212/WNL.55.12.1869" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1212%2FWNL.55.12.1869" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1212%2FWNL.55.12.1869"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/11134387" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Spatial%20discrimination%20is%20abnormal%20in%20focal%20hand%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b6" class="js-splitview-ref-item" data-legacy-id="b6"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b6" href="javascript:;" aria-label="jumplink-b6" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b6" class="ref-content " data-id="b6"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Bara-Jimenez</div> <div class="given-names">W</div></div>,  <div class="name"><div class="surname">Shelton</div> <div class="given-names">P</div></div>,  <div class="name"><div class="surname">Sanger</div> <div class="given-names">TD</div></div>,  <div class="name"><div class="surname">Hallett</div> <div class="given-names">M</div></div>. </span><div class="article-title">Sensory discrimination capabilities in patients with focal hand dystonia</div>, <div class="source ">Ann Neurol</div>, <div class="year">2000</div>, vol. <div class="volume">47</div> (pg. <div class="fpage">377</div>-<div class="lpage">80</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Sensory%20discrimination%20capabilities%20in%20patients%20with%20focal%20hand%20dystonia&amp;author=W%20Bara-Jimenez&amp;author=P%20Shelton&amp;author=TD%20Sanger&amp;author=M%20Hallett&amp;publication_year=2000&amp;journal=Ann%20Neurol&amp;volume=47&amp;pages=377-80" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1002/(ISSN)1531-8249" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1002%2F(ISSN)1531-8249" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1002%2F(ISSN)1531-8249"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/10716260" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Sensory%20discrimination%20capabilities%20in%20patients%20with%20focal%20hand%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b7" class="js-splitview-ref-item" data-legacy-id="b7"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b7" href="javascript:;" aria-label="jumplink-b7" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b7" class="ref-content " data-id="b7"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Berardelli</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Rothwell</div> <div class="given-names">JC</div></div>,  <div class="name"><div class="surname">Hallett</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Thompson</div> <div class="given-names">PD</div></div>,  <div class="name"><div class="surname">Manfredi</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Marsden</div> <div class="given-names">CD</div></div>. </span><div class="article-title">The pathophysiology of primary dystonia</div>, <div class="source ">Brain</div>, <div class="year">1998</div>, vol. <div class="volume">121</div> (pg. <div class="fpage">1195</div>-<div class="lpage">212</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20pathophysiology%20of%20primary%20dystonia&amp;author=A%20Berardelli&amp;author=JC%20Rothwell&amp;author=M%20Hallett&amp;author=PD%20Thompson&amp;author=M%20Manfredi&amp;author=CD%20Marsden&amp;publication_year=1998&amp;journal=Brain&amp;volume=121&amp;pages=1195-212" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1093/brain/121.7.1195" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1093%2Fbrain%2F121.7.1195" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1093%2Fbrain%2F121.7.1195"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/9679773" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20pathophysiology%20of%20primary%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b8" class="js-splitview-ref-item" data-legacy-id="b8"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b8" href="javascript:;" aria-label="jumplink-b8" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b8" class="ref-content " data-id="b8"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Blood</div> <div class="given-names">AJ</div></div>,  <div class="name"><div class="surname">Flaherty</div> <div class="given-names">AW</div></div>,  <div class="name"><div class="surname">Choi</div> <div class="given-names">JK</div></div>,  <div class="name"><div class="surname">Hochberg</div> <div class="given-names">FH</div></div>,  <div class="name"><div class="surname">Greve</div> <div class="given-names">DN</div></div>,  <div class="name"><div class="surname">Bonmassar</div> <div class="given-names">G</div></div>, et al. </span><div class="article-title">Basal ganglia activity remains elevated after movement in focal hand dystonia</div>, <div class="source ">Ann Neurol</div>, <div class="year">2004</div>, vol. <div class="volume">55</div> (pg. <div class="fpage">744</div>-<div class="lpage">8</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Basal%20ganglia%20activity%20remains%20elevated%20after%20movement%20in%20focal%20hand%20dystonia&amp;author=AJ%20Blood&amp;author=AW%20Flaherty&amp;author=JK%20Choi&amp;author=FH%20Hochberg&amp;author=DN%20Greve&amp;author=G%20Bonmassar&amp;publication_year=2004&amp;journal=Ann%20Neurol&amp;volume=55&amp;pages=744-8" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1002/(ISSN)1531-8249" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1002%2F(ISSN)1531-8249" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1002%2F(ISSN)1531-8249"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15122718" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Basal%20ganglia%20activity%20remains%20elevated%20after%20movement%20in%20focal%20hand%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b9" class="js-splitview-ref-item" data-legacy-id="b9"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b9" href="javascript:;" aria-label="jumplink-b9" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b9" class="ref-content " data-id="b9"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Braun</div> <div class="given-names">C</div></div>,  <div class="name"><div class="surname">Schweizer</div> <div class="given-names">R</div></div>,  <div class="name"><div class="surname">Heinz</div> <div class="given-names">U</div></div>,  <div class="name"><div class="surname">Wiech</div> <div class="given-names">K</div></div>,  <div class="name"><div class="surname">Birbaumer</div> <div class="given-names">N</div></div>,  <div class="name"><div class="surname">Topka</div> <div class="given-names">H</div></div>. </span><div class="article-title">Task-specific plasticity of somatosensory cortex in patients with writer's cramp</div>, <div class="source ">Neuroimage</div>, <div class="year">2003</div>, vol. <div class="volume">20</div> (pg. <div class="fpage">1329</div>-<div class="lpage">38</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Task-specific%20plasticity%20of%20somatosensory%20cortex%20in%20patients%20with%20writer%27s%20cramp&amp;author=C%20Braun&amp;author=R%20Schweizer&amp;author=U%20Heinz&amp;author=K%20Wiech&amp;author=N%20Birbaumer&amp;author=H%20Topka&amp;publication_year=2003&amp;journal=Neuroimage&amp;volume=20&amp;pages=1329-38" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/S1053-8119(03)00375-6" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2FS1053-8119(03)00375-6" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2FS1053-8119(03)00375-6"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/14568501" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Task-specific%20plasticity%20of%20somatosensory%20cortex%20in%20patients%20with%20writer%27s%20cramp&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b10" class="js-splitview-ref-item" data-legacy-id="b10"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b10" href="javascript:;" aria-label="jumplink-b10" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b10" class="ref-content " data-id="b10"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Butterworth</div> <div class="given-names">S</div></div>,  <div class="name"><div class="surname">Francis</div> <div class="given-names">S</div></div>,  <div class="name"><div class="surname">Kelly</div> <div class="given-names">E</div></div>,  <div class="name"><div class="surname">McGlone</div> <div class="given-names">F</div></div>,  <div class="name"><div class="surname">Bowtell</div> <div class="given-names">R</div></div>,  <div class="name"><div class="surname">Sawle</div> <div class="given-names">GV</div></div>. </span><div class="article-title">Abnormal cortical sensory activation in dystonia: an fMRI study</div>, <div class="source ">Mov Disord</div>, <div class="year">2003</div>, vol. <div class="volume">18</div> (pg. <div class="fpage">673</div>-<div class="lpage">82</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Abnormal%20cortical%20sensory%20activation%20in%20dystonia%3A%20an%20fMRI%20study&amp;author=S%20Butterworth&amp;author=S%20Francis&amp;author=E%20Kelly&amp;author=F%20McGlone&amp;author=R%20Bowtell&amp;author=GV%20Sawle&amp;publication_year=2003&amp;journal=Mov%20Disord&amp;volume=18&amp;pages=673-82" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1002/mds.v18:6" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1002%2Fmds.v18:6" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1002%2Fmds.v18:6"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12784271" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Abnormal%20cortical%20sensory%20activation%20in%20dystonia%3A%20an%20fMRI%20study&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b11" class="js-splitview-ref-item" data-legacy-id="b11"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b11" href="javascript:;" aria-label="jumplink-b11" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b11" class="ref-content " data-id="b11"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Byl</div> <div class="given-names">NN</div></div>,  <div class="name"><div class="surname">Merzenich</div> <div class="given-names">MM</div></div>,  <div class="name"><div class="surname">Jenkins</div> <div class="given-names">WM</div></div>. </span><div class="article-title">A primate genesis model of focal dystonia and repetitive strain injury: I. Learning-induced dedifferentiation of the representation of the hand in the primary somatosensory cortex in adult monkeys</div>, <div class="source ">Neurology</div>, <div class="year">1996</div>, vol. <div class="volume">47</div> (pg. <div class="fpage">508</div>-<div class="lpage">20</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=A%20primate%20genesis%20model%20of%20focal%20dystonia%20and%20repetitive%20strain%20injury%3A%20I.%20Learning-induced%20dedifferentiation%20of%20the%20representation%20of%20the%20hand%20in%20the%20primary%20somatosensory%20cortex%20in%20adult%20monkeys&amp;author=NN%20Byl&amp;author=MM%20Merzenich&amp;author=WM%20Jenkins&amp;publication_year=1996&amp;journal=Neurology&amp;volume=47&amp;pages=508-20" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1212/WNL.47.2.508" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1212%2FWNL.47.2.508" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1212%2FWNL.47.2.508"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/8757029" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:A%20primate%20genesis%20model%20of%20focal%20dystonia%20and%20repetitive%20strain%20injury%3A%20I.%20Learning-induced%20dedifferentiation%20of%20the%20representation%20of%20the%20hand%20in%20the%20primary%20somatosensory%20cortex%20in%20adult%20monkeys&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b12" class="js-splitview-ref-item" data-legacy-id="b12"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b12" href="javascript:;" aria-label="jumplink-b12" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b12" class="ref-content " data-id="b12"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Byl</div> <div class="given-names">NN</div></div>,  <div class="name"><div class="surname">Merzenich</div> <div class="given-names">MM</div></div>,  <div class="name"><div class="surname">Cheung</div> <div class="given-names">S</div></div>,  <div class="name"><div class="surname">Bedenbaugh</div> <div class="given-names">P</div></div>,  <div class="name"><div class="surname">Nagarajan</div> <div class="given-names">SS</div></div>,  <div class="name"><div class="surname">Jenkins</div> <div class="given-names">WM</div></div>. </span><div class="article-title">A primate model for studying focal dystonia and repetitive strain injury: effects on the primary somatosensory cortex</div>, <div class="source ">Phys Ther</div>, <div class="year">1997</div>, vol. <div class="volume">77</div> (pg. <div class="fpage">269</div>-<div class="lpage">84</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=A%20primate%20model%20for%20studying%20focal%20dystonia%20and%20repetitive%20strain%20injury%3A%20effects%20on%20the%20primary%20somatosensory%20cortex&amp;author=NN%20Byl&amp;author=MM%20Merzenich&amp;author=S%20Cheung&amp;author=P%20Bedenbaugh&amp;author=SS%20Nagarajan&amp;author=WM%20Jenkins&amp;publication_year=1997&amp;journal=Phys%20Ther&amp;volume=77&amp;pages=269-84" target="_blank">Google Scholar</a></span></p><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/9062569" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=article&amp;atitle=A+primate+model+for+studying+focal+dystonia+and+repetitive+strain+injury%3a+effects+on+the+primary+somatosensory+cortex&amp;aulast=Byl&amp;title=Phys+Ther&amp;date=1997&amp;spage=269&amp;epage=84&amp;volume=77" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:A%20primate%20model%20for%20studying%20focal%20dystonia%20and%20repetitive%20strain%20injury%3A%20effects%20on%20the%20primary%20somatosensory%20cortex&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b13" class="js-splitview-ref-item" data-legacy-id="b13"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b13" href="javascript:;" aria-label="jumplink-b13" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b13" class="ref-content " data-id="b13"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Ceballos-Baumann</div> <div class="given-names">AO</div></div>,  <div class="name"><div class="surname">Sheean</div> <div class="given-names">G</div></div>,  <div class="name"><div class="surname">Passingham</div> <div class="given-names">RE</div></div>,  <div class="name"><div class="surname">Marsden</div> <div class="given-names">CD</div></div>,  <div class="name"><div class="surname">Brooks</div> <div class="given-names">DJ</div></div>. </span><div class="article-title">Botulinum toxin does not reverse the cortical dysfunction associated with writer's cramp. A PET study</div>, <div class="source ">Brain</div>, <div class="year">1997</div>, vol. <div class="volume">120</div> (pg. <div class="fpage">571</div>-<div class="lpage">82</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Botulinum%20toxin%20does%20not%20reverse%20the%20cortical%20dysfunction%20associated%20with%20writer%27s%20cramp.%20A%20PET%20study&amp;author=AO%20Ceballos-Baumann&amp;author=G%20Sheean&amp;author=RE%20Passingham&amp;author=CD%20Marsden&amp;author=DJ%20Brooks&amp;publication_year=1997&amp;journal=Brain&amp;volume=120&amp;pages=571-82" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1093/brain/120.4.571" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1093%2Fbrain%2F120.4.571" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1093%2Fbrain%2F120.4.571"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/9153120" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Botulinum%20toxin%20does%20not%20reverse%20the%20cortical%20dysfunction%20associated%20with%20writer%27s%20cramp.%20A%20PET%20study&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b14" class="js-splitview-ref-item" data-legacy-id="b14"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b14" href="javascript:;" aria-label="jumplink-b14" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b14" class="ref-content " data-id="b14"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Cicirata</div> <div class="given-names">F</div></div>,  <div class="name"><div class="surname">Serapide</div> <div class="given-names">MF</div></div>,  <div class="name"><div class="surname">Parenti</div> <div class="given-names">R</div></div>,  <div class="name"><div class="surname">Panto</div> <div class="given-names">MR</div></div>,  <div class="name"><div class="surname">Zappala</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Nicotra</div> <div class="given-names">A</div></div>, et al. </span><div class="article-title">The basilar pontine nuclei and the nucleus reticularis tegmenti pontis subserve distinct cerebrocerebellar pathways</div>, <div class="source ">Prog Brain Res</div>, <div class="year">2005</div>, vol. <div class="volume">148</div> (pg. <div class="fpage">259</div>-<div class="lpage">82</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20basilar%20pontine%20nuclei%20and%20the%20nucleus%20reticularis%20tegmenti%20pontis%20subserve%20distinct%20cerebrocerebellar%20pathways&amp;author=F%20Cicirata&amp;author=MF%20Serapide&amp;author=R%20Parenti&amp;author=MR%20Panto&amp;author=A%20Zappala&amp;author=A%20Nicotra&amp;publication_year=2005&amp;journal=Prog%20Brain%20Res&amp;volume=148&amp;pages=259-82" target="_blank">Google Scholar</a></span></p><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15661196" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=article&amp;atitle=The+basilar+pontine+nuclei+and+the+nucleus+reticularis+tegmenti+pontis+subserve+distinct+cerebrocerebellar+pathways&amp;aulast=Cicirata&amp;title=Prog+Brain+Res&amp;date=2005&amp;spage=259&amp;epage=82&amp;volume=148" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20basilar%20pontine%20nuclei%20and%20the%20nucleus%20reticularis%20tegmenti%20pontis%20subserve%20distinct%20cerebrocerebellar%20pathways&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b15" class="js-splitview-ref-item" data-legacy-id="b15"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b15" href="javascript:;" aria-label="jumplink-b15" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b15" class="ref-content " data-id="b15"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Delmaire</div> <div class="given-names">C</div></div>,  <div class="name"><div class="surname">Krainik</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Tezenas du Montcel</div> <div class="given-names">S</div></div>,  <div class="name"><div class="surname">Gerardin</div> <div class="given-names">E</div></div>,  <div class="name"><div class="surname">Meunier</div> <div class="given-names">S</div></div>,  <div class="name"><div class="surname">Mangin</div> <div class="given-names">JF</div></div>, et al. </span><div class="article-title">Disorganized somatotopy in the putamen of patients with focal hand dystonia</div>, <div class="source ">Neurology</div>, <div class="year">2005</div>, vol. <div class="volume">64</div> (pg. <div class="fpage">1391</div>-<div class="lpage">6</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Disorganized%20somatotopy%20in%20the%20putamen%20of%20patients%20with%20focal%20hand%20dystonia&amp;author=C%20Delmaire&amp;author=A%20Krainik&amp;author=S%20Tezenas%20du%20Montcel&amp;author=E%20Gerardin&amp;author=S%20Meunier&amp;author=JF%20Mangin&amp;publication_year=2005&amp;journal=Neurology&amp;volume=64&amp;pages=1391-6" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1212/01.WNL.0000158424.01299.76" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1212%2F01.WNL.0000158424.01299.76" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1212%2F01.WNL.0000158424.01299.76"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15851729" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Disorganized%20somatotopy%20in%20the%20putamen%20of%20patients%20with%20focal%20hand%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b16" class="js-splitview-ref-item" data-legacy-id="b16"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b16" href="javascript:;" aria-label="jumplink-b16" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b16" class="ref-content " data-id="b16"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Eidelberg</div> <div class="given-names">D</div></div>,  <div class="name"><div class="surname">Moeller</div> <div class="given-names">JR</div></div>,  <div class="name"><div class="surname">Ishikawa</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Dhawan</div> <div class="given-names">V</div></div>,  <div class="name"><div class="surname">Spetsieris</div> <div class="given-names">P</div></div>,  <div class="name"><div class="surname">Przedborski</div> <div class="given-names">S</div></div>, et al. </span><div class="article-title">The metabolic topography of idiopathic torsion dystonia</div>, <div class="source ">Brain</div>, <div class="year">1995</div>, vol. <div class="volume">118</div> (pg. <div class="fpage">1473</div>-<div class="lpage">84</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20metabolic%20topography%20of%20idiopathic%20torsion%20dystonia&amp;author=D%20Eidelberg&amp;author=JR%20Moeller&amp;author=T%20Ishikawa&amp;author=V%20Dhawan&amp;author=P%20Spetsieris&amp;author=S%20Przedborski&amp;publication_year=1995&amp;journal=Brain&amp;volume=118&amp;pages=1473-84" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1093/brain/118.6.1473" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1093%2Fbrain%2F118.6.1473" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1093%2Fbrain%2F118.6.1473"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/8595478" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20metabolic%20topography%20of%20idiopathic%20torsion%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b17" class="js-splitview-ref-item" data-legacy-id="b17"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b17" href="javascript:;" aria-label="jumplink-b17" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b17" class="ref-content " data-id="b17"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Eidelberg</div> <div class="given-names">D</div></div>,  <div class="name"><div class="surname">Moeller</div> <div class="given-names">JR</div></div>,  <div class="name"><div class="surname">Antonini</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Kazumata</div> <div class="given-names">K</div></div>,  <div class="name"><div class="surname">Nakamura</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Dhawan</div> <div class="given-names">V</div></div>, et al. </span><div class="article-title">Functional brain networks in DYT1 dystonia</div>, <div class="source ">Ann Neurol</div>, <div class="year">1998</div>, vol. <div class="volume">44</div> (pg. <div class="fpage">303</div>-<div class="lpage">12</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Functional%20brain%20networks%20in%20DYT1%20dystonia&amp;author=D%20Eidelberg&amp;author=JR%20Moeller&amp;author=A%20Antonini&amp;author=K%20Kazumata&amp;author=T%20Nakamura&amp;author=V%20Dhawan&amp;publication_year=1998&amp;journal=Ann%20Neurol&amp;volume=44&amp;pages=303-12" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1002/(ISSN)1531-8249" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1002%2F(ISSN)1531-8249" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1002%2F(ISSN)1531-8249"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/9749595" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Functional%20brain%20networks%20in%20DYT1%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b18" class="js-splitview-ref-item" data-legacy-id="b18"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b18" href="javascript:;" aria-label="jumplink-b18" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b18" class="ref-content " data-id="b18"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Elbert</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Candia</div> <div class="given-names">V</div></div>,  <div class="name"><div class="surname">Altenmuller</div> <div class="given-names">E</div></div>,  <div class="name"><div class="surname">Rau</div> <div class="given-names">H</div></div>,  <div class="name"><div class="surname">Sterr</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Rockstroh</div> <div class="given-names">B</div></div>, et al. </span><div class="article-title">Alteration of digital representations in somatosensory cortex in focal hand dystonia</div>, <div class="source ">Neuroreport</div>, <div class="year">1998</div>, vol. <div class="volume">9</div> (pg. <div class="fpage">3571</div>-<div class="lpage">5</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Alteration%20of%20digital%20representations%20in%20somatosensory%20cortex%20in%20focal%20hand%20dystonia&amp;author=T%20Elbert&amp;author=V%20Candia&amp;author=E%20Altenmuller&amp;author=H%20Rau&amp;author=A%20Sterr&amp;author=B%20Rockstroh&amp;publication_year=1998&amp;journal=Neuroreport&amp;volume=9&amp;pages=3571-5" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1097/00001756-199811160-00006" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1097%2F00001756-199811160-00006" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1097%2F00001756-199811160-00006"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/9858362" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Alteration%20of%20digital%20representations%20in%20somatosensory%20cortex%20in%20focal%20hand%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b19" class="js-splitview-ref-item" data-legacy-id="b19"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b19" href="javascript:;" aria-label="jumplink-b19" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b19" class="ref-content " data-id="b19"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Fahn</div> <div class="given-names">S</div></div>. </span><span class="person-group"><div class="name"><div class="surname">Munsat</div> <div class="given-names">T</div></div>. </span><div class="article-title">Assessment of the primary dystonias</div>, <div class="source ">The quantification of neurologic deficit</div>, <div class="year">1989</div><div class="publisher-loc">Boston</div><div class="publisher-name">Butterworths</div>(pg. <div class="fpage">241</div>-<div class="lpage">70</div>)<!--citationLinks: case 2--><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20quantification%20of%20neurologic%20deficit&amp;author=S%20Fahn&amp;author=T%20Munsat&amp;publication_year=1989&amp;book=The%20quantification%20of%20neurologic%20deficit" target="_blank">Google Scholar</a></span></p><p class="citation-links-compatibility"><span class="google-preview-ref-link js-google-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.google.com/search?q=The%20quantification%20of%20neurologic%20deficit&amp;btnG=Search+Books&amp;tbm=bks&amp;tbo=1" target="_blank">Google Preview</a></span></p><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=book&amp;title=The+quantification+of+neurologic+deficit&amp;aulast=Fahn&amp;date=1989&amp;spage=241&amp;epage=70" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20quantification%20of%20neurologic%20deficit&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p><div class="copac-reference-ref-link js-copac-preview-ref-link" style="display:none" data-pubtype="book"><span class="inst-copac"><a class="openInAnotherWindow" target="_blank" href="http://copac.ac.uk/search?ti=The%20quantification%20of%20neurologic%20deficit">COPAC</a></span></div> </div></div></div></div></div><div content-id="b20" class="js-splitview-ref-item" data-legacy-id="b20"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b20" href="javascript:;" aria-label="jumplink-b20" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b20" class="ref-content " data-id="b20"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Fiorio</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Tinazzi</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Bertolasi</div> <div class="given-names">L</div></div>,  <div class="name"><div class="surname">Aglioti</div> <div class="given-names">SM</div></div>. </span><div class="article-title">Temporal processing of visuotactile and tactile stimuli in writer's cramp</div>, <div class="source ">Ann Neurol</div>, <div class="year">2003</div>, vol. <div class="volume">53</div> (pg. <div class="fpage">630</div>-<div class="lpage">5</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Temporal%20processing%20of%20visuotactile%20and%20tactile%20stimuli%20in%20writer%27s%20cramp&amp;author=M%20Fiorio&amp;author=M%20Tinazzi&amp;author=L%20Bertolasi&amp;author=SM%20Aglioti&amp;publication_year=2003&amp;journal=Ann%20Neurol&amp;volume=53&amp;pages=630-5" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1002/(ISSN)1531-8249" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1002%2F(ISSN)1531-8249" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1002%2F(ISSN)1531-8249"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12730997" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Temporal%20processing%20of%20visuotactile%20and%20tactile%20stimuli%20in%20writer%27s%20cramp&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b21" class="js-splitview-ref-item" data-legacy-id="b21"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b21" href="javascript:;" aria-label="jumplink-b21" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b21" class="ref-content " data-id="b21"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Friston</div> <div class="given-names">KJ</div></div>,  <div class="name"><div class="surname">Holmes</div> <div class="given-names">AP</div></div>,  <div class="name"><div class="surname">Poline</div> <div class="given-names">JB</div></div>,  <div class="name"><div class="surname">Grasby</div> <div class="given-names">PJ</div></div>,  <div class="name"><div class="surname">Williams</div> <div class="given-names">SC</div></div>,  <div class="name"><div class="surname">Frackowiak</div> <div class="given-names">RS</div></div>, et al. </span><div class="article-title">Analysis of fMRI time-series revisited</div>, <div class="source ">Neuroimage</div>, <div class="year">1995</div>, vol. <div class="volume">2</div> (pg. <div class="fpage">45</div>-<div class="lpage">53</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Analysis%20of%20fMRI%20time-series%20revisited&amp;author=KJ%20Friston&amp;author=AP%20Holmes&amp;author=JB%20Poline&amp;author=PJ%20Grasby&amp;author=SC%20Williams&amp;author=RS%20Frackowiak&amp;publication_year=1995&amp;journal=Neuroimage&amp;volume=2&amp;pages=45-53" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1006/nimg.1995.1007" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1006%2Fnimg.1995.1007" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1006%2Fnimg.1995.1007"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/9343589" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Analysis%20of%20fMRI%20time-series%20revisited&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b22" class="js-splitview-ref-item" data-legacy-id="b22"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b22" href="javascript:;" aria-label="jumplink-b22" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b22" class="ref-content " data-id="b22"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Galardi</div> <div class="given-names">G</div></div>,  <div class="name"><div class="surname">Perani</div> <div class="given-names">D</div></div>,  <div class="name"><div class="surname">Grassi</div> <div class="given-names">F</div></div>,  <div class="name"><div class="surname">Bressi</div> <div class="given-names">S</div></div>,  <div class="name"><div class="surname">Amadio</div> <div class="given-names">S</div></div>,  <div class="name"><div class="surname">Antoni</div> <div class="given-names">M</div></div>, et al. </span><div class="article-title">Basal ganglia and thalamo-cortical hypermetabolism in patients with spasmodic torticollis</div>, <div class="source ">Acta Neurol Scand</div>, <div class="year">1996</div>, vol. <div class="volume">94</div> (pg. <div class="fpage">172</div>-<div class="lpage">6</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Basal%20ganglia%20and%20thalamo-cortical%20hypermetabolism%20in%20patients%20with%20spasmodic%20torticollis&amp;author=G%20Galardi&amp;author=D%20Perani&amp;author=F%20Grassi&amp;author=S%20Bressi&amp;author=S%20Amadio&amp;author=M%20Antoni&amp;publication_year=1996&amp;journal=Acta%20Neurol%20Scand&amp;volume=94&amp;pages=172-6" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1111/ane.1996.94.issue-3" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1111%2Fane.1996.94.issue-3" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1111%2Fane.1996.94.issue-3"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/8899050" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Basal%20ganglia%20and%20thalamo-cortical%20hypermetabolism%20in%20patients%20with%20spasmodic%20torticollis&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b23" class="js-splitview-ref-item" data-legacy-id="b23"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b23" href="javascript:;" aria-label="jumplink-b23" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b23" class="ref-content " data-id="b23"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Grunewald</div> <div class="given-names">RA</div></div>,  <div class="name"><div class="surname">Yoneda</div> <div class="given-names">Y</div></div>,  <div class="name"><div class="surname">Shipman</div> <div class="given-names">JM</div></div>,  <div class="name"><div class="surname">Sagar</div> <div class="given-names">HJ</div></div>. </span><div class="article-title">Idiopathic focal dystonia: a disorder of muscle spindle afferent processing?</div>, <div class="source ">Brain</div>, <div class="year">1997</div>, vol. <div class="volume">120</div> (pg. <div class="fpage">2179</div>-<div class="lpage">85</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Idiopathic%20focal%20dystonia%3A%20a%20disorder%20of%20muscle%20spindle%20afferent%20processing%3F&amp;author=RA%20Grunewald&amp;author=Y%20Yoneda&amp;author=JM%20Shipman&amp;author=HJ%20Sagar&amp;publication_year=1997&amp;journal=Brain&amp;volume=120&amp;pages=2179-85" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1093/brain/120.12.2179" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1093%2Fbrain%2F120.12.2179" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1093%2Fbrain%2F120.12.2179"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/9448573" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Idiopathic%20focal%20dystonia%3A%20a%20disorder%20of%20muscle%20spindle%20afferent%20processing%3F&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b24" class="js-splitview-ref-item" data-legacy-id="b24"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b24" href="javascript:;" aria-label="jumplink-b24" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b24" class="ref-content " data-id="b24"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Hallett</div> <div class="given-names">M</div></div>. </span><div class="article-title">The neurophysiology of dystonia</div>, <div class="source ">Arch Neurol</div>, <div class="year">1998</div>, vol. <div class="volume">55</div> (pg. <div class="fpage">601</div>-<div class="lpage">3</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20neurophysiology%20of%20dystonia&amp;author=M%20Hallett&amp;publication_year=1998&amp;journal=Arch%20Neurol&amp;volume=55&amp;pages=601-3" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1001/archneur.55.5.601" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1001%2Farchneur.55.5.601" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1001%2Farchneur.55.5.601"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/9605716" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20neurophysiology%20of%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b25" class="js-splitview-ref-item" data-legacy-id="b25"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b25" href="javascript:;" aria-label="jumplink-b25" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b25" class="ref-content " data-id="b25"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Hutchinson</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Nakamura</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Moeller</div> <div class="given-names">JR</div></div>,  <div class="name"><div class="surname">Antonini</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Belakhlef</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Dhawan</div> <div class="given-names">V</div></div>, et al. </span><div class="article-title">The metabolic topography of essential blepharospasm: a focal dystonia with general implications</div>, <div class="source ">Neurology</div>, <div class="year">2000</div>, vol. <div class="volume">55</div> (pg. <div class="fpage">673</div>-<div class="lpage">7</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20metabolic%20topography%20of%20essential%20blepharospasm%3A%20a%20focal%20dystonia%20with%20general%20implications&amp;author=M%20Hutchinson&amp;author=T%20Nakamura&amp;author=JR%20Moeller&amp;author=A%20Antonini&amp;author=A%20Belakhlef&amp;author=V%20Dhawan&amp;publication_year=2000&amp;journal=Neurology&amp;volume=55&amp;pages=673-7" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1212/WNL.55.5.673" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1212%2FWNL.55.5.673" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1212%2FWNL.55.5.673"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/10980732" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20metabolic%20topography%20of%20essential%20blepharospasm%3A%20a%20focal%20dystonia%20with%20general%20implications&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b26" class="js-splitview-ref-item" data-legacy-id="b26"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b26" href="javascript:;" aria-label="jumplink-b26" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b26" class="ref-content " data-id="b26"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Ibanez</div> <div class="given-names">V</div></div>,  <div class="name"><div class="surname">Sadato</div> <div class="given-names">N</div></div>,  <div class="name"><div class="surname">Karp</div> <div class="given-names">B</div></div>,  <div class="name"><div class="surname">Deiber</div> <div class="given-names">MP</div></div>,  <div class="name"><div class="surname">Hallett</div> <div class="given-names">M</div></div>. </span><div class="article-title">Deficient activation of the motor cortical network in patients with writer's cramp</div>, <div class="source ">Neurology</div>, <div class="year">1999</div>, vol. <div class="volume">53</div> (pg. <div class="fpage">96</div>-<div class="lpage">105</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Deficient%20activation%20of%20the%20motor%20cortical%20network%20in%20patients%20with%20writer%27s%20cramp&amp;author=V%20Ibanez&amp;author=N%20Sadato&amp;author=B%20Karp&amp;author=MP%20Deiber&amp;author=M%20Hallett&amp;publication_year=1999&amp;journal=Neurology&amp;volume=53&amp;pages=96-105" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1212/WNL.53.1.96" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1212%2FWNL.53.1.96" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1212%2FWNL.53.1.96"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/10408543" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Deficient%20activation%20of%20the%20motor%20cortical%20network%20in%20patients%20with%20writer%27s%20cramp&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b27" class="js-splitview-ref-item" data-legacy-id="b27"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b27" href="javascript:;" aria-label="jumplink-b27" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b27" class="ref-content " data-id="b27"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Kaji</div> <div class="given-names">R</div></div>. </span><div class="article-title">Basal ganglia as a sensory gating devise for motor control</div>, <div class="source ">J Med Invest</div>, <div class="year">2001</div>, vol. <div class="volume">48</div> (pg. <div class="fpage">142</div>-<div class="lpage">6</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Basal%20ganglia%20as%20a%20sensory%20gating%20devise%20for%20motor%20control&amp;author=R%20Kaji&amp;publication_year=2001&amp;journal=J%20Med%20Invest&amp;volume=48&amp;pages=142-6" target="_blank">Google Scholar</a></span></p><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/11694953" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=article&amp;atitle=Basal+ganglia+as+a+sensory+gating+devise+for+motor+control&amp;aulast=Kaji&amp;title=J+Med+Invest&amp;date=2001&amp;spage=142&amp;epage=6&amp;volume=48" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Basal%20ganglia%20as%20a%20sensory%20gating%20devise%20for%20motor%20control&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b28" class="js-splitview-ref-item" data-legacy-id="b28"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b28" href="javascript:;" aria-label="jumplink-b28" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b28" class="ref-content " data-id="b28"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Kobayashi</div> <div class="given-names">Y</div></div>,  <div class="name"><div class="surname">Inoue</div> <div class="given-names">Y</div></div>,  <div class="name"><div class="surname">Yamamoto</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Isa</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Aizawa</div> <div class="given-names">H</div></div>. </span><div class="article-title">Contribution of pedunculopontine tegmental nucleus neurons to performance of visually guided saccade tasks in monkeys</div>, <div class="source ">J Neurophysiol</div>, <div class="year">2002</div>, vol. <div class="volume">88</div> (pg. <div class="fpage">715</div>-<div class="lpage">31</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Contribution%20of%20pedunculopontine%20tegmental%20nucleus%20neurons%20to%20performance%20of%20visually%20guided%20saccade%20tasks%20in%20monkeys&amp;author=Y%20Kobayashi&amp;author=Y%20Inoue&amp;author=M%20Yamamoto&amp;author=T%20Isa&amp;author=H%20Aizawa&amp;publication_year=2002&amp;journal=J%20Neurophysiol&amp;volume=88&amp;pages=715-31" target="_blank">Google Scholar</a></span></p><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12163524" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=article&amp;atitle=Contribution+of+pedunculopontine+tegmental+nucleus+neurons+to+performance+of+visually+guided+saccade+tasks+in+monkeys&amp;aulast=Kobayashi&amp;title=J+Neurophysiol&amp;date=2002&amp;spage=715&amp;epage=31&amp;volume=88" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Contribution%20of%20pedunculopontine%20tegmental%20nucleus%20neurons%20to%20performance%20of%20visually%20guided%20saccade%20tasks%20in%20monkeys&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b29" class="js-splitview-ref-item" data-legacy-id="b29"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b29" href="javascript:;" aria-label="jumplink-b29" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b29" class="ref-content " data-id="b29"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Kobayashi</div> <div class="given-names">Y</div></div>,  <div class="name"><div class="surname">Inoue</div> <div class="given-names">Y</div></div>,  <div class="name"><div class="surname">Isa</div> <div class="given-names">T</div></div>. </span><div class="article-title">Pedunculo-pontine control of visually guided saccades</div>, <div class="source ">Prog Brain Res</div>, <div class="year">2004</div>, vol. <div class="volume">143</div> (pg. <div class="fpage">439</div>-<div class="lpage">45</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Pedunculo-pontine%20control%20of%20visually%20guided%20saccades&amp;author=Y%20Kobayashi&amp;author=Y%20Inoue&amp;author=T%20Isa&amp;publication_year=2004&amp;journal=Prog%20Brain%20Res&amp;volume=143&amp;pages=439-45" target="_blank">Google Scholar</a></span></p><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/14653186" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=article&amp;atitle=Pedunculo-pontine+control+of+visually+guided+saccades&amp;aulast=Kobayashi&amp;title=Prog+Brain+Res&amp;date=2004&amp;spage=439&amp;epage=45&amp;volume=143" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Pedunculo-pontine%20control%20of%20visually%20guided%20saccades&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b30" class="js-splitview-ref-item" data-legacy-id="b30"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b30" href="javascript:;" aria-label="jumplink-b30" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b30" class="ref-content " data-id="b30"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Lenz</div> <div class="given-names">FA</div></div>,  <div class="name"><div class="surname">Byl</div> <div class="given-names">NN</div></div>. </span><div class="article-title">Reorganization in the cutaneous core of the human thalamic principal somatic sensory nucleus (ventral caudal) in patients with dystonia</div>, <div class="source ">J Neurophysiol</div>, <div class="year">1999</div>, vol. <div class="volume">82</div> (pg. <div class="fpage">3204</div>-<div class="lpage">12</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Reorganization%20in%20the%20cutaneous%20core%20of%20the%20human%20thalamic%20principal%20somatic%20sensory%20nucleus%20%28ventral%20caudal%29%20in%20patients%20with%20dystonia&amp;author=FA%20Lenz&amp;author=NN%20Byl&amp;publication_year=1999&amp;journal=J%20Neurophysiol&amp;volume=82&amp;pages=3204-12" target="_blank">Google Scholar</a></span></p><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/10601454" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=article&amp;atitle=Reorganization+in+the+cutaneous+core+of+the+human+thalamic+principal+somatic+sensory+nucleus+(ventral+caudal)+in+patients+with+dystonia&amp;aulast=Lenz&amp;title=J+Neurophysiol&amp;date=1999&amp;spage=3204&amp;epage=12&amp;volume=82" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Reorganization%20in%20the%20cutaneous%20core%20of%20the%20human%20thalamic%20principal%20somatic%20sensory%20nucleus%20%28ventral%20caudal%29%20in%20patients%20with%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b31" class="js-splitview-ref-item" data-legacy-id="b31"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b31" href="javascript:;" aria-label="jumplink-b31" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b31" class="ref-content " data-id="b31"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Lenz</div> <div class="given-names">FA</div></div>,  <div class="name"><div class="surname">Jaeger</div> <div class="given-names">CJ</div></div>,  <div class="name"><div class="surname">Seike</div> <div class="given-names">MS</div></div>,  <div class="name"><div class="surname">Lin</div> <div class="given-names">YC</div></div>,  <div class="name"><div class="surname">Reich</div> <div class="given-names">SG</div></div>,  <div class="name"><div class="surname">DeLong</div> <div class="given-names">MR</div></div>, et al. </span><div class="article-title">Thalamic single neuron activity in patients with dystonia: dystonia-related activity and somatic sensory reorganization</div>, <div class="source ">J Neurophysiol</div>, <div class="year">1999</div>, vol. <div class="volume">82</div> (pg. <div class="fpage">2372</div>-<div class="lpage">92</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Thalamic%20single%20neuron%20activity%20in%20patients%20with%20dystonia%3A%20dystonia-related%20activity%20and%20somatic%20sensory%20reorganization&amp;author=FA%20Lenz&amp;author=CJ%20Jaeger&amp;author=MS%20Seike&amp;author=YC%20Lin&amp;author=SG%20Reich&amp;author=MR%20DeLong&amp;publication_year=1999&amp;journal=J%20Neurophysiol&amp;volume=82&amp;pages=2372-92" target="_blank">Google Scholar</a></span></p><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/10561412" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=article&amp;atitle=Thalamic+single+neuron+activity+in+patients+with+dystonia%3a+dystonia-related+activity+and+somatic+sensory+reorganization&amp;aulast=Lenz&amp;title=J+Neurophysiol&amp;date=1999&amp;spage=2372&amp;epage=92&amp;volume=82" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Thalamic%20single%20neuron%20activity%20in%20patients%20with%20dystonia%3A%20dystonia-related%20activity%20and%20somatic%20sensory%20reorganization&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b32" class="js-splitview-ref-item" data-legacy-id="b32"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b32" href="javascript:;" aria-label="jumplink-b32" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b32" class="ref-content " data-id="b32"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Lerner</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Shill</div> <div class="given-names">H</div></div>,  <div class="name"><div class="surname">Hanakawa</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Bushara</div> <div class="given-names">K</div></div>,  <div class="name"><div class="surname">Goldfine</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Hallett</div> <div class="given-names">M</div></div>. </span><div class="article-title">Regional cerebral blood flow correlates of the severity of writer's cramp symptoms</div>, <div class="source ">Neuroimage</div>, <div class="year">2004</div>, vol. <div class="volume">21</div> (pg. <div class="fpage">904</div>-<div class="lpage">13</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Regional%20cerebral%20blood%20flow%20correlates%20of%20the%20severity%20of%20writer%27s%20cramp%20symptoms&amp;author=A%20Lerner&amp;author=H%20Shill&amp;author=T%20Hanakawa&amp;author=K%20Bushara&amp;author=A%20Goldfine&amp;author=M%20Hallett&amp;publication_year=2004&amp;journal=Neuroimage&amp;volume=21&amp;pages=904-13" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/j.neuroimage.2003.10.019" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2Fj.neuroimage.2003.10.019" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2Fj.neuroimage.2003.10.019"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15006657" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Regional%20cerebral%20blood%20flow%20correlates%20of%20the%20severity%20of%20writer%27s%20cramp%20symptoms&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b33" class="js-splitview-ref-item" data-legacy-id="b33"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b33" href="javascript:;" aria-label="jumplink-b33" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b33" class="ref-content " data-id="b33"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Marsden</div> <div class="given-names">CD</div></div>,  <div class="name"><div class="surname">Obeso</div> <div class="given-names">JA</div></div>,  <div class="name"><div class="surname">Zarranz</div> <div class="given-names">JJ</div></div>,  <div class="name"><div class="surname">Lang</div> <div class="given-names">AE</div></div>. </span><div class="article-title">The anatomical basis of symptomatic hemidystonia</div>, <div class="source ">Brain</div>, <div class="year">1985</div>, vol. <div class="volume">108</div> (pg. <div class="fpage">463</div>-<div class="lpage">83</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20anatomical%20basis%20of%20symptomatic%20hemidystonia&amp;author=CD%20Marsden&amp;author=JA%20Obeso&amp;author=JJ%20Zarranz&amp;author=AE%20Lang&amp;publication_year=1985&amp;journal=Brain&amp;volume=108&amp;pages=463-83" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1093/brain/108.2.463" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1093%2Fbrain%2F108.2.463" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1093%2Fbrain%2F108.2.463"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/4005532" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20anatomical%20basis%20of%20symptomatic%20hemidystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b34" class="js-splitview-ref-item" data-legacy-id="b34"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b34" href="javascript:;" aria-label="jumplink-b34" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b34" class="ref-content " data-id="b34"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Meunier</div> <div class="given-names">S</div></div>,  <div class="name"><div class="surname">Garnero</div> <div class="given-names">L</div></div>,  <div class="name"><div class="surname">Ducorps</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Mazieres</div> <div class="given-names">L</div></div>,  <div class="name"><div class="surname">Lehericy</div> <div class="given-names">S</div></div>,  <div class="name"><div class="surname">du Montcel</div> <div class="given-names">ST</div></div>, et al. </span><div class="article-title">Human brain mapping in dystonia reveals both endophenotypic traits and adaptive reorganization</div>, <div class="source ">Ann Neurol</div>, <div class="year">2001</div>, vol. <div class="volume">50</div> (pg. <div class="fpage">521</div>-<div class="lpage">7</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Human%20brain%20mapping%20in%20dystonia%20reveals%20both%20endophenotypic%20traits%20and%20adaptive%20reorganization&amp;author=S%20Meunier&amp;author=L%20Garnero&amp;author=A%20Ducorps&amp;author=L%20Mazieres&amp;author=S%20Lehericy&amp;author=ST%20du%20Montcel&amp;publication_year=2001&amp;journal=Ann%20Neurol&amp;volume=50&amp;pages=521-7" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1002/ana.1234" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1002%2Fana.1234" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1002%2Fana.1234"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/11601503" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Human%20brain%20mapping%20in%20dystonia%20reveals%20both%20endophenotypic%20traits%20and%20adaptive%20reorganization&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b35" class="js-splitview-ref-item" data-legacy-id="b35"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b35" href="javascript:;" aria-label="jumplink-b35" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b35" class="ref-content " data-id="b35"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Middleton</div> <div class="given-names">FA</div></div>,  <div class="name"><div class="surname">Strick</div> <div class="given-names">PL</div></div>. </span><div class="article-title">Dentate output channels: motor and cognitive components</div>, <div class="source ">Prog Brain Res</div>, <div class="year">1997</div>, vol. <div class="volume">114</div> (pg. <div class="fpage">553</div>-<div class="lpage">66</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Dentate%20output%20channels%3A%20motor%20and%20cognitive%20components&amp;author=FA%20Middleton&amp;author=PL%20Strick&amp;publication_year=1997&amp;journal=Prog%20Brain%20Res&amp;volume=114&amp;pages=553-66" target="_blank">Google Scholar</a></span></p><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/9193166" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=article&amp;atitle=Dentate+output+channels%3a+motor+and+cognitive+components&amp;aulast=Middleton&amp;title=Prog+Brain+Res&amp;date=1997&amp;spage=553&amp;epage=66&amp;volume=114" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Dentate%20output%20channels%3A%20motor%20and%20cognitive%20components&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b36" class="js-splitview-ref-item" data-legacy-id="b36"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b36" href="javascript:;" aria-label="jumplink-b36" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b36" class="ref-content " data-id="b36"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Mink</div> <div class="given-names">JW</div></div>. </span><div class="article-title">The basal ganglia: focused selection and inhibition of competing motor programs</div>, <div class="source ">Prog Neurobiol</div>, <div class="year">1996</div>, vol. <div class="volume">50</div> (pg. <div class="fpage">381</div>-<div class="lpage">425</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20basal%20ganglia%3A%20focused%20selection%20and%20inhibition%20of%20competing%20motor%20programs&amp;author=JW%20Mink&amp;publication_year=1996&amp;journal=Prog%20Neurobiol&amp;volume=50&amp;pages=381-425" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/S0301-0082(96)00042-1" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2FS0301-0082(96)00042-1" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2FS0301-0082(96)00042-1"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/9004351" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20basal%20ganglia%3A%20focused%20selection%20and%20inhibition%20of%20competing%20motor%20programs&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b37" class="js-splitview-ref-item" data-legacy-id="b37"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b37" href="javascript:;" aria-label="jumplink-b37" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b37" class="ref-content " data-id="b37"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Molloy</div> <div class="given-names">FM</div></div>,  <div class="name"><div class="surname">Carr</div> <div class="given-names">TD</div></div>,  <div class="name"><div class="surname">Zeuner</div> <div class="given-names">KE</div></div>,  <div class="name"><div class="surname">Dambrosia</div> <div class="given-names">JM</div></div>,  <div class="name"><div class="surname">Hallett</div> <div class="given-names">M</div></div>. </span><div class="article-title">Abnormalities of spatial discrimination in focal and generalized dystonia</div>, <div class="source ">Brain</div>, <div class="year">2003</div>, vol. <div class="volume">126</div> (pg. <div class="fpage">2175</div>-<div class="lpage">82</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Abnormalities%20of%20spatial%20discrimination%20in%20focal%20and%20generalized%20dystonia&amp;author=FM%20Molloy&amp;author=TD%20Carr&amp;author=KE%20Zeuner&amp;author=JM%20Dambrosia&amp;author=M%20Hallett&amp;publication_year=2003&amp;journal=Brain&amp;volume=126&amp;pages=2175-82" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1093/brain/awg219" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1093%2Fbrain%2Fawg219" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1093%2Fbrain%2Fawg219"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12821512" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Abnormalities%20of%20spatial%20discrimination%20in%20focal%20and%20generalized%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b38" class="js-splitview-ref-item" data-legacy-id="b38"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b38" href="javascript:;" aria-label="jumplink-b38" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b38" class="ref-content " data-id="b38"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Murase</div> <div class="given-names">N</div></div>,  <div class="name"><div class="surname">Kaji</div> <div class="given-names">R</div></div>,  <div class="name"><div class="surname">Shimazu</div> <div class="given-names">H</div></div>,  <div class="name"><div class="surname">Katayama-Hirota</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Ikeda</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Kohara</div> <div class="given-names">N</div></div>, et al. </span><div class="article-title">Abnormal premovement gating of somatosensory input in writer's cramp</div>, <div class="source ">Brain</div>, <div class="year">2000</div>, vol. <div class="volume">123</div> (pg. <div class="fpage">1813</div>-<div class="lpage">29</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Abnormal%20premovement%20gating%20of%20somatosensory%20input%20in%20writer%27s%20cramp&amp;author=N%20Murase&amp;author=R%20Kaji&amp;author=H%20Shimazu&amp;author=M%20Katayama-Hirota&amp;author=A%20Ikeda&amp;author=N%20Kohara&amp;publication_year=2000&amp;journal=Brain&amp;volume=123&amp;pages=1813-29" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1093/brain/123.9.1813" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1093%2Fbrain%2F123.9.1813" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1093%2Fbrain%2F123.9.1813"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/10960045" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Abnormal%20premovement%20gating%20of%20somatosensory%20input%20in%20writer%27s%20cramp&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b39" class="js-splitview-ref-item" data-legacy-id="b39"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b39" href="javascript:;" aria-label="jumplink-b39" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b39" class="ref-content " data-id="b39"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Odergren</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Stone-Elander</div> <div class="given-names">S</div></div>,  <div class="name"><div class="surname">Ingvar</div> <div class="given-names">M</div></div>. </span><div class="article-title">Cerebral and cerebellar activation in correlation to the action-induced dystonia in writer's cramp</div>, <div class="source ">Mov Disord</div>, <div class="year">1998</div>, vol. <div class="volume">13</div> (pg. <div class="fpage">497</div>-<div class="lpage">508</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Cerebral%20and%20cerebellar%20activation%20in%20correlation%20to%20the%20action-induced%20dystonia%20in%20writer%27s%20cramp&amp;author=T%20Odergren&amp;author=S%20Stone-Elander&amp;author=M%20Ingvar&amp;publication_year=1998&amp;journal=Mov%20Disord&amp;volume=13&amp;pages=497-508" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1002/mds.870130321" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1002%2Fmds.870130321" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1002%2Fmds.870130321"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/9613744" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Cerebral%20and%20cerebellar%20activation%20in%20correlation%20to%20the%20action-induced%20dystonia%20in%20writer%27s%20cramp&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b40" class="js-splitview-ref-item" data-legacy-id="b40"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b40" href="javascript:;" aria-label="jumplink-b40" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b40" class="ref-content " data-id="b40"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">O'Dwyer</div> <div class="given-names">JP</div></div>,  <div class="name"><div class="surname">O'Riordan</div> <div class="given-names">S</div></div>,  <div class="name"><div class="surname">Saunders-Pullman</div> <div class="given-names">R</div></div>,  <div class="name"><div class="surname">Bressman</div> <div class="given-names">SB</div></div>,  <div class="name"><div class="surname">Molloy</div> <div class="given-names">F</div></div>,  <div class="name"><div class="surname">Lynch</div> <div class="given-names">T</div></div>, et al. </span><div class="article-title">Sensory abnormalities in unaffected relatives in familial adult-onset dystonia</div>, <div class="source ">Neurology</div>, <div class="year">2005</div>, vol. <div class="volume">65</div> (pg. <div class="fpage">938</div>-<div class="lpage">40</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Sensory%20abnormalities%20in%20unaffected%20relatives%20in%20familial%20adult-onset%20dystonia&amp;author=JP%20O%27Dwyer&amp;author=S%20O%27Riordan&amp;author=R%20Saunders-Pullman&amp;author=SB%20Bressman&amp;author=F%20Molloy&amp;author=T%20Lynch&amp;publication_year=2005&amp;journal=Neurology&amp;volume=65&amp;pages=938-40" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1212/01.wnl.0000176068.23983.a8" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1212%2F01.wnl.0000176068.23983.a8" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1212%2F01.wnl.0000176068.23983.a8"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/16186541" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Sensory%20abnormalities%20in%20unaffected%20relatives%20in%20familial%20adult-onset%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b41" class="js-splitview-ref-item" data-legacy-id="b41"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b41" href="javascript:;" aria-label="jumplink-b41" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b41" class="ref-content " data-id="b41"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Oga</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Honda</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Toma</div> <div class="given-names">K</div></div>,  <div class="name"><div class="surname">Murase</div> <div class="given-names">N</div></div>,  <div class="name"><div class="surname">Okada</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Hanakawa</div> <div class="given-names">T</div></div>, et al. </span><div class="article-title">Abnormal cortical mechanisms of voluntary muscle relaxation in patients with writer's cramp: an fMRI study</div>, <div class="source ">Brain</div>, <div class="year">2002</div>, vol. <div class="volume">125</div> (pg. <div class="fpage">895</div>-<div class="lpage">903</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Abnormal%20cortical%20mechanisms%20of%20voluntary%20muscle%20relaxation%20in%20patients%20with%20writer%27s%20cramp%3A%20an%20fMRI%20study&amp;author=T%20Oga&amp;author=M%20Honda&amp;author=K%20Toma&amp;author=N%20Murase&amp;author=T%20Okada&amp;author=T%20Hanakawa&amp;publication_year=2002&amp;journal=Brain&amp;volume=125&amp;pages=895-903" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1093/brain/awf083" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1093%2Fbrain%2Fawf083" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1093%2Fbrain%2Fawf083"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/11912121" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Abnormal%20cortical%20mechanisms%20of%20voluntary%20muscle%20relaxation%20in%20patients%20with%20writer%27s%20cramp%3A%20an%20fMRI%20study&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b42" class="js-splitview-ref-item" data-legacy-id="b42"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b42" href="javascript:;" aria-label="jumplink-b42" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b42" class="ref-content " data-id="b42"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Oldfield</div> <div class="given-names">RC</div></div>. </span><div class="article-title">The assessment and analysis of handedness: the Edinburgh inventory</div>, <div class="source ">Neuropsychologia</div>, <div class="year">1971</div>, vol. <div class="volume">9</div> (pg. <div class="fpage">97</div>-<div class="lpage">113</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20assessment%20and%20analysis%20of%20handedness%3A%20the%20Edinburgh%20inventory&amp;author=RC%20Oldfield&amp;publication_year=1971&amp;journal=Neuropsychologia&amp;volume=9&amp;pages=97-113" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/0028-3932(71)90067-4" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2F0028-3932(71)90067-4" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2F0028-3932(71)90067-4"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/5146491" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20assessment%20and%20analysis%20of%20handedness%3A%20the%20Edinburgh%20inventory&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b43" class="js-splitview-ref-item" data-legacy-id="b43"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b43" href="javascript:;" aria-label="jumplink-b43" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b43" class="ref-content " data-id="b43"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Parent</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Hazrati</div> <div class="given-names">LN</div></div>. </span><div class="article-title">Functional anatomy of the basal ganglia. I. The cortico-basal ganglia-thalamo-cortical loop</div>, <div class="source ">Brain Res Brain Res Rev</div>, <div class="year">1995</div>, vol. <div class="volume">20</div> (pg. <div class="fpage">91</div>-<div class="lpage">127</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Functional%20anatomy%20of%20the%20basal%20ganglia.%20I.%20The%20cortico-basal%20ganglia-thalamo-cortical%20loop&amp;author=A%20Parent&amp;author=LN%20Hazrati&amp;publication_year=1995&amp;journal=Brain%20Res%20Brain%20Res%20Rev&amp;volume=20&amp;pages=91-127" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/0165-0173(94)00007-C" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2F0165-0173(94)00007-C" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2F0165-0173(94)00007-C"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/7711769" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Functional%20anatomy%20of%20the%20basal%20ganglia.%20I.%20The%20cortico-basal%20ganglia-thalamo-cortical%20loop&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b44" class="js-splitview-ref-item" data-legacy-id="b44"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b44" href="javascript:;" aria-label="jumplink-b44" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b44" class="ref-content " data-id="b44"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Preibisch</div> <div class="given-names">C</div></div>,  <div class="name"><div class="surname">Berg</div> <div class="given-names">D</div></div>,  <div class="name"><div class="surname">Hofmann</div> <div class="given-names">E</div></div>,  <div class="name"><div class="surname">Solymosi</div> <div class="given-names">L</div></div>,  <div class="name"><div class="surname">Naumann</div> <div class="given-names">M</div></div>. </span><div class="article-title">Cerebral activation patterns in patients with writer's cramp: a functional magnetic resonance imaging study</div>, <div class="source ">J Neurol</div>, <div class="year">2001</div>, vol. <div class="volume">248</div> (pg. <div class="fpage">10</div>-<div class="lpage">7</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Cerebral%20activation%20patterns%20in%20patients%20with%20writer%27s%20cramp%3A%20a%20functional%20magnetic%20resonance%20imaging%20study&amp;author=C%20Preibisch&amp;author=D%20Berg&amp;author=E%20Hofmann&amp;author=L%20Solymosi&amp;author=M%20Naumann&amp;publication_year=2001&amp;journal=J%20Neurol&amp;volume=248&amp;pages=10-7" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1007/s004150170263" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1007%2Fs004150170263" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1007%2Fs004150170263"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/11266013" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Cerebral%20activation%20patterns%20in%20patients%20with%20writer%27s%20cramp%3A%20a%20functional%20magnetic%20resonance%20imaging%20study&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b45" class="js-splitview-ref-item" data-legacy-id="b45"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b45" href="javascript:;" aria-label="jumplink-b45" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b45" class="ref-content " data-id="b45"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Pujol</div> <div class="given-names">J</div></div>,  <div class="name"><div class="surname">Roset-Llobet</div> <div class="given-names">J</div></div>,  <div class="name"><div class="surname">Rosines-Cubells</div> <div class="given-names">D</div></div>,  <div class="name"><div class="surname">Deus</div> <div class="given-names">J</div></div>,  <div class="name"><div class="surname">Narberhaus</div> <div class="given-names">B</div></div>,  <div class="name"><div class="surname">Valls-Sole</div> <div class="given-names">J</div></div>, et al. </span><div class="article-title">Brain cortical activation during guitar-induced hand dystonia studied by functional MRI</div>, <div class="source ">Neuroimage</div>, <div class="year">2000</div>, vol. <div class="volume">12</div> (pg. <div class="fpage">257</div>-<div class="lpage">67</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Brain%20cortical%20activation%20during%20guitar-induced%20hand%20dystonia%20studied%20by%20functional%20MRI&amp;author=J%20Pujol&amp;author=J%20Roset-Llobet&amp;author=D%20Rosines-Cubells&amp;author=J%20Deus&amp;author=B%20Narberhaus&amp;author=J%20Valls-Sole&amp;publication_year=2000&amp;journal=Neuroimage&amp;volume=12&amp;pages=257-67" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1006/nimg.2000.0615" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1006%2Fnimg.2000.0615" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1006%2Fnimg.2000.0615"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/10944408" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Brain%20cortical%20activation%20during%20guitar-induced%20hand%20dystonia%20studied%20by%20functional%20MRI&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b46" class="js-splitview-ref-item" data-legacy-id="b46"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b46" href="javascript:;" aria-label="jumplink-b46" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b46" class="ref-content " data-id="b46"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Quartarone</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Bagnato</div> <div class="given-names">S</div></div>,  <div class="name"><div class="surname">Rizzo</div> <div class="given-names">V</div></div>,  <div class="name"><div class="surname">Siebner</div> <div class="given-names">HR</div></div>,  <div class="name"><div class="surname">Dattola</div> <div class="given-names">V</div></div>,  <div class="name"><div class="surname">Scalfari</div> <div class="given-names">A</div></div>, et al. </span><div class="article-title">Abnormal associative plasticity of the human motor cortex in writer's cramp</div>, <div class="source ">Brain</div>, <div class="year">2003</div>, vol. <div class="volume">126</div> (pg. <div class="fpage">2586</div>-<div class="lpage">96</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Abnormal%20associative%20plasticity%20of%20the%20human%20motor%20cortex%20in%20writer%27s%20cramp&amp;author=A%20Quartarone&amp;author=S%20Bagnato&amp;author=V%20Rizzo&amp;author=HR%20Siebner&amp;author=V%20Dattola&amp;author=A%20Scalfari&amp;publication_year=2003&amp;journal=Brain&amp;volume=126&amp;pages=2586-96" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1093/brain/awg273" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1093%2Fbrain%2Fawg273" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1093%2Fbrain%2Fawg273"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/14506068" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Abnormal%20associative%20plasticity%20of%20the%20human%20motor%20cortex%20in%20writer%27s%20cramp&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b47" class="js-splitview-ref-item" data-legacy-id="b47"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b47" href="javascript:;" aria-label="jumplink-b47" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b47" class="ref-content " data-id="b47"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Quartarone</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Bagnato</div> <div class="given-names">S</div></div>,  <div class="name"><div class="surname">Rizzo</div> <div class="given-names">V</div></div>,  <div class="name"><div class="surname">Morgante</div> <div class="given-names">F</div></div>,  <div class="name"><div class="surname">Sant'Angelo</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Crupi</div> <div class="given-names">D</div></div>, et al. </span><div class="article-title">Corticospinal excitability during motor imagery of a simple tonic finger movement in patients with writer's cramp</div>, <div class="source ">Mov Disord</div>, <div class="year">2005</div>, vol. <div class="volume">20</div> (pg. <div class="fpage">1488</div>-<div class="lpage">95</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Corticospinal%20excitability%20during%20motor%20imagery%20of%20a%20simple%20tonic%20finger%20movement%20in%20patients%20with%20writer%27s%20cramp&amp;author=A%20Quartarone&amp;author=S%20Bagnato&amp;author=V%20Rizzo&amp;author=F%20Morgante&amp;author=A%20Sant%27Angelo&amp;author=D%20Crupi&amp;publication_year=2005&amp;journal=Mov%20Disord&amp;volume=20&amp;pages=1488-95" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1002/(ISSN)1531-8257" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1002%2F(ISSN)1531-8257" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1002%2F(ISSN)1531-8257"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/16078218" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Corticospinal%20excitability%20during%20motor%20imagery%20of%20a%20simple%20tonic%20finger%20movement%20in%20patients%20with%20writer%27s%20cramp&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b48" class="js-splitview-ref-item" data-legacy-id="b48"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b48" href="javascript:;" aria-label="jumplink-b48" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b48" class="ref-content " data-id="b48"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Quartarone</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Siebner</div> <div class="given-names">HR</div></div>,  <div class="name"><div class="surname">Rothwell</div> <div class="given-names">J</div></div>. </span><div class="article-title">Task-specific hand dystonia: can too much plasticity be bad for you?</div>, <div class="source ">Trends Neurosci</div>, <div class="year">2006</div>, vol. <div class="volume">29</div> (pg. <div class="fpage">192</div>-<div class="lpage">9</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Task-specific%20hand%20dystonia%3A%20can%20too%20much%20plasticity%20be%20bad%20for%20you%3F&amp;author=A%20Quartarone&amp;author=HR%20Siebner&amp;author=J%20Rothwell&amp;publication_year=2006&amp;journal=Trends%20Neurosci&amp;volume=29&amp;pages=192-9" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/j.tins.2006.02.007" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2Fj.tins.2006.02.007" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2Fj.tins.2006.02.007"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/16519953" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Task-specific%20hand%20dystonia%3A%20can%20too%20much%20plasticity%20be%20bad%20for%20you%3F&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b49" class="js-splitview-ref-item" data-legacy-id="b49"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b49" href="javascript:;" aria-label="jumplink-b49" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b49" class="ref-content " data-id="b49"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Sanger</div> <div class="given-names">TD</div></div>,  <div class="name"><div class="surname">Tarsy</div> <div class="given-names">D</div></div>,  <div class="name"><div class="surname">Pascual-Leone</div> <div class="given-names">A</div></div>. </span><div class="article-title">Abnormalities of spatial and temporal sensory discrimination in writer's cramp</div>, <div class="source ">Mov Disord</div>, <div class="year">2001</div>, vol. <div class="volume">16</div> (pg. <div class="fpage">94</div>-<div class="lpage">9</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Abnormalities%20of%20spatial%20and%20temporal%20sensory%20discrimination%20in%20writer%27s%20cramp&amp;author=TD%20Sanger&amp;author=D%20Tarsy&amp;author=A%20Pascual-Leone&amp;publication_year=2001&amp;journal=Mov%20Disord&amp;volume=16&amp;pages=94-9" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1002/(ISSN)1531-8257" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1002%2F(ISSN)1531-8257" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1002%2F(ISSN)1531-8257"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/11215600" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Abnormalities%20of%20spatial%20and%20temporal%20sensory%20discrimination%20in%20writer%27s%20cramp&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b50" class="js-splitview-ref-item" data-legacy-id="b50"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b50" href="javascript:;" aria-label="jumplink-b50" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b50" class="ref-content " data-id="b50"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Sathian</div> <div class="given-names">K</div></div>,  <div class="name"><div class="surname">Zangaladze</div> <div class="given-names">A</div></div>. </span><div class="article-title">Feeling with the mind's eye: the role of visual imagery in tactile perception</div>, <div class="source ">Optom Vis Sci</div>, <div class="year">2001</div>, vol. <div class="volume">78</div> (pg. <div class="fpage">276</div>-<div class="lpage">81</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Feeling%20with%20the%20mind%27s%20eye%3A%20the%20role%20of%20visual%20imagery%20in%20tactile%20perception&amp;author=K%20Sathian&amp;author=A%20Zangaladze&amp;publication_year=2001&amp;journal=Optom%20Vis%20Sci&amp;volume=78&amp;pages=276-81" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1097/00006324-200105000-00010" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1097%2F00006324-200105000-00010" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1097%2F00006324-200105000-00010"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/11384004" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Feeling%20with%20the%20mind%27s%20eye%3A%20the%20role%20of%20visual%20imagery%20in%20tactile%20perception&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b51" class="js-splitview-ref-item" data-legacy-id="b51"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b51" href="javascript:;" aria-label="jumplink-b51" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b51" class="ref-content " data-id="b51"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Sathian</div> <div class="given-names">K</div></div>,  <div class="name"><div class="surname">Zangaladze</div> <div class="given-names">A</div></div>. </span><div class="article-title">Feeling with the mind's eye: contribution of visual cortex to tactile perception</div>, <div class="source ">Behav Brain Res</div>, <div class="year">2002</div>, vol. <div class="volume">135</div> (pg. <div class="fpage">127</div>-<div class="lpage">32</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Feeling%20with%20the%20mind%27s%20eye%3A%20contribution%20of%20visual%20cortex%20to%20tactile%20perception&amp;author=K%20Sathian&amp;author=A%20Zangaladze&amp;publication_year=2002&amp;journal=Behav%20Brain%20Res&amp;volume=135&amp;pages=127-32" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/S0166-4328(02)00141-9" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2FS0166-4328(02)00141-9" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2FS0166-4328(02)00141-9"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12356442" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Feeling%20with%20the%20mind%27s%20eye%3A%20contribution%20of%20visual%20cortex%20to%20tactile%20perception&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b52" class="js-splitview-ref-item" data-legacy-id="b52"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b52" href="javascript:;" aria-label="jumplink-b52" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b52" class="ref-content " data-id="b52"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Sheehy</div> <div class="given-names">MP</div></div>,  <div class="name"><div class="surname">Marsden</div> <div class="given-names">CD</div></div>. </span><div class="article-title">Writers' cramp—a focal dystonia</div>, <div class="source ">Brain</div>, <div class="year">1982</div>, vol. <div class="volume">105</div> (pg. <div class="fpage">461</div>-<div class="lpage">80</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Writers%27%20cramp%E2%80%94a%20focal%20dystonia&amp;author=MP%20Sheehy&amp;author=CD%20Marsden&amp;publication_year=1982&amp;journal=Brain&amp;volume=105&amp;pages=461-80" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1093/brain/105.3.461" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1093%2Fbrain%2F105.3.461" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1093%2Fbrain%2F105.3.461"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/7104663" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Writers%27%20cramp%E2%80%94a%20focal%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b53" class="js-splitview-ref-item" data-legacy-id="b53"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b53" href="javascript:;" aria-label="jumplink-b53" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b53" class="ref-content " data-id="b53"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Siebner</div> <div class="given-names">HR</div></div>,  <div class="name"><div class="surname">Filipovic</div> <div class="given-names">SR</div></div>,  <div class="name"><div class="surname">Rowe</div> <div class="given-names">JB</div></div>,  <div class="name"><div class="surname">Cordivari</div> <div class="given-names">C</div></div>,  <div class="name"><div class="surname">Gerschlager</div> <div class="given-names">W</div></div>,  <div class="name"><div class="surname">Rothwell</div> <div class="given-names">JC</div></div>, et al. </span><div class="article-title">Patients with focal arm dystonia have increased sensitivity to slow-frequency repetitive TMS of the dorsal premotor cortex</div>, <div class="source ">Brain</div>, <div class="year">2003</div>, vol. <div class="volume">126</div> (pg. <div class="fpage">2710</div>-<div class="lpage">25</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Patients%20with%20focal%20arm%20dystonia%20have%20increased%20sensitivity%20to%20slow-frequency%20repetitive%20TMS%20of%20the%20dorsal%20premotor%20cortex&amp;author=HR%20Siebner&amp;author=SR%20Filipovic&amp;author=JB%20Rowe&amp;author=C%20Cordivari&amp;author=W%20Gerschlager&amp;author=JC%20Rothwell&amp;publication_year=2003&amp;journal=Brain&amp;volume=126&amp;pages=2710-25" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1093/brain/awg282" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1093%2Fbrain%2Fawg282" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1093%2Fbrain%2Fawg282"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12937071" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Patients%20with%20focal%20arm%20dystonia%20have%20increased%20sensitivity%20to%20slow-frequency%20repetitive%20TMS%20of%20the%20dorsal%20premotor%20cortex&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b54" class="js-splitview-ref-item" data-legacy-id="b54"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b54" href="javascript:;" aria-label="jumplink-b54" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b54" class="ref-content " data-id="b54"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Sohn</div> <div class="given-names">YH</div></div>,  <div class="name"><div class="surname">Hallett</div> <div class="given-names">M</div></div>. </span><div class="article-title">Disturbed surround inhibition in focal hand dystonia</div>, <div class="source ">Ann Neurol</div>, <div class="year">2004</div>, vol. <div class="volume">56</div> (pg. <div class="fpage">595</div>-<div class="lpage">9</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Disturbed%20surround%20inhibition%20in%20focal%20hand%20dystonia&amp;author=YH%20Sohn&amp;author=M%20Hallett&amp;publication_year=2004&amp;journal=Ann%20Neurol&amp;volume=56&amp;pages=595-9" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1002/(ISSN)1531-8249" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1002%2F(ISSN)1531-8249" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1002%2F(ISSN)1531-8249"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15455393" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Disturbed%20surround%20inhibition%20in%20focal%20hand%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b55" class="js-splitview-ref-item" data-legacy-id="b55"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b55" href="javascript:;" aria-label="jumplink-b55" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b55" class="ref-content " data-id="b55"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Stein</div> <div class="given-names">JF</div></div>,  <div class="name"><div class="surname">Glickstein</div> <div class="given-names">M</div></div>. </span><div class="article-title">Role of the cerebellum in visual guidance of movement</div>, <div class="source ">Physiol Rev</div>, <div class="year">1992</div>, vol. <div class="volume">72</div> (pg. <div class="fpage">967</div>-<div class="lpage">1017</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Role%20of%20the%20cerebellum%20in%20visual%20guidance%20of%20movement&amp;author=JF%20Stein&amp;author=M%20Glickstein&amp;publication_year=1992&amp;journal=Physiol%20Rev&amp;volume=72&amp;pages=967-1017" target="_blank">Google Scholar</a></span></p><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/1438583" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=article&amp;atitle=Role+of+the+cerebellum+in+visual+guidance+of+movement&amp;aulast=Stein&amp;title=Physiol+Rev&amp;date=1992&amp;spage=967&amp;epage=1017&amp;volume=72" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Role%20of%20the%20cerebellum%20in%20visual%20guidance%20of%20movement&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b56" class="js-splitview-ref-item" data-legacy-id="b56"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b56" href="javascript:;" aria-label="jumplink-b56" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b56" class="ref-content " data-id="b56"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Tempel</div> <div class="given-names">LW</div></div>,  <div class="name"><div class="surname">Perlmutter</div> <div class="given-names">JS</div></div>. </span><div class="article-title">Abnormal cortical responses in patients with writer's cramp</div>, <div class="source ">Neurology</div>, <div class="year">1993</div>, vol. <div class="volume">43</div> (pg. <div class="fpage">2252</div>-<div class="lpage">7</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Abnormal%20cortical%20responses%20in%20patients%20with%20writer%27s%20cramp&amp;author=LW%20Tempel&amp;author=JS%20Perlmutter&amp;publication_year=1993&amp;journal=Neurology&amp;volume=43&amp;pages=2252-7" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1212/WNL.43.11.2252" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1212%2FWNL.43.11.2252" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1212%2FWNL.43.11.2252"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/8232938" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Abnormal%20cortical%20responses%20in%20patients%20with%20writer%27s%20cramp&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b57" class="js-splitview-ref-item" data-legacy-id="b57"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b57" href="javascript:;" aria-label="jumplink-b57" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b57" class="ref-content " data-id="b57"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Tinazzi</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Priori</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Bertolasi</div> <div class="given-names">L</div></div>,  <div class="name"><div class="surname">Frasson</div> <div class="given-names">E</div></div>,  <div class="name"><div class="surname">Mauguiere</div> <div class="given-names">F</div></div>,  <div class="name"><div class="surname">Fiaschi</div> <div class="given-names">A</div></div>. </span><div class="article-title">Abnormal central integration of a dual somatosensory input in dystonia. Evidence for sensory overflow</div>, <div class="source ">Brain</div>, <div class="year">2000</div>, vol. <div class="volume">123</div> (pg. <div class="fpage">42</div>-<div class="lpage">50</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Abnormal%20central%20integration%20of%20a%20dual%20somatosensory%20input%20in%20dystonia.%20Evidence%20for%20sensory%20overflow&amp;author=M%20Tinazzi&amp;author=A%20Priori&amp;author=L%20Bertolasi&amp;author=E%20Frasson&amp;author=F%20Mauguiere&amp;author=A%20Fiaschi&amp;publication_year=2000&amp;journal=Brain&amp;volume=123&amp;pages=42-50" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1093/brain/123.1.42" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1093%2Fbrain%2F123.1.42" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1093%2Fbrain%2F123.1.42"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/10611119" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Abnormal%20central%20integration%20of%20a%20dual%20somatosensory%20input%20in%20dystonia.%20Evidence%20for%20sensory%20overflow&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b58" class="js-splitview-ref-item" data-legacy-id="b58"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b58" href="javascript:;" aria-label="jumplink-b58" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b58" class="ref-content " data-id="b58"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Tinazzi</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Rosso</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Fiaschi</div> <div class="given-names">A</div></div>. </span><div class="article-title">Role of the somatosensory system in primary dystonia</div>, <div class="source ">Mov Disord</div>, <div class="year">2003</div>, vol. <div class="volume">18</div> (pg. <div class="fpage">605</div>-<div class="lpage">22</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Role%20of%20the%20somatosensory%20system%20in%20primary%20dystonia&amp;author=M%20Tinazzi&amp;author=T%20Rosso&amp;author=A%20Fiaschi&amp;publication_year=2003&amp;journal=Mov%20Disord&amp;volume=18&amp;pages=605-22" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1002/mds.v18:6" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1002%2Fmds.v18:6" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1002%2Fmds.v18:6"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12784263" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Role%20of%20the%20somatosensory%20system%20in%20primary%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b59" class="js-splitview-ref-item" data-legacy-id="b59"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b59" href="javascript:;" aria-label="jumplink-b59" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b59" class="ref-content " data-id="b59"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Tinazzi</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Farina</div> <div class="given-names">S</div></div>,  <div class="name"><div class="surname">Edwards</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Moretto</div> <div class="given-names">G</div></div>,  <div class="name"><div class="surname">Restivo</div> <div class="given-names">D</div></div>,  <div class="name"><div class="surname">Fiaschi</div> <div class="given-names">A</div></div>, et al. </span><div class="article-title">Task-specific impairment of motor cortical excitation and inhibition in patients with writer's cramp</div>, <div class="source ">Neurosci Lett</div>, <div class="year">2005</div>, vol. <div class="volume">378</div> (pg. <div class="fpage">55</div>-<div class="lpage">8</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Task-specific%20impairment%20of%20motor%20cortical%20excitation%20and%20inhibition%20in%20patients%20with%20writer%27s%20cramp&amp;author=M%20Tinazzi&amp;author=S%20Farina&amp;author=M%20Edwards&amp;author=G%20Moretto&amp;author=D%20Restivo&amp;author=A%20Fiaschi&amp;publication_year=2005&amp;journal=Neurosci%20Lett&amp;volume=378&amp;pages=55-8" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/j.neulet.2004.12.015" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2Fj.neulet.2004.12.015" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2Fj.neulet.2004.12.015"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15763172" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Task-specific%20impairment%20of%20motor%20cortical%20excitation%20and%20inhibition%20in%20patients%20with%20writer%27s%20cramp&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b60" class="js-splitview-ref-item" data-legacy-id="b60"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b60" href="javascript:;" aria-label="jumplink-b60" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b60" class="ref-content " data-id="b60"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Van Boven</div> <div class="given-names">RW</div></div>,  <div class="name"><div class="surname">Johnson</div> <div class="given-names">KO</div></div>. </span><div class="article-title">The limit of tactile spatial resolution in humans: grating orientation discrimination at the lip, tongue, and finger</div>, <div class="source ">Neurology</div>, <div class="year">1994</div>, vol. <div class="volume">44</div> (pg. <div class="fpage">2361</div>-<div class="lpage">6</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20limit%20of%20tactile%20spatial%20resolution%20in%20humans%3A%20grating%20orientation%20discrimination%20at%20the%20lip%2C%20tongue%2C%20and%20finger&amp;author=RW%20Van%20Boven&amp;author=KO%20Johnson&amp;publication_year=1994&amp;journal=Neurology&amp;volume=44&amp;pages=2361-6" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1212/WNL.44.12.2361" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1212%2FWNL.44.12.2361" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1212%2FWNL.44.12.2361"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/7991127" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20limit%20of%20tactile%20spatial%20resolution%20in%20humans%3A%20grating%20orientation%20discrimination%20at%20the%20lip%2C%20tongue%2C%20and%20finger&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b61" class="js-splitview-ref-item" data-legacy-id="b61"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b61" href="javascript:;" aria-label="jumplink-b61" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b61" class="ref-content " data-id="b61"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Van Boven</div> <div class="given-names">RW</div></div>,  <div class="name"><div class="surname">Ingeholm</div> <div class="given-names">JE</div></div>,  <div class="name"><div class="surname">Beauchamp</div> <div class="given-names">MS</div></div>,  <div class="name"><div class="surname">Bikle</div> <div class="given-names">PC</div></div>,  <div class="name"><div class="surname">Ungerleider</div> <div class="given-names">LG</div></div>. </span><div class="article-title">Tactile form and location processing in the human brain</div>, <div class="source ">Proc Natl Acad Sci USA</div>, <div class="year">2005</div>, vol. <div class="volume">102</div> (pg. <div class="fpage">12601</div>-<div class="lpage">5</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Tactile%20form%20and%20location%20processing%20in%20the%20human%20brain&amp;author=RW%20Van%20Boven&amp;author=JE%20Ingeholm&amp;author=MS%20Beauchamp&amp;author=PC%20Bikle&amp;author=LG%20Ungerleider&amp;publication_year=2005&amp;journal=Proc%20Natl%20Acad%20Sci%20USA&amp;volume=102&amp;pages=12601-5" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1073/pnas.0505907102" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1073%2Fpnas.0505907102" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1073%2Fpnas.0505907102"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/16116098" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Tactile%20form%20and%20location%20processing%20in%20the%20human%20brain&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b62" class="js-splitview-ref-item" data-legacy-id="b62"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b62" href="javascript:;" aria-label="jumplink-b62" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b62" class="ref-content " data-id="b62"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Vitek</div> <div class="given-names">JL</div></div>,  <div class="name"><div class="surname">Chockkan</div> <div class="given-names">V</div></div>,  <div class="name"><div class="surname">Zhang</div> <div class="given-names">JY</div></div>,  <div class="name"><div class="surname">Kaneoke</div> <div class="given-names">Y</div></div>,  <div class="name"><div class="surname">Evatt</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">DeLong</div> <div class="given-names">MR</div></div>, et al. </span><div class="article-title">Neuronal activity in the basal ganglia in patients with generalized dystonia and hemiballismus</div>, <div class="source ">Ann Neurol</div>, <div class="year">1999</div>, vol. <div class="volume">46</div> (pg. <div class="fpage">22</div>-<div class="lpage">35</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Neuronal%20activity%20in%20the%20basal%20ganglia%20in%20patients%20with%20generalized%20dystonia%20and%20hemiballismus&amp;author=JL%20Vitek&amp;author=V%20Chockkan&amp;author=JY%20Zhang&amp;author=Y%20Kaneoke&amp;author=M%20Evatt&amp;author=MR%20DeLong&amp;publication_year=1999&amp;journal=Ann%20Neurol&amp;volume=46&amp;pages=22-35" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1002/(ISSN)1531-8249" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1002%2F(ISSN)1531-8249" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1002%2F(ISSN)1531-8249"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/10401777" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Neuronal%20activity%20in%20the%20basal%20ganglia%20in%20patients%20with%20generalized%20dystonia%20and%20hemiballismus&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b63" class="js-splitview-ref-item" data-legacy-id="b63"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b63" href="javascript:;" aria-label="jumplink-b63" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b63" class="ref-content " data-id="b63"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Zangaladze</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">Epstein</div> <div class="given-names">CM</div></div>,  <div class="name"><div class="surname">Grafton</div> <div class="given-names">ST</div></div>,  <div class="name"><div class="surname">Sathian</div> <div class="given-names">K</div></div>. </span><div class="article-title">Involvement of visual cortex in tactile discrimination of orientation</div>, <div class="source ">Nature</div>, <div class="year">1999</div>, vol. <div class="volume">401</div> (pg. <div class="fpage">587</div>-<div class="lpage">90</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Involvement%20of%20visual%20cortex%20in%20tactile%20discrimination%20of%20orientation&amp;author=A%20Zangaladze&amp;author=CM%20Epstein&amp;author=ST%20Grafton&amp;author=K%20Sathian&amp;publication_year=1999&amp;journal=Nature&amp;volume=401&amp;pages=587-90" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1038/44139" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1038%2F44139" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1038%2F44139"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/10524625" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Involvement%20of%20visual%20cortex%20in%20tactile%20discrimination%20of%20orientation&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b64" class="js-splitview-ref-item" data-legacy-id="b64"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b64" href="javascript:;" aria-label="jumplink-b64" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b64" class="ref-content " data-id="b64"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Zhang</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Weisser</div> <div class="given-names">VD</div></div>,  <div class="name"><div class="surname">Stilla</div> <div class="given-names">R</div></div>,  <div class="name"><div class="surname">Prather</div> <div class="given-names">SC</div></div>,  <div class="name"><div class="surname">Sathian</div> <div class="given-names">K</div></div>. </span><div class="article-title">Multisensory cortical processing of object shape and its relation to mental imagery</div>, <div class="source ">Cogn Affect Behav Neurosci</div>, <div class="year">2004</div>, vol. <div class="volume">4</div> (pg. <div class="fpage">251</div>-<div class="lpage">9</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Multisensory%20cortical%20processing%20of%20object%20shape%20and%20its%20relation%20to%20mental%20imagery&amp;author=M%20Zhang&amp;author=VD%20Weisser&amp;author=R%20Stilla&amp;author=SC%20Prather&amp;author=K%20Sathian&amp;publication_year=2004&amp;journal=Cogn%20Affect%20Behav%20Neurosci&amp;volume=4&amp;pages=251-9" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.3758/CABN.4.2.251" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.3758%2FCABN.4.2.251" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.3758%2FCABN.4.2.251"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15460931" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Multisensory%20cortical%20processing%20of%20object%20shape%20and%20its%20relation%20to%20mental%20imagery&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b65" class="js-splitview-ref-item" data-legacy-id="b65"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b65" href="javascript:;" aria-label="jumplink-b65" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b65" class="ref-content " data-id="b65"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Zhang</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Mariola</div> <div class="given-names">E</div></div>,  <div class="name"><div class="surname">Stilla</div> <div class="given-names">R</div></div>,  <div class="name"><div class="surname">Stoesz</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Mao</div> <div class="given-names">H</div></div>,  <div class="name"><div class="surname">Hu</div> <div class="given-names">X</div></div>, et al. </span><div class="article-title">Tactile discrimination of grating orientation: fMRI activation patterns</div>, <div class="source ">Hum Brain Mapp</div>, <div class="year">2005</div><!--citationLinks: case 2--><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Tactile%20discrimination%20of%20grating%20orientation%3A%20fMRI%20activation%20patterns&amp;author=M%20Zhang&amp;author=E%20Mariola&amp;author=R%20Stilla&amp;author=M%20Stoesz&amp;author=H%20Mao&amp;author=X%20Hu&amp;publication_year=2005&amp;journal=Hum%20Brain%20Mapp&amp;volume=&amp;pages=" target="_blank">Google Scholar</a></span></p><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=article&amp;atitle=Tactile+discrimination+of+grating+orientation%3a+fMRI+activation+patterns&amp;aulast=Zhang&amp;title=Hum+Brain+Mapp&amp;date=2005" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Tactile%20discrimination%20of%20grating%20orientation%3A%20fMRI%20activation%20patterns&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="b66" class="js-splitview-ref-item" data-legacy-id="b66"><div class="refLink-parent"><span class="refLink"><a name="jumplink-b66" href="javascript:;" aria-label="jumplink-b66" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-b66" class="ref-content " data-id="b66"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Zhuang</div> <div class="given-names">P</div></div>,  <div class="name"><div class="surname">Li</div> <div class="given-names">Y</div></div>,  <div class="name"><div class="surname">Hallett</div> <div class="given-names">M</div></div>. </span><div class="article-title">Neuronal activity in the basal ganglia and thalamus in patients with dystonia</div>, <div class="source ">Clin Neurophysiol</div>, <div class="year">2004</div>, vol. <div class="volume">115</div> (pg. <div class="fpage">2542</div>-<div class="lpage">57</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Neuronal%20activity%20in%20the%20basal%20ganglia%20and%20thalamus%20in%20patients%20with%20dystonia&amp;author=P%20Zhuang&amp;author=Y%20Li&amp;author=M%20Hallett&amp;publication_year=2004&amp;journal=Clin%20Neurophysiol&amp;volume=115&amp;pages=2542-57" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/j.clinph.2004.06.006" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2Fj.clinph.2004.06.006" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2Fj.clinph.2004.06.006"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15465444" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Neuronal%20activity%20in%20the%20basal%20ganglia%20and%20thalamus%20in%20patients%20with%20dystonia&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div></div>    <!-- /foreach in Model.Sections -->
+    <div class="widget widget-ArticlePubStateInfo widget-instance-OUP_ArticlePubStateInfo">
+         
+    </div>
+
+
+
+        <div class="article-metadata-standalone-panel clearfix"></div>
+
+        
+<div class="copyright copyright-statement">© The Author (2006). Published by Oxford University Press on behalf of the Guarantors of Brain. All rights reserved. For Permissions, please email: journals.permissions@oxfordjournals.org</div><!-- /foreach -->
+
+        <span id="UserHasAccess" data-userHasAccess="True"></span>
+
+    </div><!-- /.widget-items -->
+</div><!-- /.module-widget -->
+
+
+
+
+
+ 
+    </div>
+    <div class="widget widget-RelatedTags widget-instance-OUP_Article_RelatedTags_Widget">
+            <div class="related-topic-tags">
+        <div class="related-topic-tag-label">Topic:</div>
+        <ul class="related-topic-tag-list">
+<li>
+                    <a href="https://academic.oup.com/brain/search-results?f_SemanticFilterTopics=basal ganglia"><span>basal ganglia</span></a>
+                </li>
+<li>
+                    <a href="https://academic.oup.com/brain/search-results?f_SemanticFilterTopics=dystonia"><span>dystonia</span></a>
+                </li>
+<li>
+                    <a href="https://academic.oup.com/brain/search-results?f_SemanticFilterTopics=caudate nucleus"><span>caudate nucleus</span></a>
+                </li>
+<li>
+                    <a href="https://academic.oup.com/brain/search-results?f_SemanticFilterTopics=putamen"><span>putamen</span></a>
+                </li>
+<li>
+                    <a href="https://academic.oup.com/brain/search-results?f_SemanticFilterTopics=thalamus"><span>thalamus</span></a>
+                </li>
+<li>
+                    <a href="https://academic.oup.com/brain/search-results?f_SemanticFilterTopics=cerebellum"><span>cerebellum</span></a>
+                </li>
+<li>
+                    <a href="https://academic.oup.com/brain/search-results?f_SemanticFilterTopics=writer&#39;s cramp"><span>writer&#39;s cramp</span></a>
+                </li>
+<li>
+                    <a href="https://academic.oup.com/brain/search-results?f_SemanticFilterTopics=functional magnetic resonance imaging"><span>functional magnetic resonance imaging</span></a>
+                </li>
+<li>
+                    <a href="https://academic.oup.com/brain/search-results?f_SemanticFilterTopics=blood oxygen level dependent"><span>blood oxygen level dependent</span></a>
+                </li>
+<li>
+                    <a href="https://academic.oup.com/brain/search-results?f_SemanticFilterTopics=index finger"><span>index finger</span></a>
+                </li>
+        </ul>
+    </div>
+ 
+    </div>
+    <div class="widget widget-SolrResourceMetadata widget-instance-OUP_Article_ResourceMetadata_Widget">
+        
+    <div class="article-metadata-panel solr-resource-metadata js-metadata-panel at-ContentMetadata">
+                <div class="article-metadata-taxonomies">
+                </div>
+                <div class="article-metadata-tocSections">
+                    <div class="article-metadata-tocSections-title">Issue Section:</div>
+                        <a href="/brain/search-results?f_TocHeadingTitle=Original+Articles">Original Articles</a>
+                </div>
+
+    </div>
+
+
+ 
+    </div>
+    <div class="widget widget-EditorInformation widget-instance-OUP_Article_EditorInformation_Widget">
+        
+ 
+    </div>
+
+                <div id="ContentTabFilteredView"></div>
+                <div class="downloadImagesppt js-download-images-ppt st-download-images-ppt">
+                    <a id="lnkDownloadAllImages"
+                       class="js-download-all-images-link btn"
+                       href="/DownloadFile/DownloadImage.aspx?image=&amp;PPTtype=SlideSet&amp;ar=290089&amp;xsltPath=~/UI/app/XSLT&amp;siteId=5367">Download all slides</a>
+                </div>
+                    <div class="widget widget-ArticleDataRepositories widget-instance-Article_DryadLink">
+         
+    </div>
+
+                <div class="comments">
+    <div class="widget widget-UserCommentBody widget-instance-UserCommentBody_Article">
+        
+
+ 
+    </div>
+    <div class="widget widget-UserComment widget-instance-OUP_UserComment_Article">
+         
+    </div>
+
+                </div>
+            </div>
+        </div>
+
+    </div>
+</div>
+<div id="Sidebar" class="page-column page-column--right">
+    <div class="widget widget-AdBlock widget-instance-ArticlePageTopSidebar">
+        <div class="js-adBlock-parent-wrap">    
+    <div class="adBlockMainBodyTop-wrap js-adBlockMainBodyTop hide">
+    
+        <div id="adBlockMainBodyTop" class="js-adblock at-adblock">
+            <script>
+                googletag.cmd.push(function () {
+                    googletag.display('adBlockMainBodyTop');
+                });
+            </script>
+        </div>
+        <div class="advertisement-text at-adblock js-adblock-advertisement-text hide">Advertisement</div>
+    </div>
+</div> 
+    </div>
+<div class="widget widget-dynamic " data-count="1"> 
+
+    <div class="widget-dynamic-inner-wrap">
+
+<div class="widget widget-dynamic " data-count="8"> 
+
+    <div class="widget-dynamic-inner-wrap">
+
+    <div class="widget widget-ArticleLevelMetrics widget-instance-Article_RightRailB0Article_RightRail_ArticleLevelMetrics">
+        
+
+
+
+        <div class="artmet-wrapper horizontal-artmet">
+
+<div class="contentmet-border">
+    <div class="contentmet-wrapper horizontal-contentmet">
+            <div class="contentmet-citations contentmet-badges-wrap js-contentmet-citations hide">
+                <h3 class="contentmet-text">Citations</h3>
+                    <div class="contentmet-item contentmet-dimensions">
+    <div class="widget widget-DimensionsBadge widget-instance-ArticleLevelMetrics_DimensionsBadge">
+        <span class="__dimensions_badge_embed__" 
+      data-doi="10.1093/brain/awl181" 
+      data-legend="never" 
+      data-style="small_circle" 
+      data-hide-zero-citations="true"></span>
+<script async src="https://badge.dimensions.ai/badge.js" charset="utf-8"></script>
+ 
+    </div>
+
+                    </div>
+                            </div>
+                    <div class="contentmet-views contentmet-badges-wrap js-contentmet-views">
+                <h3 class="contentmet-text">Views</h3>
+                <div class="contentmet-item circle-text circle-text-views">
+                    <div class="contentmet-number">1,538</div>
+                </div>
+            </div>
+                    <div class="contentmet-item contentmet-badges-wrap">
+                    <h3 class="contentmet-text">Altmetric</h3>
+                    <div class="contentmet-item contentmet-altmetric">
+    <div class="widget widget-AltmetricLink widget-instance-ArticleLevelMetrics_AltmetricLinkSummary">
+            <!-- Altmetrics -->
+    <div id="altmetricEmbedId"
+         runat="server"
+         class='altmetric-embed'
+         data-badge-type="donut"
+         data-hide-no-mentions="false"
+         data-doi="10.1093/brain/awl181"
+
+        
+
+        ></div>
+         <script type='text/javascript' src='https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js'></script>
+ 
+    </div>
+
+                    </div>
+
+
+            </div>
+                    <div class="contentmet-modal-trigger-wrap clearfix">
+                <a href="javascript:;" class="artmet-modal-trigger js-artmet-modal-trigger at-alm-metrics-modal-trigger" data-resource-id="290089" data-resource-type="3">
+                    <img class="contentmet-info-icon" src="//oup.silverchair-cdn.com/UI/app/svg/i.svg" alt="Information">
+                    <span class="contentmet-more-info">More metrics information</span>
+                </a>
+            </div>
+    </div>
+</div>
+
+                <div class="artmet-modal js-artmet-modal" id="MetricsModal">
+                    <div class="artmet-modal-contents js-metric-modal-contents at-alm-modal-contents">
+                        <a class="artmet-close-modal js-artmet-close-modal">&#215;</a>
+                    </div>
+                </div>
+        </div>
+ 
+    </div>
+    <div class="widget widget-Alerts widget-instance-Article_RightRailB0Article_RightRail_Alerts">
+        
+    <div class="alertsWidget">
+        <h3>Email alerts</h3>
+                <div class="userAlert alertType-1">
+                    <a href="javascript:;" class="js-user-alert" role="button"
+                       data-userLoggedIn="False"
+                       data-alertType="1" href="javascript:;">Article activity alert</a>
+                </div>
+                <div class="userAlert alertType-3">
+                    <a href="javascript:;" class="js-user-alert" role="button"
+                       data-userLoggedIn="False"
+                       data-alertType="3" href="javascript:;">Advance article alerts</a>
+                </div>
+                <div class="userAlert alertType-5">
+                    <a href="javascript:;" class="js-user-alert" role="button"
+                       data-userLoggedIn="False"
+                       data-alertType="5" href="javascript:;">New issue alert</a>
+                </div>
+                <div class="userAlert alertType-33">
+                    <a href="javascript:;" class="js-user-alert" role="button"
+                       data-userLoggedIn="False"
+                       data-alertType="33" href="javascript:;">Subject alert</a>
+                </div>
+                    <div class="userAlert alertType-MarketingLink">
+                <a href="javascript:;" class="js-user-alert" role="button"
+                   data-userLoggedIn="False"
+                   data-additionalUrl="/my-account/communication-preferences" href="javascript:;">Receive exclusive offers and updates from Oxford Academic</a>
+            </div>
+        <div class="userAlertSignUpModal reveal-modal small" data-reveal>
+            <div class="userAlertSignUp at-userAlertSignUp"></div>
+            <a href="javascript:;" role="button" aria-label="Close" class="close-reveal-modal" href="javascript:;">
+                <i class="icon-general-close"></i>
+            </a>
+        </div>
+    </div>
+ 
+    </div>
+    <div class="widget widget-TrendMD widget-instance-Article_RightRailB0trendmd">
+        <script defer async src='//js.trendmd.com/trendmd.min.js'  data-trendmdconfig='{"journal_id":"62054","element":"#trendmd-suggestions"}'></script>
+
+<div id="trendmd-suggestions"></div> 
+    </div>
+    <div class="widget widget-ArticleCitedBy widget-instance-Article_RightRailB0Article_RightRail_ArticleCitedBy">
+        <div class="rail-widget_wrap vt-articles-cited-by">
+    <h3 class="article-cited-title">Citing articles via</h3>
+    <div class="widget-links_wrap">
+            <div class="article-cited-link-wrap web-of-science">
+                <a href="https://www.webofscience.com/api/gateway?GWVersion=2&SrcApp=PARTNER_APP&SrcAuth=Silverchair&KeyUT=WOS:000240925500018&DestLinkType=CitingArticles&DestApp=WOS_CPL&UsrCustomerID=61f30d8ae69c46f86624c5f98a3bc13a" target="_blank">Web of Science (86)</a>
+            </div>
+                    <div class="article-cited-link-wrap google-scholar-url">
+                <a href="http://scholar.google.com/scholar?q=link:https%3A%2F%2Facademic.oup.com%2Fbrain%2Farticle%2F129%2F10%2F2697%2F290089" target="_blank">Google Scholar</a>
+            </div>
+            </div>
+</div> 
+    </div>
+    <div class="widget widget-ArticleListNewAndPopular widget-instance-Article_RightRailB0Article_RightRail_ArticleNewPopularCombined">
+            <ul class="articleListNewAndPopularCombinedView">
+            <li>
+                <h3>
+                    <a href="javascript:;" class="articleListNewAndPopular-mode active" data-mode="MostRecent">Latest</a>
+                </h3>
+            </li>
+            <li>
+                <h3>
+                    <a href="javascript:;" class="articleListNewAndPopular-mode " data-mode="MostRead">Most Read</a>
+                </h3>
+            </li>
+            <li>
+                <h3>
+                    <a href="javascript:;" class="articleListNewAndPopular-mode " data-mode="MostCited">Most Cited</a>
+                </h3>
+            </li>
+    </ul>
+        <section class="articleListNewPopContent articleListNewAndPopular-ContentView-MostRecent hasContent">
+
+
+
+
+<div id="newPopularList-Article_RightRailB0Article_RightRail_ArticleNewPopularCombined" class="fb">
+
+    
+
+
+
+<div class="widget-layout widget-layout--vert ">
+            <div class="widget-columns widget-col-1">
+                    <div class="col">
+
+<div class="widget-dynamic-entry journalArticleItem at-widget-entry-SCL">
+    <span class="hfDoi" data-attribute="10.1093/brain/awad200" aria-hidden="true"></span>
+
+
+    
+
+
+<a class="journal-link" href="/brain/advance-article/doi/10.1093/brain/awad200/7192462?searchresult=1">
+        <div class="widget-dynamic-journal-title">
+Intracranial stimulation and EEG feature analysis reveal affective salience network specialization    </div>
+</a>
+
+ 
+
+
+
+
+
+<div class="widget-dynamic-journal-image-synopsis">
+        <div class="widget-dynamic-journal-synopsis">
+            
+        </div>
+</div>
+</div>
+<div class="widget-dynamic-entry journalArticleItem at-widget-entry-SCL">
+    <span class="hfDoi" data-attribute="10.1093/brain/awad195" aria-hidden="true"></span>
+
+
+    
+
+
+<a class="journal-link" href="/brain/advance-article/doi/10.1093/brain/awad195/7192328?searchresult=1">
+        <div class="widget-dynamic-journal-title">
+The coming of age of liquid biopsy in neuro-oncology    </div>
+</a>
+
+ 
+
+
+
+
+
+<div class="widget-dynamic-journal-image-synopsis">
+        <div class="widget-dynamic-journal-synopsis">
+            
+        </div>
+</div>
+</div>
+<div class="widget-dynamic-entry journalArticleItem at-widget-entry-SCL">
+    <span class="hfDoi" data-attribute="10.1093/brain/awad194" aria-hidden="true"></span>
+
+
+    
+
+
+<a class="journal-link" href="/brain/advance-article/doi/10.1093/brain/awad194/7191595?searchresult=1">
+        <div class="widget-dynamic-journal-title">
+Characteristics of amnestic patients with hypometabolism patterns suggestive of Lewy body pathology    </div>
+</a>
+
+ 
+
+
+
+
+
+<div class="widget-dynamic-journal-image-synopsis">
+        <div class="widget-dynamic-journal-synopsis">
+            
+        </div>
+</div>
+</div>
+<div class="widget-dynamic-entry journalArticleItem at-widget-entry-SCL">
+    <span class="hfDoi" data-attribute="10.1093/brain/awad191" aria-hidden="true"></span>
+
+
+    
+
+
+<a class="journal-link" href="/brain/advance-article/doi/10.1093/brain/awad191/7191594?searchresult=1">
+        <div class="widget-dynamic-journal-title">
+Peripheral CCL2-CCR2 signalling contributes to chronic headache-related sensitization    </div>
+</a>
+
+ 
+
+
+
+
+
+<div class="widget-dynamic-journal-image-synopsis">
+        <div class="widget-dynamic-journal-synopsis">
+            
+        </div>
+</div>
+</div>
+<div class="widget-dynamic-entry journalArticleItem at-widget-entry-SCL">
+    <span class="hfDoi" data-attribute="10.1093/brain/awad187" aria-hidden="true"></span>
+
+
+    
+
+
+<a class="journal-link" href="/brain/advance-article/doi/10.1093/brain/awad187/7191593?searchresult=1">
+        <div class="widget-dynamic-journal-title">
+Genetic analysis and natural history of Charcot-Marie-Tooth disease CMTX1 due to GJB1 variants    </div>
+</a>
+
+ 
+
+
+
+
+
+<div class="widget-dynamic-journal-image-synopsis">
+        <div class="widget-dynamic-journal-synopsis">
+            
+        </div>
+</div>
+</div>
+                    </div>
+            </div>
+
+</div></div>
+        </section>
+        <section class="articleListNewPopContent articleListNewAndPopular-ContentView-MostRead hide">
+        </section>
+        <section class="articleListNewPopContent articleListNewAndPopular-ContentView-MostCited hide">
+        </section>
+ 
+    </div>
+    <div class="widget widget-RelatedTaxonomies widget-instance-Article_RightRailB0Article_RightRail_RelatedTaxonomies">
+            <div class="widget-related-taxonomies-wrap vt-related-taxonomies">
+        <div class="widget-related-taxonomies_title">More from Oxford Academic</div>
+            <div class="widget-related-taxonomies">
+                <a id="more-from-oa-AcademicSubjects_MED00010" class="related-taxonomies-link" href="/search-results?tax=AcademicSubjects/MED00010">Medicine and Health</a>
+            </div>
+            <div class="widget-related-taxonomies">
+                <a id="more-from-oa-AcademicSubjects_MED00310" class="related-taxonomies-link" href="/search-results?tax=AcademicSubjects/MED00310">Neurology</a>
+            </div>
+            <div class="widget-related-taxonomies">
+                <a id="more-from-oa-AcademicSubjects_SCI01870" class="related-taxonomies-link" href="/search-results?tax=AcademicSubjects/SCI01870">Neuroscience</a>
+            </div>
+            <div class="widget-related-taxonomies">
+                <a id="more-from-oa-AcademicSubjects_SCI00010" class="related-taxonomies-link" href="/search-results?tax=AcademicSubjects/SCI00010">Science and Mathematics</a>
+            </div>
+
+            <div class="widget-related-taxonomies">
+                <a id="more-from-oa-format-Books" class="related-taxonomies-link" href="/books">Books</a>
+            </div>
+            <div class="widget-related-taxonomies">
+                <a id="more-from-oa-format-Journals" class="related-taxonomies-link" href="/journals">Journals</a>
+            </div>
+    </div>
+ 
+    </div>
+    <div class="widget widget-JobTarget widget-instance-Article_RightRailB0Article_RightRail_JobTarget">
+        <div class="wrapper">
+    <div class="header">
+        <h3>
+            <a href="http://medicine-and-health-careernetwork.oxfordjournals.org/jobseeker/search/results/">Looking for your next opportunity?</a>
+        </h3>
+    </div>
+
+        <div id="jobs" class="jobs-list">
+                <div class="job">
+                    <div class="job-position"><a href="https://Medicine-and-health-careernetwork.oxfordjournals.org/job/academic-surgical-pathologistbreast-pathologist/69633050/20102/">Academic Surgical Pathologist/Breast Pathologist</a></div>
+                    <div class="job-location">
+                        , Utah
+                    </div>
+                </div>
+                <div class="job">
+                    <div class="job-position"><a href="https://Medicine-and-health-careernetwork.oxfordjournals.org/job/director-clinical-research-computing-unit-crcu-standing-faculty-sr-ranks/68515001/20102/">Director, Clinical Research Computing Unit (CRCU) (Standing Faculty Sr. Ranks)</a></div>
+                    <div class="job-location">
+                        Philadelphia, Pennsylvania
+                    </div>
+                </div>
+                <div class="job">
+                    <div class="job-position"><a href="https://Medicine-and-health-careernetwork.oxfordjournals.org/job/autopsy-pathologist-and-clia-medical-director-leadership-opportunity-university-of-vermont-health-network/68711553/20102/">Autopsy Pathologist and CLIA Medical Director Leadership Opportunity University of Vermont Health Network</a></div>
+                    <div class="job-location">
+                        , Vermont
+                    </div>
+                </div>
+                <div class="job">
+                    <div class="job-position"><a href="https://Medicine-and-health-careernetwork.oxfordjournals.org/job/academic-surgical-pathologist/68938012/20102/">ACADEMIC SURGICAL PATHOLOGIST</a></div>
+                    <div class="job-location">
+                        , Vermont
+                    </div>
+                </div>
+        </div>
+        <div class="all-jobs"><a href="http://medicine-and-health-careernetwork.oxfordjournals.org/jobseeker/search/results/">View all jobs</a></div>
+
+    <div class="sponsor-and-jobnetwork-links">
+        <div class="job-sponsor"><a href="http://global.oup.com/"><img src="https://oup.silverchair-cdn.com/data/Multimedia/oup-logo.svg" alt="Oxford University Press"/></a></div>
+        <div class="job-network"><a href="http://globaljobs-careernetwork.oxfordjournals.org/home/index.cfm?site_id=20101"><img src="https://oup.silverchair-cdn.com/data/Multimedia/journals-careers-network.svg" alt="Journals Career Network"/></a></div>
+    </div>
+</div>
+ 
+    </div>
+
+    </div>
+
+</div>
+    </div>
+
+</div>    <div class="widget widget-AdBlock widget-instance-ArticlePageTopMainBodyBottom">
+        <div class="js-adBlock-parent-wrap">    
+    <div class="adBlockMainBodyBottom-wrap js-adBlockMainBodyBottom hide">
+    
+        <div id="adBlockMainBodyBottom" class="js-adblock at-adblock js-adblock-lazy-loading">
+            <script>
+                googletag.cmd.push(function () {
+                    googletag.display('adBlockMainBodyBottom');
+                });
+            </script>
+        </div>
+        <div class="advertisement-text at-adblock js-adblock-advertisement-text hide">Advertisement</div>
+    </div>
+</div> 
+    </div>
+
+</div>
+
+</div>
+<input id="hfArticleTitle" name="hfArticleTitle" type="hidden" value="" />
+<input id="hfLeftNavStickyOffset" name="hfLeftNavStickyOffset" type="hidden" value="29" />
+<input id="hfAreOpFeaturesEnabled" name="hfAreOpFeaturesEnabled" type="hidden" value="True" />
+
+
+
+                </div><!-- /.center-inner-row no-overflow -->
+            </section>
+    </div>
+
+        <div class="mobile-mask">
+        </div>
+
+        <section class="footer_wrap vt-site-footer">
+            
+
+
+    <div class="widget widget-SitePageFooter widget-instance-SitePageFooter">
+            <div class="ad-banner ad-banner-footer">
+    <div class="widget widget-AdBlock widget-instance-FooterAd">
+        <div class="js-adBlock-parent-wrap">    
+    <div class="adBlockFooter-wrap js-adBlockFooter hide">
+    
+        <div id="adBlockFooter" class="js-adblock at-adblock js-adblock-lazy-loading">
+            <script>
+                googletag.cmd.push(function () {
+                    googletag.display('adBlockFooter');
+                });
+            </script>
+        </div>
+        <div class="advertisement-text at-adblock js-adblock-advertisement-text hide">Advertisement</div>
+    </div>
+</div> 
+    </div>
+
+
+    <div class="widget widget-AdBlock widget-instance-StickyFooterAd">
+        <div class="js-adBlock-parent-wrap">    
+    <div class="adBlockStickyFooter-wrap js-adBlockStickyFooter hide">
+    
+        <div id="adBlockStickyFooter" class="js-adblock at-adblock js-adblock-lazy-loading">
+            <script>
+                googletag.cmd.push(function () {
+                    googletag.display('adBlockStickyFooter');
+                });
+            </script>
+        </div>
+        <div class="advertisement-text at-adblock js-adblock-advertisement-text hide">Advertisement</div>
+    </div>
+</div> 
+    </div>
+
+    </div>
+
+<div class="journal-footer journal-bg">
+    <div class="center-inner-row">
+
+<div class="journal-footer-menu">
+
+    <ul>
+<li class="link-1">
+    <a href="/brain/pages/About">About Brain</a>
+</li> <li class="link-2">
+    <a href="/brain/pages/Editorial_Board">Editorial Board</a>
+</li> <li class="link-3">
+    <a href="/brain/pages/General_Instructions">Author Guidelines</a>
+</li> <li class="link-4">
+    <a href="/brain/pages/Contact_the_editorial_office">Contact the editorial office</a>
+</li> <li class="link-5">
+    <a href="http://twitter.com/brain1878/">Twitter</a>
+</li> </ul><ul><li class="link-1">
+    <a href="https://www.youtube.com/channel/UClJJHH2xKQk8uZTC7-mJICg">YouTube</a>
+</li> <li class="link-2">
+    <a href="/brain/pages/brain_app">Brain app</a>
+</li> <li class="link-3">
+    <a href="http://guarantorsofbrain.org">Guarantors of Brain</a>
+</li> <li class="link-4">
+    <a href="/brain/subscribe">Purchase</a>
+</li> <li class="link-5">
+    <a href="http://www.oxfordjournals.org/en/library-recommendation-form.html">Recommend to your Library</a>
+</li> </ul><ul><li class="link-1">
+    <a href="https://academic.oup.com/advertising-and-corporate-services/pages/brain-media-kit">Mediakit</a>
+</li> <li class="link-2">
+    <a href="http://medicine-and-health-careernetwork.oxfordjournals.org">Journals Career Network</a>
+</li> 
+    </ul>
+
+
+</div><!-- /.journal-footer-menu -->
+        <div class="journal-footer-affiliations">
+            <!-- <h3>Affiliations</h3> -->
+<a href="" target="">
+    <img id="footer-logo-Brain" class="journal-footer-affiliations-logo" src="//oup.silverchair-cdn.com/data/SiteBuilderAssets/Live/Images/brain/brain_f1-1833597595.svg" alt="Brain" />
+</a>                        </div><!-- /.journal-footer-affiliations -->
+
+        <div class="journal-footer-colophon">
+            <ul>
+<li>Online ISSN 1460-2156</li>                <li>Print ISSN 0006-8950</li>                <li>Copyright &#169; 2023 Guarantors of Brain</li>
+            </ul>
+        </div><!-- /.journal-footer-colophon -->
+
+
+    </div><!-- /.center-inner-row -->
+</div><!-- /.journal-footer --> 
+    </div>
+
+    <div class="oup-footer">
+        <div class="center-inner-row">
+    <div class="widget widget-SelfServeContent widget-instance-OupUmbrellaFooterSelfServe">
+        
+
+
+
+    <input type="hidden" class="SelfServeContentId" value="GlobalFooter_Links" />
+    <input type="hidden" class="SelfServeVersionId" value="0" />
+
+<div class="oup-footer-row journal-links">
+<div class="global-footer selfservelinks">
+<ul>
+    <li><a href="/pages/about-oxford-academic">About Oxford Academic</a></li>
+    <li><a href="/pages/about-oxford-academic/publish-journals-with-us">Publish journals with us</a></li>
+    <li><a href="/pages/about-oxford-academic/our-university-press-partners">University press partners</a></li>
+    <li><a href="/pages/what-we-publish">What we publish</a></li>
+    <li><a href="/pages/new-features">New features</a>&nbsp;</li>
+</ul>
+</div>
+<div class="global-footer selfservelinks">
+<ul>
+    <li><a href="/pages/authoring">Authoring</a></li>
+    <li><a href="/pages/open-research/open-access">Open access</a></li>
+    <li><a href="/pages/purchasing">Purchasing</a></li>
+    <li><a href="/pages/institutional-account-management">Institutional account management</a></li>
+    <li><a href="https://academic.oup.com/pages/purchasing/rights-and-permissions">Rights and permissions</a></li>
+</ul>
+</div>
+<div class="global-footer selfservelinks">
+<ul>
+    <li><a href="/pages/get-help-with-access">Get help with access</a></li>
+    <li><a href="/pages/about-oxford-academic/accessibility">Accessibility</a></li>
+    <li><a href="/pages/contact-us">Contact us</a></li>
+    <li><a href="/pages/advertising">Advertising</a></li>
+    <li><a href="/pages/media-enquiries">Media enquiries</a></li>
+</ul>
+</div>
+<div class="global-footer selfservelinks global-footer-external">
+<ul>
+    <li><a href="https://global.oup.com/">Oxford University Press</a></li>
+    <li><a href="https://www.mynewsdesk.com/uk/oxford-university-press">News</a></li>
+    <li><a href="https://languages.oup.com/">Oxford Languages</a></li>
+    <li><a href="https://www.ox.ac.uk/">University of Oxford</a></li>
+</ul>
+</div>
+<div class="OUP-mission">
+<p>Oxford University Press is a department of the University of Oxford. It furthers the University's objective of excellence in research, scholarship, and education by publishing worldwide</p>
+<img class="journal-footer-logo" src="//oup.silverchair-cdn.com/UI/app/svg/umbrella/oup-logo.svg" alt="Oxford University Press" width="150" height="42" />
+</div>
+</div>
+<div class="oup-footer-row">
+<div class="oup-footer-row-links">
+<ul>
+    <li>Copyright © 2023 Oxford University Press</li>
+    <li><button id="Change-Preferences" type="button" onclick="window.top.document.dispatchEvent(new Event('changeConsent'))">Cookie settings</button></li>
+    <li><a href="https://global.oup.com/cookiepolicy">Cookie policy</a></li>
+    <li><a href="https://global.oup.com/privacy">Privacy policy</a></li>
+    <li><a href="/pages/legal-and-policy/legal-notice">Legal notice</a></li>
+</ul>
+</div>
+</div>
+<style type="text/css">
+    /* Issue right column fix for tablet/mobile */
+    @media (max-width: 1200px) {
+    .pg_issue .widget-instance-OUP_Issue {
+    width: 100%;
+    }
+    }
+    .sf-facet-list .sf-facet label,
+    .sf-facet-list .taxonomy-label-wrap label {
+    font-size: 0.9375rem;
+    }
+    .issue-pagination-wrap .pagination-container {
+    float: right;
+    }
+</style>
+
+
+
+ 
+    </div>
+
+        </div>
+    </div>
+    <div class="ss-ui-only">
+
+    </div>
+
+        </section>
+</div>
+
+
+
+
+
+
+    
+
+
+
+    <div class="widget widget-SiteWideModals widget-instance-SiteWideModals">
+        <div id="revealModal" class="reveal-modal" data-reveal>
+    <div id="revealContent"></div>
+    <a class="close-reveal-modal" href="javascript:;"><i class="icon-general-close"></i><span class="screenreader-text">Close</span></a>
+</div>
+
+<div id="globalModalContainer" class="modal-global-container">
+    <div id="globalModalContent">
+        <div class="js-globalModalPlaceholder"></div>
+    </div>
+    <a class="close-modal js-close-modal" href="javascript:;"><i class="icon-general-close"><span class="screenreader-text">Close</span></i></a>
+</div>
+<div id="globalModalOverlay" class="modal-overlay js-modal-overlay"></div>
+
+<div id="NeedSubscription" class="reveal-modal small" data-reveal>
+    <div class="subscription-needed">
+        <h5>This Feature Is Available To Subscribers Only</h5>
+        <p><a href="/sign-in">Sign In</a> or <a href="/my-account/register?siteId=5367&amp;returnUrl=%2fbrain%2farticle%2f129%2f10%2f2697%2f290089%3fsearchresult%3d1">Create an Account</a></p>
+    </div>
+    <a class="close-reveal-modal" href="javascript:;"><i class="icon-general-close"></i><span class="screenreader-text">Close</span></a>
+</div>
+
+<div id="noAccessReveal" class="reveal-modal tiny" data-reveal>
+    <p>This PDF is available to Subscribers Only</p>
+    <a class="hide-for-article-page" id="articleLinkToPurchase" data-reveal><span>View Article Abstract & Purchase Options</span></a>
+    <div class="issue-purchase-modal">
+        <p>For full access to this pdf, sign in to an existing account, or purchase an annual subscription.</p>
+    </div>
+    <a class="close-reveal-modal" href="javascript:;"><i class="icon-general-close"></i><span class="screenreader-text">Close</span></a>
+</div>
+ 
+    </div>
+
+    
+
+
+<script src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+
+
+<script src="//cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>
+
+    <!-- CookiePro Default Categories -->
+    <!-- When the Cookie Compliance code loads, if cookies for the associated group have consent...
+         it will dynamically change the tag to: script type=text/JavaScript...
+         the code inside the tags will then be recognized and run as normal. -->
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <script>
+        var NTPT_PGEXTRA = 'event_type=full-text\u0026supplier_tag=SC_Journals\u0026object_type=Article\u0026taxonomy=taxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aSCI01870%7cnodeLabel%3aNeuroscience%7cnodeLevel%3a2%3btaxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aMED00310%7cnodeLabel%3aNeurology%7cnodeLevel%3a2\u0026siteid=brainj\u0026authentication_method=IP\u0026authzrequired=false\u0026account_id=22482551\u0026account_list=22482551,20003025,20001100,20058187\u0026result_click=true\u0026authnips=136.62.3.74\u0026doi=10.1093/brain/awl181';
+    </script>
+    <!-- Copyright 2001-2010, IBM Corporation All rights reserved. -->
+    <script type="text/javascript" src="//ouptag.scholarlyiq.com/ntpagetag.js" class="optanon-category-C0002"></script>
+        <noscript>
+            <img src="//ouptag.scholarlyiq.com/ntpagetag.gif?js=0" height="1" width="1" border="0" hspace="0" vspace="0" alt="Scholarly IQ" />
+        </noscript>
+
+
+
+
+
+
+
+
+
+
+    <script type="text/javascript" src="//oup.silverchair-cdn.com/Themes/Client/app/jsdist/v-638216042113932239/site.min.js"></script>
+
+
+    
+    
+    
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/chartist.js/latest/chartist.min.js"></script>
+
+    <script type="text/javascript" src="//oup.silverchair-cdn.com/Themes/Client/app/jsdist/v-638216041991781897/article-page.min.js"></script>
+
+
+
+    
+
+    
+    
+
+
+
+
+    <div class="ad-banner js-ad-riser ad-banner-riser">
+
+    <div class="widget widget-AdBlock widget-instance-RiserAd">
+            
+
+ 
+    </div>
+
+    </div>
+
+
+
+    </body>
+</html>
+

--- a/ace/tests/data/cerebral_cortex.html
+++ b/ace/tests/data/cerebral_cortex.html
@@ -1,0 +1,2103 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+
+<head>
+
+
+
+
+<script src="https://www.cdn.privado.ai/b230e0658a2d4f23bd9374dc1930f2c9.js" type="text/javascript" ></script>
+
+
+
+                
+        <title>Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation | Cerebral Cortex | Oxford Academic</title>
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js" type="text/javascript"></script>
+<script>window.jQuery || document.write('<script src="//oup.silverchair-cdn.com/Themes/Silver/app/js/jquery.2.2.4.min.js" type="text/javascript">\x3C/script>')</script>
+<script src="//oup.silverchair-cdn.com/Themes/Silver/app/vendor/v-638201282110071850/jquery-migrate-1.4.1.min.js" type="text/javascript"></script>    <script type='text/javascript' src='https://platform-api.sharethis.com/js/sharethis.js#property=643701de45aa460012e1032e&amp;product=sop' async='async'></script>
+
+
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10" />
+
+    
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+    <!-- Turn off telephone number detection. -->
+    <meta name="format-detection" content="telephone=no" />
+
+<!-- Bookmark Icons -->
+  <link rel="apple-touch-icon" sizes="180x180" href="//oup.silverchair-cdn.com/UI/app/img/v-638201281749154420/apple-touch-icon.png">
+  <link rel="icon" type="image/png" href="//oup.silverchair-cdn.com/UI/app/img/v-638201281749254392/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="//oup.silverchair-cdn.com/UI/app/img/v-638201281749204451/favicon-16x16.png" sizes="16x16">
+  <link rel="mask-icon" href="//oup.silverchair-cdn.com/UI/app/img/v-638201281749554598/safari-pinned-tab.svg" color="#5bbad5">
+  <link rel="icon" href="//oup.silverchair-cdn.com/UI/app/img/v-638201281749304381/favicon.ico">
+  <link rel="manifest" href="//oup.silverchair-cdn.com/UI/app/img/v-638201281749404395/manifest.json">
+  <meta name="msapplication-config" content="//oup.silverchair-cdn.com/UI/app/img/v-638201281749154420/browserconfig.xml">
+  <meta name="theme-color" content="#002f65">
+
+
+    
+
+
+
+
+<link rel="stylesheet" type="text/css" href="//oup.silverchair-cdn.com/UI/app/fonts/icons.css" />
+
+<link rel="stylesheet" type="text/css" href="//oup.silverchair-cdn.com/Themes/Client/app/css/v-638216041963981730/site.min.css" />
+
+        <link rel="stylesheet" type="text/css" href="//oup.silverchair-cdn.com/Themes/Client/app/vendor/jscrollpane/v-638201281748404445/jscrollpane.css" />
+        <link rel="stylesheet" type="text/css" href="//oup.silverchair-cdn.com/Themes/Client/app/vendor/jquery.tablesorter/v-638201281748404445/theme.default.css" />
+
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300,400,400italic,700,700italic|Source+Sans+Pro:400,400italic,700,700italic" />
+
+
+        <link href="//oup.silverchair-cdn.com/data/SiteBuilderAssetsOriginals/Live/CSS/journals/v-638217285138027635/global.css" rel="stylesheet" type="text/css" />
+            <link href="//oup.silverchair-cdn.com/data/SiteBuilderAssets/Live/CSS/cercor/v-637517646740837896/Site.css" rel="stylesheet" type="text/css" />
+
+
+
+<script> var dataLayer = [{"full_title":"Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation","short_title":"Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation","authors":"Maureen Ritchey,Florin Dolcos,Roberto Cabeza","event_type":"full-text","supplier_tag":"SC_Journals","object_type":"Article","taxonomy":"taxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aSCI01870%7cnodeLabel%3aNeuroscience%7cnodeLevel%3a2%3btaxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aMED00385%7cnodeLabel%3aClinical+Neuroscience%7cnodeLevel%3a2%3btaxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aMED00310%7cnodeLabel%3aNeurology%7cnodeLevel%3a2","siteid":"cercor","authentication_method":"IP","authzrequired":"false","account_id":"22482551","account_list":"22482551,20003025,20001100,20058187","result_click":"true","authnips":"6QBp1vEPWYkq92K9JFrXNg==","doi":"10.1093/cercor/bhm262"}]; </script>
+            <script>
+                (function (w, d, s, l, i) {
+                    w[l] = w[l] || []; w[l].push({
+                        'gtm.start':
+                            new Date().getTime(), event: 'gtm.js'
+                    }); var f = d.getElementsByTagName(s)[0],
+                        j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
+                        j.setAttribute('type', 'text/javascript');
+                        j.setAttribute('class', 'optanon-category-C0002');
+                        j.async = true; j.src =
+                        'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+                })(window, document, 'script', 'dataLayer', 'GTM-W6DD7HV');
+            </script>
+
+    
+
+        <script type="text/javascript">
+            var App = App || {};
+            App.LoginUserInfo = {
+                isInstLoggedIn: 1,
+                isIndividualLoggedIn: 0
+            };
+
+            App.CurrentSubdomain = 'cercor';
+            App.SiteURL = 'academic.oup.com/cercor';
+        </script>
+    
+    
+    <link href="https://cdn.jsdelivr.net/chartist.js/latest/chartist.min.css" rel="stylesheet" type="text/css" />
+    <script type="application/ld+json">
+        {"@context":"https://schema.org","@type":"ScholarlyArticle","@id":"https://academic.oup.com/cercor/article/18/11/2494/290170","name":"Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation","about":["emotions","amygdala","memory","functional magnetic resonance imaging"],"datePublished":"2008-03-28","isPartOf":{"@id":"https://academic.oup.com/cercor/cercor/issue/18/11","@type":"PublicationIssue","issueNumber":"11","datePublished":"2008-11-01","isPartOf":{"@id":"https://academic.oup.com/cercor/cercor","@type":"Periodical","name":"Cerebral Cortex","issn":["1460-2199"]}},"url":"https://dx.doi.org/10.1093/cercor/bhm262","keywords":["emotions","amygdala","memory","functional magnetic resonance imaging","affect","arousal","connectivity","consolidation","emotional memory"],"inLanguage":"en","copyrightHolder":"Oxford University Press","copyrightYear":"2023","publisher":"Oxford University Press","sameAs":"","author":[{"name":"Ritchey, Maureen","affiliation":"1 Center for Cognitive Neuroscience   2 Department of Psychology and Neuroscience","@type":"Person"},{"name":"Dolcos, Florin","affiliation":"1 Center for Cognitive Neuroscience   3 Brain Imaging and Analysis Center, Duke University, Durham, NC 27708, USA   4 Current address: Department of Psychiatry, University of Alberta, Edmonton, Alberta, T6G 2G3 Canada","@type":"Person"},{"name":"Cabeza, Roberto","affiliation":"1 Center for Cognitive Neuroscience   2 Department of Psychology and Neuroscience","@type":"Person"}],"description":"Abstract. According to the consolidation hypothesis, enhanced memory for emotional information reflects the modulatory effect of the amygdala on the medial temp","pageStart":"2494","pageEnd":"2504","siteName":"OUP Academic","thumbnailURL":"https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/m_cercorbhm262f01_ht.jpeg?Expires=1749525393&Signature=H-22tgdUxMK1uFFxTcX3KRt5JxMGJ56K~xbhMhMPe6rnzHHIqTNr4FnmF7AnN19WM3rT9OK2z2JGs3NNXCn1oh1dGLB2oXE1segrQEwIWwv-tiRv5iDaL~otv2JCd81OLkUET4Uo2B09B08~G9r0bly8at0iRtpDVBoZSUoQg1Op9vK6YJ5cbBAnInNsUZ8L9lEm5eK5uRxSBDe65mmNsWMkxFRDlxrJ3olXXTxjUd3ZHDQX1~3~Cojv6byIScWyYjDySYD4UBww7VvbBBTrAXwRcpNJ45gBmQ6WRhSme~nT7uJHQqB~z8mFzBQ9LY5m-WurAW27jtQVHOrNZ3xYgw__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA","headline":"Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation","image":"https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/m_cercorbhm262f01_ht.jpeg?Expires=1749525393&Signature=H-22tgdUxMK1uFFxTcX3KRt5JxMGJ56K~xbhMhMPe6rnzHHIqTNr4FnmF7AnN19WM3rT9OK2z2JGs3NNXCn1oh1dGLB2oXE1segrQEwIWwv-tiRv5iDaL~otv2JCd81OLkUET4Uo2B09B08~G9r0bly8at0iRtpDVBoZSUoQg1Op9vK6YJ5cbBAnInNsUZ8L9lEm5eK5uRxSBDe65mmNsWMkxFRDlxrJ3olXXTxjUd3ZHDQX1~3~Cojv6byIScWyYjDySYD4UBww7VvbBBTrAXwRcpNJ45gBmQ6WRhSme~nT7uJHQqB~z8mFzBQ9LY5m-WurAW27jtQVHOrNZ3xYgw__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA","image:alt":"Behavioral results. Memory at each delay was assessed using the corrected recognition score d‘, and recollection and familiarity estimates were obtained via a dual-process ROC curve-fitting procedure (Yonelinas et al. 1998). Persistence scores for memory, recollection, and familiarity were then calculated by dividing long-delay estimates by their associated short-delay estimates (e.g., emotional memory persistence is equivalent to emotional long-delay d‘ divided by emotional short-delay d‘). Recollection persistence scores were significantly greater for emotional than neutral items, suggesting an emotional recollection effect. Error bars indicate standard error of the mean. *Significant at P = 0.05."}
+    </script>
+<meta property="og:site_name" content="OUP Academic" />
+<meta property="og:title" content="Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation" />
+<meta property="og:description" content="Abstract. According to the consolidation hypothesis, enhanced memory for emotional information reflects the modulatory effect of the amygdala on the medial temp" />
+<meta property="og:type" content="article" />
+<meta property="og:url" content="https://dx.doi.org/10.1093/cercor/bhm262" />
+<meta property="og:updated_time" content="" />
+<meta property="og:image" content="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/m_cercorbhm262f01_ht.jpeg?Expires=1749525393&Signature=H-22tgdUxMK1uFFxTcX3KRt5JxMGJ56K~xbhMhMPe6rnzHHIqTNr4FnmF7AnN19WM3rT9OK2z2JGs3NNXCn1oh1dGLB2oXE1segrQEwIWwv-tiRv5iDaL~otv2JCd81OLkUET4Uo2B09B08~G9r0bly8at0iRtpDVBoZSUoQg1Op9vK6YJ5cbBAnInNsUZ8L9lEm5eK5uRxSBDe65mmNsWMkxFRDlxrJ3olXXTxjUd3ZHDQX1~3~Cojv6byIScWyYjDySYD4UBww7VvbBBTrAXwRcpNJ45gBmQ6WRhSme~nT7uJHQqB~z8mFzBQ9LY5m-WurAW27jtQVHOrNZ3xYgw__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" />
+<meta property="og:image:url" content="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/m_cercorbhm262f01_ht.jpeg?Expires=1749525393&Signature=H-22tgdUxMK1uFFxTcX3KRt5JxMGJ56K~xbhMhMPe6rnzHHIqTNr4FnmF7AnN19WM3rT9OK2z2JGs3NNXCn1oh1dGLB2oXE1segrQEwIWwv-tiRv5iDaL~otv2JCd81OLkUET4Uo2B09B08~G9r0bly8at0iRtpDVBoZSUoQg1Op9vK6YJ5cbBAnInNsUZ8L9lEm5eK5uRxSBDe65mmNsWMkxFRDlxrJ3olXXTxjUd3ZHDQX1~3~Cojv6byIScWyYjDySYD4UBww7VvbBBTrAXwRcpNJ45gBmQ6WRhSme~nT7uJHQqB~z8mFzBQ9LY5m-WurAW27jtQVHOrNZ3xYgw__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" />
+<meta property="og:image:secure_url" content="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/m_cercorbhm262f01_ht.jpeg?Expires=1749525393&Signature=H-22tgdUxMK1uFFxTcX3KRt5JxMGJ56K~xbhMhMPe6rnzHHIqTNr4FnmF7AnN19WM3rT9OK2z2JGs3NNXCn1oh1dGLB2oXE1segrQEwIWwv-tiRv5iDaL~otv2JCd81OLkUET4Uo2B09B08~G9r0bly8at0iRtpDVBoZSUoQg1Op9vK6YJ5cbBAnInNsUZ8L9lEm5eK5uRxSBDe65mmNsWMkxFRDlxrJ3olXXTxjUd3ZHDQX1~3~Cojv6byIScWyYjDySYD4UBww7VvbBBTrAXwRcpNJ45gBmQ6WRhSme~nT7uJHQqB~z8mFzBQ9LY5m-WurAW27jtQVHOrNZ3xYgw__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" />
+<meta property="og:image:alt" content="Behavioral results. Memory at each delay was assessed using the corrected recognition score d‘, and recollection and familiarity estimates were obtained via a dual-process ROC curve-fitting procedure (Yonelinas et al. 1998). Persistence scores for memory, recollection, and familiarity were then calculated by dividing long-delay estimates by their associated short-delay estimates (e.g., emotional memory persistence is equivalent to emotional long-delay d‘ divided by emotional short-delay d‘). Recollection persistence scores were significantly greater for emotional than neutral items, suggesting an emotional recollection effect. Error bars indicate standard error of the mean. *Significant at P = 0.05." />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="citation_author" content="Ritchey, Maureen" /><meta name="citation_author_institution" content="Center for Cognitive Neuroscience" /><meta name="citation_author_institution" content="Department of Psychology and Neuroscience" /><meta name="citation_author" content="Dolcos, Florin" /><meta name="citation_author_institution" content="Center for Cognitive Neuroscience" /><meta name="citation_author_institution" content="Brain Imaging and Analysis Center, Duke University, Durham, NC 27708, USA" /><meta name="citation_author_institution" content="Current address: Department of Psychiatry, University of Alberta, Edmonton, Alberta, T6G 2G3 Canada" /><meta name="citation_author" content="Cabeza, Roberto" /><meta name="citation_author_institution" content="Center for Cognitive Neuroscience" /><meta name="citation_author_institution" content="Department of Psychology and Neuroscience" /><meta name="citation_title" content="Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation" /><meta name="citation_firstpage" content="2494" /><meta name="citation_lastpage" content="2504" /><meta name="citation_doi" content="10.1093/cercor/bhm262" /><meta name="citation_keyword" content="memory" /><meta name="citation_journal_title" content="Cerebral Cortex" /><meta name="citation_journal_abbrev" content="Cereb Cortex" /><meta name="citation_volume" content="18" /><meta name="citation_issue" content="11" /><meta name="citation_publication_date" content="2008/11/01" /><meta name="citation_issn" content="1047-3211" /><meta name="citation_publisher" content="Oxford Academic" /><meta name="citation_reference" content="citation_title=Episodic memory, amnesia and the hippocampal-anterior thalamic axis; Behav Brain Sci;  citation_year=1999;  citation_volume=22;  citation_pages=425-444; " /><meta name="citation_reference" content="citation_title=Dissociated neural representations of intensity and valence in human olfaction; Nat Neurosci;  citation_year=2003;  citation_volume=6;  citation_pages=196-202; " /><meta name="citation_reference" content="citation_title=Emotional memories are not all created equal: evidence for selective memory enhancement; Learn Mem;  citation_year=2006;  citation_volume=13;  citation_pages=711-718; " /><meta name="citation_reference" content="citation_title=The amygdala is involved in the modulation of long-term memory, but not in working or short-term memory; Neurobiol Learn Mem;  citation_year=1999;  citation_volume=71;  citation_pages=127-131; " /><meta name="citation_reference" content="citation_title=Sex-related influences on the neurobiology of emotionally influenced memory; Ann N Y Acad Sci;  citation_year=2003;  citation_volume=985;  citation_pages=163-173; " /><meta name="citation_reference" content="citation_title=Amygdala activity at encoding correlated with long-term, free recall of emotional information; Proc Natl Acad Sci USA;  citation_year=1996;  citation_volume=93;  citation_pages=8016-8021; " /><meta name="citation_reference" content="citation_title=Event-related activation in the human amygdala associates with later memory for individual emotional experience; J Neurosci;  citation_year=2000;  citation_volume=20;  citation_pages=5" /><meta name="citation_reference" content="citation_title=Triple dissociation in the medial temporal lobes: recollection, familiarity, and novelty; J Neurophysiol;  citation_year=2006;  citation_volume=96;  citation_pages=1902-1911; " /><meta name="citation_reference" content="citation_title=Effects of healthy aging on hippocampal and rhinal memory functions: an event-related fMRI study; Cereb Cortex;  citation_year=2006;  citation_volume=16;  citation_pages=1771-1782; " /><meta name="citation_reference" content="citation_title=Multiple routes to memory: distinct medial temporal lobe processes build item and source memories; Proc Natl Acad Sci USA;  citation_year=2003;  citation_volume=100;  citation_pages=2157-2162; " /><meta name="citation_reference" content="citation_title=Amygdala automaticity in emotional processing; Ann N Y Acad Sci;  citation_year=2003;  citation_volume=985;  citation_pages=348-355; " /><meta name="citation_reference" content="citation_title=Dissociable effects of arousal and valence on prefrontal activity indexing emotional evaluation and subsequent memory: an event-related fMRI study; Neuroimage;  citation_year=2004;  citation_volume=23;  citation_pages=64-74; " /><meta name="citation_reference" content="citation_title=Interaction between the amygdala and the medial temporal lobe memory system predicts better memory for emotional events; Neuron;  citation_year=2004;  citation_volume=42;  citation_pages=855-863; " /><meta name="citation_reference" content="citation_title=Remembering one year later: role of the amygdala and medial temporal lobe memory system in retrieving emotional memories; Proc Natl Acad Sci USA;  citation_year=2005;  citation_volume=102;  citation_pages=2626-2631; " /><meta name="citation_reference" content="citation_title=The medial temporal lobe and recognition memory; Annu Rev Neurosci;  citation_year=2007;  citation_volume=30;  citation_pages=123-152; " /><meta name="citation_reference" content="citation_title=On the “probable error” of a coefficient of correlation deduced from a small sample; Metron;  citation_year=1921;  citation_volume=1;  citation_pages=3-32; " /><meta name="citation_reference" content="citation_publisher=Oliver and Boyd, London; Statistical methods for research workers;  citation_year=1950;  citation_pages=354" /><meta name="citation_reference" content="citation_title=The role of left prefrontal cortex in language and memory; Proc Natl Acad Sci USA;  citation_year=1998;  citation_volume=95;  citation_pages=906-913; " /><meta name="citation_reference" content="citation_title=Cognitive and neural mechanisms of emotional memory; Trends Cogn Sci;  citation_year=2001;  citation_volume=5;  citation_pages=394-400; " /><meta name="citation_reference" content="citation_title=Amygdala activity related to enhanced memory for pleasant and aversive stimuli; Nat Neurosci;  citation_year=1999;  citation_volume=2;  citation_pages=289-293; " /><meta name="citation_reference" content="citation_title=Emotion enhances learning via norepinephrine regulation of AMPA-receptor trafficking; Cell;  citation_year=2007;  citation_volume=131;  citation_pages=160-173; " /><meta name="citation_reference" content="citation_title=Remembering emotional experiences: the contribution of valence and arousal; Rev Neurosci;  citation_year=2004;  citation_volume=15;  citation_pages=241-253; " /><meta name="citation_reference" content="citation_title=Memory enhancement for emotional words: are emotional words more vividly remembered than neutral words?; Mem Cognit;  citation_year=2003;  citation_volume=31;  citation_pages=1169-1180; " /><meta name="citation_reference" content="citation_title=Two routes to emotional memory: distinct neural processes for valence and arousal; Proc Natl Acad Sci USA;  citation_year=2004;  citation_volume=101;  citation_pages=3310-3315; " /><meta name="citation_reference" content="citation_title=Amygdala activity is associated with the successful encoding of item, but not source, information for positive and negative stimuli; J Neurosci;  citation_year=2006;  citation_volume=26;  citation_pages=2564-2570; " /><meta name="citation_reference" content="citation_title=Amygdala modulation of parahippocampal and frontal regions during emotionally influenced memory storage; Neuroimage;  citation_year=2003;  citation_volume=20;  citation_pages=2091-2099; " /><meta name="citation_reference" content="citation_title=Paired-associate learning as a function of arousal and interpolated interval; J Exp Psychol;  citation_year=1963;  citation_volume=65;  citation_pages=190-193; " /><meta name="citation_reference" content="citation_title=Cognitive neuroscience of emotional memory; Nat Rev Neurosci;  citation_year=2006;  citation_volume=7;  citation_pages=54-64; " /><meta name="citation_reference" content="citation_title=Arousal-mediated memory consolidation: role of the medial temporal lobe in humans; Psychol Sci;  citation_year=1998;  citation_volume=9;  citation_pages=490-493; " /><meta name="citation_reference" content="citation_text=Report No.: A-5; citation_publisher=The Center for Research in Psychophysiology, University of Florida., Gainesville, FL; International Affective Picture System (IAPS): Instruction Manual and Affective Ratings;  citation_year=2001; " /><meta name="citation_reference" content="citation_title=Combining brains: a survey of methods for statistical pooling of information; Neuroimage;  citation_year=2002;  citation_volume=16;  citation_pages=538-550; " /><meta name="citation_reference" content="citation_title=The effect of anticipation and the specificity of sex differences for amygdala and hippocampus function in emotional memory; Proc Natl Acad Sci USA;  citation_year=2006;  citation_volume=103;  citation_pages=14200-14205; " /><meta name="citation_reference" content="citation_title=The amygdala modulates the consolidation of memories of emotionally arousing experiences; Annu Rev Neurosci;  citation_year=2004;  citation_volume=27;  citation_pages=1-28; " /><meta name="citation_reference" content="citation_title=Amygdala modulation of memory consolidation: interaction with other brain systems; Neurobiol Learn Mem;  citation_year=2002;  citation_volume=78;  citation_pages=539-552; " /><meta name="citation_reference" content="citation_title=Role of the basolateral amygdala in memory consolidation; Ann N Y Acad Sci;  citation_year=2003;  citation_volume=985;  citation_pages=273-293; " /><meta name="citation_reference" content="citation_title=Amygdala stimulation modulates hippocampal synaptic plasticity; Proc Natl Acad Sci USA;  citation_year=2004;  citation_volume=101;  citation_pages=14270-14275; " /><meta name="citation_reference" content="citation_title=Are affective events richly recollected or simply familiar? The experience and process of recognizing feelings past; J Exp Psychol Gen;  citation_year=2000;  citation_volume=129;  citation_pages=242-261; " /><meta name="citation_reference" content="citation_title=Observing the transformation of experience into memory; Trends Cogn Sci;  citation_year=2002;  citation_volume=6;  citation_pages=93-102; " /><meta name="citation_reference" content="citation_title=Amygdalo-entorhinal relations and their reflection in the hippocampal formation: generation of sharp sleep potentials; J Neurosci;  citation_year=1995;  citation_volume=15;  citation_pages=2482-2503; " /><meta name="citation_reference" content="citation_title=Emotional enhancement of memory via amygdala-driven facilitation of rhinal interactions; Nat Neurosci;  citation_year=2006;  citation_volume=9;  citation_pages=1321-1329; " /><meta name="citation_reference" content="citation_title=Lasting increases in basolateral amygdala activity after emotional arousal: implications for facilitated consolidation of emotional memories; Learn Mem;  citation_year=2005;  citation_volume=12;  citation_pages=96-102; " /><meta name="citation_reference" content="citation_title=Dissociable correlates of recollection and familiarity within the medial temporal lobes; Neuropsychologia;  citation_year=2004;  citation_volume=42;  citation_pages=2-13; " /><meta name="citation_reference" content="citation_title=Encoding of emotional memories depends on amygdala and hippocampus and their interactions; Nat Neurosci;  citation_year=2004;  citation_volume=7;  citation_pages=278-285; " /><meta name="citation_reference" content="citation_title=Measuring functional connectivity during distinct stages of a cognitive task; Neuroimage;  citation_year=2004;  citation_volume=23;  citation_pages=752-763; " /><meta name="citation_reference" content="citation_title=Basolateral amygdala lesions block the memory-enhancing effect of 8-Br-cAMP infused into the entorhinal cortex of rats after training; Eur J Neurosci;  citation_year=2002;  citation_volume=15;  citation_pages=905-910; " /><meta name="citation_reference" content="citation_title=Basolateral amygdala noradrenergic influence enables enhancement of memory consolidation induced by hippocampal glucocorticoid receptor activation; Proc Natl Acad Sci USA;  citation_year=1999;  citation_volume=96;  citation_pages=11642-11647; " /><meta name="citation_reference" content="citation_title=How emotion enhances the feeling of remembering; Nat Neurosci;  citation_year=2004;  citation_volume=7;  citation_pages=1376-1380; " /><meta name="citation_reference" content="citation_title=How arousal modulates memory: disentangling the effects of attention and retention; Cogn Affect Behav Neurosci;  citation_year=2004;  citation_volume=4;  citation_pages=294-306; " /><meta name="citation_reference" content="citation_title=Differential time-dependent effects of emotion on recollective experience and memory for contextual information; Cognition;  citation_year=2008;  citation_volume=106;  citation_pages=538-547; " /><meta name="citation_reference" content="citation_title=Dissociable prefrontal brain systems for attention and emotion; Proc Natl Acad Sci USA;  citation_year=2002;  citation_volume=99;  citation_pages=11447-11451; " /><meta name="citation_reference" content="citation_title=Recollection and familiarity deficits in amnesia: convergence of remember-know, process dissociation, and receiver operating characteristic data; Neuropsychology;  citation_year=1998;  citation_volume=12;  citation_pages=323-339; " /><meta name="citation_fulltext_world_readable" content="" /><meta name="citation_pdf_url" content="https://academic.oup.com/cercor/article-pdf/18/11/2494/819207/bhm262.pdf" /><meta name="description" content="Abstract. According to the consolidation hypothesis, enhanced memory for emotional information reflects the modulatory effect of the amygdala on the medial temp" /><meta name="citation_xml_url" content="https://academic.oup.com/cercor/article-xml/18/11/2494/290170" />
+
+
+    <link rel="canonical" href="https://academic.oup.com/cercor/article/18/11/2494/290170" />
+
+
+
+
+
+
+
+
+
+
+
+
+    
+
+
+
+<script async="async" src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+<script>
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+</script>
+    
+        <script type='text/javascript'>
+            var gptAdSlots = [];
+            googletag.cmd.push(function() {
+                    
+                    var mapping_ad1 = googletag.sizeMapping()
+                        .addSize([1024, 0], [[970, 90], [728, 90]])
+                        .addSize([768, 0], [728, 90])
+                        .addSize([0, 0], [320, 50])
+                        .build();
+                    gptAdSlots["ad1"] = googletag.defineSlot('/116097782/cercor_Behind_Ad1',
+                            [[970, 90], [728, 90], [320, 50]], 'adBlockHeader')
+                        .defineSizeMapping(mapping_ad1)
+                        .addService(googletag.pubads());
+                    
+
+                    
+                    var mapping_ad2 = googletag.sizeMapping()
+                        .addSize([768, 0], [[300, 250], [300, 600], [160, 600]])
+                        .build();
+                    gptAdSlots["ad2"] = googletag.defineSlot('/116097782/cercor_Behind_Ad2',
+                            [[300, 250], [160, 600], [300, 600]], 'adBlockMainBodyTop')
+                        .defineSizeMapping(mapping_ad2)
+                        .addService(googletag.pubads());
+                    
+
+                    
+                    var mapping_ad3 = googletag.sizeMapping()
+                        .addSize([768, 0], [[300, 250], [300, 600], [160, 600]])
+                        .build();
+                    gptAdSlots["ad3"] = googletag.defineSlot('/116097782/cercor_Behind_Ad3',
+                        [[300, 250], [160, 600], [300, 600]], 'adBlockMainBodyBottom')
+                        .defineSizeMapping(mapping_ad3)
+                        .addService(googletag.pubads());
+                    
+
+                    
+                var mapping_ad4 = googletag.sizeMapping()
+                        .addSize([0,0], [320, 50])
+                        .addSize([768, 0], [728, 90])
+                        .build();
+                    gptAdSlots["ad4"] = googletag.defineSlot('/116097782/cercor_Behind_Ad4',
+                        [728, 90], 'adBlockFooter')
+                        .defineSizeMapping(mapping_ad4)
+                        .addService(googletag.pubads());
+                    
+
+                    
+                var mapping_ad6 = googletag.sizeMapping()
+                        .addSize([1024, 0], [[970, 90], [728, 90]])
+                        .addSize([0, 0], [[320, 50], [300, 50]])
+                        .build();
+                    gptAdSlots["ad6"] = googletag.defineSlot('/116097782/cercor_Behind_Ad6',
+                        [[728, 90], [970, 90]], 'adBlockStickyFooter')
+                        .defineSizeMapping(mapping_ad6)
+                        .addService(googletag.pubads());
+                    
+
+                    
+                    gptAdSlots["adInterstital"] = googletag.defineOutOfPageSlot('/116097782/cercor_Interstitial_Ad',
+                        googletag.enums.OutOfPageFormat.INTERSTITIAL)
+                        .addService(googletag.pubads());
+                                        
+
+                googletag.pubads().addEventListener('slotRenderEnded', function (event) {
+                    if (!event.isEmpty) {
+                        $('.js-' + event.slot.getSlotElementId()).each(function () {
+                            if ($(this).find('iframe').length) {
+                                $(this).removeClass('hide');
+                            }
+                        });
+                    }
+                });
+
+                googletag.pubads().addEventListener('impressionViewable', function (event) {
+                    if (!event.isEmpty) {
+                        $('.js-' + event.slot.getSlotElementId()).each(function () {
+                            var $adblockDiv = $(this).find('.js-adblock');
+                            var $adText = $(this).find('.js-adblock-advertisement-text');
+                            if ($adblockDiv && $adblockDiv.is(':visible') && $adblockDiv.find('*').length > 1) {
+                                $adText.removeClass('hide');
+                                App.CenterAdBlock.Init($adblockDiv, $adText);
+                            }
+                            else {
+                                $adText.addClass('hide');
+                            }
+                        });
+                    }
+                });
+
+                googletag.pubads().setTargeting("jnlspage", "article");
+                googletag.pubads().setTargeting("jnlsurl", "cercor/article/18/11/2494/290170");
+                googletag.pubads().enableSingleRequest();
+                googletag.pubads().disableInitialLoad();
+                googletag.pubads().collapseEmptyDivs();
+            });
+        </script>
+    
+<input type="hidden"
+       class="hfInterstitial"
+       data-interstitiallinks="cercor/issue,cercor/advance-articles,cercor/advance-article,cercor/supplements,cercor/article,cercor/article-abstract,cercor/pages"
+       data-subdomain="cercor"/>
+    
+    
+        <script type="text/javascript">
+                googletag.cmd.push(function () {
+                    
+                    googletag.pubads().setTargeting("jnlsdoi", "10.1093/cercor/bhm262");
+                    googletag.enableServices();
+                });
+        </script>
+
+
+
+
+    
+
+
+    <script type="text/javascript">
+        var NTPT_PGEXTRA= 'event_type=full-text&supplier_tag=SC_Journals&object_type=Article&taxonomy=taxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aSCI01870%7cnodeLabel%3aNeuroscience%7cnodeLevel%3a2%3btaxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aMED00385%7cnodeLabel%3aClinical+Neuroscience%7cnodeLevel%3a2%3btaxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aMED00310%7cnodeLabel%3aNeurology%7cnodeLevel%3a2&siteid=cercor&authentication_method=IP&authzrequired=false&account_id=22482551&account_list=22482551,20003025,20001100,20058187&result_click=true&authnips=136.62.3.74&doi=10.1093/cercor/bhm262';
+    </script>
+
+
+
+
+    <script src="https://scholar.google.com/scholar_js/casa.js" async></script>
+</head>
+
+<body data-sitename="cerebralcortex" class="off-canvas pg_Article pg_article   " theme-cercor data-sitestyletemplate="Journal" >
+            <noscript>
+                <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W6DD7HV"
+                        height="0" width="0" style="display:none;visibility:hidden"></iframe>
+            </noscript>
+            <a href="#skipNav" class="skipnav">Skip to Main Content</a>
+<input id="hdnSiteID" name="hdnSiteID" type="hidden" value="5122" /><input id="hdnAdDelaySeconds" name="hdnAdDelaySeconds" type="hidden" value="5000" /><input id="hdnAdConfigurationTop" name="hdnAdConfigurationTop" type="hidden" value="scrolldelay" /><input id="hdnAdConfigurationRightRail" name="hdnAdConfigurationRightRail" type="hidden" value="sticky" />
+    
+
+
+
+
+
+
+<div class="master-container js-master-container">
+<section class="master-header row js-master-header vt-site-page-header">
+    <div class="widget widget-SitePageHeader widget-instance-SitePageHeader">
+        
+
+    <div class="ad-banner js-ad-banner-header">
+    <div class="widget widget-AdBlock widget-instance-HeaderAd">
+        <div class="js-adBlock-parent-wrap">    
+    <div class="adBlockHeader-wrap js-adBlockHeader hide">
+    
+        <div id="adBlockHeader" class="js-adblock at-adblock">
+            <script>
+                googletag.cmd.push(function () {
+                    googletag.display('adBlockHeader');
+                });
+            </script>
+        </div>
+        <div class="advertisement-text at-adblock js-adblock-advertisement-text hide">Advertisement</div>
+    </div>
+</div> 
+    </div>
+
+    </div>
+
+    <div class="oup-header sigma ">
+        <div class="center-inner-row">
+
+<div class="oup-header-logo">
+
+        <a href="/">
+            <img src="//oup.silverchair-cdn.com/UI/app/svg/umbrella/oxford-academic-logo.svg" alt="Oxford Academic"
+                 class="oup-header-image at-oup-header-image " />
+        </a>
+
+</div>                <div class="widget widget-CustomNavLinks widget-instance-CustomNavLinksDeskTop">
+            <div class="custom-nav-links-box">
+            <div class="custom-nav-link">
+                <a href="/journals">Journals</a>
+            </div>
+            <div class="custom-nav-link">
+                <a href="/books">Books</a>
+            </div>
+
+    </div>
+ 
+    </div>
+            <ul class="oup-header-menu account-menu sigma-account-menu ">
+
+                
+                <li class="oup-header-menu-item mobile">
+                    <a href="javascript:;" class="mobile-dropdown-toggle mobile-search-toggle">
+                        <i class="icon-menu_search"><span class="screenreader-text">Search Menu</span></i>
+                    </a>
+                </li>
+
+                
+                        <li class="oup-header-menu-item mobile info-icon-menu-item">
+            <a href="/pages/information" target="_blank" class="at-info-button sigma-info-wrapper" role="button">
+            <img class="sigma-info-icon" src="//oup.silverchair-cdn.com/UI/app/svg/i.svg" alt="Information" />
+            </a>
+        </li>
+    <li class="oup-header-menu-item mobile account-icon-menu-item">
+        <a href="javascript:;" class="account-button js-account-button at-account-button "
+                role="button" data-turnawayparams="journal%3dcercor">
+            <img class="sigma-account-icon" src="//oup.silverchair-cdn.com/UI/app/svg/account.svg" alt="Account" />
+        </a>
+    </li>
+
+
+                
+                <li class="oup-header-menu-item mobile">
+                    <a href="javascript:;" class="mobile-dropdown-toggle mobile-nav-toggle">
+                        <i class="icon-menu_hamburger"><span class="screenreader-text">Menu</span></i>
+                    </a>
+                </li>
+            
+                
+               
+                        <li class="oup-header-menu-item desktop info-icon-menu-item">
+            <a href="/pages/information" target="_blank" class="at-info-button sigma-info-wrapper" role="button">
+            <img class="sigma-info-icon" src="//oup.silverchair-cdn.com/UI/app/svg/i.svg" alt="Information" />
+            </a>
+        </li>
+    <li class="oup-header-menu-item desktop account-icon-menu-item">
+        <a href="javascript:;" class="account-button js-account-button at-account-button sigma-logo-wrapper"
+                role="button" data-turnawayparams="journal%3dcercor">
+            <img class="sigma-account-icon" src="//oup.silverchair-cdn.com/UI/app/svg/account.svg" alt="Account" />
+        </a>
+    </li>
+
+
+                
+
+            </ul>
+
+            <div class="login-box-placeholder js-login-box-placeholder hide">
+                <div class="spinner"></div>
+            </div>
+        </div>
+    </div>
+<div class="dropdown-panel-wrap">
+
+    
+    <div class="dropdown-panel mobile-search-dropdown">
+        <div class="mobile-search-inner-wrap">
+
+
+<div class="navbar-search">
+    <div class="mobile-microsite-search">
+            <label for="SitePageHeader-mobile-navbar-search-filter" class="screenreader-text js-mobile-navbar-search-filter-label">
+                Navbar Search Filter
+            </label>
+            <select class="mobile-navbar-search-filter js-mobile-navbar-search-filter at-navbar-search-filter" id="SitePageHeader-mobile-navbar-search-filter">
+
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="">Cerebral Cortex</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Issue">This issue</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Parent">Cerebral Cortex Journals</option>
+                    <optgroup class="navbar-search-optgroup" label="Search across Oxford Academic">
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/MED00385">Clinical Neuroscience</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/MED00310">Neurology</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/SCI01870">Neuroscience</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Books">Books</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Journals">Journals</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Umbrella">Oxford Academic</option>                    </optgroup>
+            </select>
+
+        <label for="SitePageHeader-mobile-microsite-search-term" class="screenreader-text js-mobile-microsite-search-term-label">
+            Mobile Enter search term
+        </label>
+        <input class="mobile-search-input mobile-microsite-search-term js-mobile-microsite-search-term at-microsite-search-term" type="text"
+               maxlength="255" placeholder="Search" id="SitePageHeader-mobile-microsite-search-term">
+
+        <a href="javascript:;" class="mobile-microsite-search-icon mobile-search-submit icon-menu_search">
+            <span class="screenreader-text">Search</span>
+        </a>
+
+    </div>
+</div>
+
+
+        </div>
+    </div>
+   
+    <div class="dropdown-panel mobile-nav-dropdown">
+
+
+    <ul class="site-menu site-menu-lvl-0 at-site-menu">
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1565935">
+
+                <a href="/cercor/issue" class="nav-link">
+                    Issues
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1565936">
+
+                <a href="/cercor/advance-articles" class="nav-link">
+                    Advance articles
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1565933">
+
+                <a href="javascript:;" class="nav-link js-nav-dropdown at-nav-dropdown" role="button" aria-expanded="false">
+                    Submit
+                    <i class="desktop-nav-arrow icon-general-arrow-filled-down arrow-icon"></i>
+                </a>
+                <i class="mobile-nav-arrow icon-general_arrow-down"></i>
+                <ul class="site-menu site-menu-lvl-1 at-site-menu">
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565937">
+
+                <a href="/cercor/pages/General_Instructions" class="nav-link">
+                    Author Guidelines
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565938">
+
+                <a href="http://mc.manuscriptcentral.com/cercor" class="nav-link">
+                    Submission Site
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565939">
+
+                <a href="/cercor/pages/General_Instructions" class="nav-link">
+                    Open Access
+                </a>
+            
+        </li>
+            </ul>
+
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1565940">
+
+                <a href="/cercor/subscribe" class="nav-link">
+                    Purchase
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1565941">
+
+                <a href="/my-account/email-alerts" class="nav-link">
+                    Alerts
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1565934">
+
+                <a href="javascript:;" class="nav-link js-nav-dropdown at-nav-dropdown" role="button" aria-expanded="false">
+                    About
+                    <i class="desktop-nav-arrow icon-general-arrow-filled-down arrow-icon"></i>
+                </a>
+                <i class="mobile-nav-arrow icon-general_arrow-down"></i>
+                <ul class="site-menu site-menu-lvl-1 at-site-menu">
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565942">
+
+                <a href="/cercor/pages/About" class="nav-link">
+                    About Cerebral Cortex
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565943">
+
+                <a href="/cercor/pages/Editorial_Board" class="nav-link">
+                    Editorial Board
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565944">
+
+                <a href="https://academic.oup.com/advertising-and-corporate-services/pages/cercor-media-kit" class="nav-link">
+                    Advertising and Corporate Services
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565945">
+
+                <a href="http://medicine-and-health-careernetwork.oxfordjournals.org" class="nav-link">
+                    Journals Career Network
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565946">
+
+                <a href="https://academic.oup.com/journals/pages/access_purchase/rights_and_permissions/self_archiving_policy_b" class="nav-link">
+                    Self-Archiving Policy
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565947">
+
+                <a href="http://www.oxfordjournals.org/en/access-purchase/dispatch-dates.html" class="nav-link">
+                    Dispatch Dates
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565948">
+
+                <a href="/cercor/pages/Terms_and_Conditions" class="nav-link">
+                    Terms and Conditions
+                </a>
+            
+        </li>
+            </ul>
+
+        </li>
+                <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-custom">
+            <a href="/journals" class="nav-link">Journals on Oxford Academic</a>
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-custom">
+            <a href="/books" class="nav-link">Books on Oxford Academic</a>
+        </li>
+    </ul>
+    </div>
+
+</div>
+
+    <div class="journal-header journal-bg">
+        <div class="center-inner-row">
+                <div class="site-parent-link-wrap">
+                    <a href="//academic.oup.com/cercorjournals" class="site-parent-link">Cerebral Cortex Journals</a>
+                </div>
+                            <a href="/cercor" class="journal-logo-container">
+                    <img id="logo-CerebralCortex" class="journal-logo" src="//oup.silverchair-cdn.com/data/SiteBuilderAssets/Live/Images/cercor/cercor_title1443091482.svg" alt="Cerebral Cortex" />
+                </a>
+
+            <div class="society-logo-block">
+            </div> 
+        </div>
+    </div>
+<div class="navbar">
+    <div class="center-inner-row">
+        <nav class="navbar-menu">
+
+
+    <ul class="site-menu site-menu-lvl-0 at-site-menu">
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1565935">
+
+                <a href="/cercor/issue" class="nav-link">
+                    Issues
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1565936">
+
+                <a href="/cercor/advance-articles" class="nav-link">
+                    Advance articles
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1565933">
+
+                <a href="javascript:;" class="nav-link js-nav-dropdown at-nav-dropdown" role="button" aria-expanded="false">
+                    Submit
+                    <i class="desktop-nav-arrow icon-general-arrow-filled-down arrow-icon"></i>
+                </a>
+                <i class="mobile-nav-arrow icon-general_arrow-down"></i>
+                <ul class="site-menu site-menu-lvl-1 at-site-menu">
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565937">
+
+                <a href="/cercor/pages/General_Instructions" class="nav-link">
+                    Author Guidelines
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565938">
+
+                <a href="http://mc.manuscriptcentral.com/cercor" class="nav-link">
+                    Submission Site
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565939">
+
+                <a href="/cercor/pages/General_Instructions" class="nav-link">
+                    Open Access
+                </a>
+            
+        </li>
+            </ul>
+
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1565940">
+
+                <a href="/cercor/subscribe" class="nav-link">
+                    Purchase
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1565941">
+
+                <a href="/my-account/email-alerts" class="nav-link">
+                    Alerts
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-0 at-site-menu-item" id="site-menu-item-1565934">
+
+                <a href="javascript:;" class="nav-link js-nav-dropdown at-nav-dropdown" role="button" aria-expanded="false">
+                    About
+                    <i class="desktop-nav-arrow icon-general-arrow-filled-down arrow-icon"></i>
+                </a>
+                <i class="mobile-nav-arrow icon-general_arrow-down"></i>
+                <ul class="site-menu site-menu-lvl-1 at-site-menu">
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565942">
+
+                <a href="/cercor/pages/About" class="nav-link">
+                    About Cerebral Cortex
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565943">
+
+                <a href="/cercor/pages/Editorial_Board" class="nav-link">
+                    Editorial Board
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565944">
+
+                <a href="https://academic.oup.com/advertising-and-corporate-services/pages/cercor-media-kit" class="nav-link">
+                    Advertising and Corporate Services
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565945">
+
+                <a href="http://medicine-and-health-careernetwork.oxfordjournals.org" class="nav-link">
+                    Journals Career Network
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565946">
+
+                <a href="https://academic.oup.com/journals/pages/access_purchase/rights_and_permissions/self_archiving_policy_b" class="nav-link">
+                    Self-Archiving Policy
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565947">
+
+                <a href="http://www.oxfordjournals.org/en/access-purchase/dispatch-dates.html" class="nav-link">
+                    Dispatch Dates
+                </a>
+            
+        </li>
+        <li class="site-menu-item site-menu-lvl-1 at-site-menu-item" id="site-menu-item-1565948">
+
+                <a href="/cercor/pages/Terms_and_Conditions" class="nav-link">
+                    Terms and Conditions
+                </a>
+            
+        </li>
+            </ul>
+
+        </li>
+            </ul>
+        </nav>
+            <div class="navbar-search-container js-navbar-search-container">
+                <a href="javascript:;" class="navbar-search-close js_close-navsearch">Close</a>
+
+
+<div class="navbar-search">
+    <div class="microsite-search">
+            <label for="SitePageHeader-navbar-search-filter" class="screenreader-text js-navbar-search-filter-label">
+                Navbar Search Filter
+            </label>
+            <select class="navbar-search-filter js-navbar-search-filter at-navbar-search-filter" id="SitePageHeader-navbar-search-filter">
+
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="">Cerebral Cortex</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Issue">This issue</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Parent">Cerebral Cortex Journals</option>
+                    <optgroup class="navbar-search-optgroup" label="Search across Oxford Academic">
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/MED00385">Clinical Neuroscience</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/MED00310">Neurology</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/SCI01870">Neuroscience</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Books">Books</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Journals">Journals</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Umbrella">Oxford Academic</option>                    </optgroup>
+            </select>
+
+        <label for="SitePageHeader-microsite-search-term" class="screenreader-text js-microsite-search-term-label">
+            Enter search term
+        </label>
+        <input class="navbar-search-input microsite-search-term js-microsite-search-term at-microsite-search-term" type="text"
+               maxlength="255" placeholder="Search" id="SitePageHeader-microsite-search-term">
+
+        <a href="javascript:;" class="microsite-search-icon navbar-search-submit icon-menu_search">
+            <span class="screenreader-text">Search</span>
+        </a>
+
+    </div>
+</div>
+
+<input id="hfCurrentBookSearch" name="hfCurrentBookSearch" type="hidden" value="" /><input id="hfCurrentBookScope" name="hfCurrentBookScope" type="hidden" value="CurrentBook" /><input id="hfBookSiteScope" name="hfBookSiteScope" type="hidden" value="Books" /><input id="hfSeriesScope" name="hfSeriesScope" type="hidden" value="taxWithOr" /><input id="hfParentSiteName" name="hfParentSiteName" type="hidden" value="Cerebral Cortex Journals" /><input id="hfParentSiteUrl" name="hfParentSiteUrl" type="hidden" value="academic.oup.com/cercorjournals" /><input id="hfSiteID" name="hfSiteID" type="hidden" value="5122" /><input id="hfParentSiteID" name="hfParentSiteID" type="hidden" value="6262" /><input id="hfJournalSiteScope" name="hfJournalSiteScope" type="hidden" value="Journals" /><input id="hfParentSiteScope" name="hfParentSiteScope" type="hidden" value="Parent" /><input id="hfDefaultSearchURL" name="hfDefaultSearchURL" type="hidden" value="search-results?page=1&amp;q=" /><input id="hfIssueSearch" name="hfIssueSearch" type="hidden" value="&amp;fl_IssueID=10731" /><input id="hfIssueSiteScope" name="hfIssueSiteScope" type="hidden" value="Issue" /><input id="hfUmbrellaScope" name="hfUmbrellaScope" type="hidden" value="Umbrella" /><input id="hfUmbrellaSiteUrl" name="hfUmbrellaSiteUrl" type="hidden" value="academic.oup.com" /><input id="hfUmbrellaSiteId" name="hfUmbrellaSiteId" type="hidden" value="191" /><input id="hfDefaultAdvancedSearchUrl" name="hfDefaultAdvancedSearchUrl" type="hidden" value="advanced-search?page=1&amp;q=" /><input id="hfTaggedCollectionScope" name="hfTaggedCollectionScope" type="hidden" value="" />                <div class="navbar-search-advanced"><a href="/cercor/advanced-search" class="advanced-search js-advanced-search">Advanced Search</a></div>
+            </div>            <div class="navbar-search-collapsed"><a href="javascript:;" class="icon-menu_search js_expand-navsearch"><span class="screenreader-text">Search Menu</span></a></div>
+    </div>
+</div>
+<input id="hfEnableOupOnlineProductsFeatures" name="hfEnableOupOnlineProductsFeatures" type="hidden" value="True" />
+
+    <input type="hidden" name="searchScope" id="hfSolrJournalID" value="" />
+    <input type="hidden" id="hfSolrJournalName" value="" />
+    <input type="hidden" id="hfSolrMaxAllowSearchChar" value="100" />
+    <input type="hidden" id="hfJournalShortName" value="" />
+    <input type="hidden" id="hfSearchPlaceholder" value="" />
+    <input type="hidden" name="hfGlobalSearchSiteURL" id="hfGlobalSearchSiteURL" value="" />
+    <input type="hidden" name="hfSearchSiteURL" id="hfSiteURL" value="academic.oup.com/cercor" />
+    <script type="text/javascript">
+        (function () {
+            var hfSiteUrl = document.getElementById('hfSiteURL');
+            var siteUrl = hfSiteUrl.value;
+            var subdomainIndex = siteUrl.indexOf('/');
+
+            hfSiteUrl.value = location.host + (subdomainIndex >= 0 ? siteUrl.substring(subdomainIndex) : '');
+        })();
+    </script>
+<input id="routename" name="RouteName" type="hidden" value="cercor" /> 
+    </div>
+
+</section>
+        <div class="widget widget-SitewideBanner widget-instance-">
+        
+
+ 
+    </div>
+
+
+    <div id="main" class="content-main js-main ui-base">
+            <section class="master-main row">
+                <div class="center-inner-row no-overflow">
+                    <div id="skipNav" tabindex="-1"></div>
+                    
+
+
+<div class="page-column-wrap">
+<div id="InfoColumn" class="page-column page-column--left js-left-nav-col">
+    <div class="mobile-content-topbar hide">
+        <button class="toggle-left-col toggle-left-col__article">Article Navigation</button>
+    </div>
+    <div class="info-inner-wrap js-left-nav">
+        <button class="toggle-left-col__close btn-as-icon icon-general-close">
+            <span class="screenreader-text">Close mobile search navigation</span>
+        </button>
+        <div class="responsive-nav-title">Article Navigation</div>
+        <div class="info-widget-wrap">
+    <div class="widget widget-IssueInfo widget-instance-OUP_IssueInfo_Article">
+        
+
+<div id="issueInfo-OUP_IssueInfo_Article" class="article-info-wrap clearfix">
+    <i class="icon-general-close mobile-nav-btn nav-open"></i>
+    <a class="article-issue-link" href="/cercor/issue/18/11">
+        <div class="article-issue-img">
+                <img id="issueImage" class="fb-featured-image" src="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/Issue/18/11/0/m_cercor18_11.cover.gif?Expires=1689792643&amp;Signature=xrGqDu8yFMCl31DfhqB05wdz0B87ZzJuJ2QwpfYRtlnCVjI08JT3itCRUvuZ-hqr1AzKzsgNtr0hxmVbeek1r1HqNScUE1NTCNtxp81EHVNkSLgz7ct7R28tW5BogXCLCdU7-NfRl5cNTWToCPuuBuKaqlpQmaChYOauGTYqcPRj1eS2DOn-mBK0QvaZMzm7owZ409UkHgcQkxJR2Rzw4NdC1sK9TrNIFauuyiBsyMue4R4bvK3N0wl1ChpV87Fv0YkEsKfdQCwxwH1jNAUmkXuTR-8Lk0xRd8oepwWwwkCZt-ik3urDYQAPMZSkWXBFytSmxSEaRXQgP13Q~A5KGQ__&amp;Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" alt="Issue Cover" />
+        </div>
+        <div class="article-issue-info">
+            <div class="volume-issue__wrap">
+
+                        <div class="volume trailing-comma">Volume 18</div>
+                        <div class="issue">Issue 11</div>
+
+
+
+            </div>
+            <div class="ii-pub-date">
+November 2008            </div>
+            
+        </div>
+    </a>
+</div> 
+    </div>
+
+            <div class="content-nav">
+    <div class="widget widget-ArticleJumpLinks widget-instance-OUP_ArticleJumpLinks_Widget">
+        
+
+<h3 class="contents-title" >Article Contents</h3>
+<ul class="jumplink-list js-jumplink-list">
+        <li class="section-jump-link head-1" link-destination="3674375">
+            <div class="section-jump-link__link-wrap">
+
+                <a class="js-jumplink scrollTo" href="#3674375">Abstract</a>
+            </div>
+        </li>
+        <li class="section-jump-link head-1" link-destination="3674386">
+            <div class="section-jump-link__link-wrap">
+
+                <a class="js-jumplink scrollTo" href="#3674386">Methods</a>
+            </div>
+        </li>
+        <li class="section-jump-link head-1" link-destination="3674410">
+            <div class="section-jump-link__link-wrap">
+
+                <a class="js-jumplink scrollTo" href="#3674410">Results</a>
+            </div>
+        </li>
+        <li class="section-jump-link head-1" link-destination="3674429">
+            <div class="section-jump-link__link-wrap">
+
+                <a class="js-jumplink scrollTo" href="#3674429">Discussion</a>
+            </div>
+        </li>
+        <li class="section-jump-link head-1" link-destination="3674448">
+            <div class="section-jump-link__link-wrap">
+
+                <a class="js-jumplink scrollTo" href="#3674448">Funding</a>
+            </div>
+        </li>
+        <li class="section-jump-link head-1 backReferenceLink" link-destination="3674452">
+            <div class="section-jump-link__link-wrap">
+
+                <a class="js-jumplink scrollTo" href="#3674452">References</a>
+            </div>
+        </li>
+</ul>
+ 
+    </div>
+
+            </div>
+    <div class="widget widget-ArticleNavLinks widget-instance-OUP_ArticleNavLinks_Article">
+        <ul class="inline-list">
+        <li class="prev arrow">
+            <a href="/cercor/article/18/11/2483/290025">&lt; Previous</a>
+        </li>        
+            <li class="next arrow">
+            <a href="/cercor/article/18/11/2505/290566">Next &gt;</a>
+        </li>
+</ul> 
+    </div>
+
+        </div>
+    </div>
+</div>
+<div class="sticky-toolbar js-sticky-toolbar"></div>
+<div id="ContentColumn" class="page-column page-column--center">
+
+    <div class="article-browse-top article-browse-mobile-nav js-mobile-nav">
+    <div class="article-browse-mobile-nav-inner js-mobile-nav-inner">
+        <button class="toggle-left-col toggle-left-col__article btn-as-link">
+            Article Navigation
+        </button>
+    </div>
+</div>
+<div class="article-browse-top article-browse-mobile-nav mobile-sticky-toolbar js-mobile-nav-sticky">
+    <div class="article-browse-mobile-nav-inner">
+        <button class="toggle-left-col toggle-left-col__article btn-as-link">
+            Article Navigation
+        </button>
+    </div>
+</div>
+
+    <div class="content-inner-wrap">
+    <div class="widget widget-ArticleTopInfo widget-instance-OUP_ArticleTop_Info_Widget">
+        <div class="module-widget article-top-widget">
+
+    
+
+    
+        <div class="access-state-logos all-viewports">
+            <span class="journal-info__format-label">Journal Article</span>
+                    </div>
+
+
+    <div class="widget-items">
+                <div class="title-wrap">
+                    <h1 class="wi-article-title article-title-main accessible-content-title at-articleTitle">
+                        Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation
+<i class='icon-availability_unlocked' title='Purchased' ></i>                    </h1>
+
+                </div>
+                <div class="wi-authors at-ArticleAuthors">
+                    <div class="al-authors-list">
+                                <span class="al-author-name-more js-flyout-wrap">
+
+
+
+
+
+
+                                    <a class="linked-name js-linked-name-trigger" href="javascript:;">Maureen Ritchey</a><span class='delimiter'>, </span>
+
+                                    <span class="al-author-info-wrap arrow-up">
+<div class="info-card-author authorInfo_OUP_ArticleTop_Info_Widget">
+    <div class="name-role-wrap">
+        <div class="info-card-name">
+    Maureen Ritchey
+</div>
+
+    </div>
+
+    <div class="info-card-affilitation">
+        <div class="aff"><span class="label">1</span>Center for Cognitive Neuroscience</div><div class="aff"><span class="label">2</span>Department of Psychology and Neuroscience</div>
+    </div>
+
+    <div class="info-card-search-label">
+        Search for other works by this author on:
+    </div>
+
+<div class="info-card-search info-card-search-internal">
+    <a href="/cercor/search-results?f_Authors=Maureen+Ritchey" rel="nofollow">Oxford Academic</a>
+</div>
+
+    <div class="info-card-search info-card-search-pubmed">
+        <a href="http://www.ncbi.nlm.nih.gov/pubmed?cmd=search&amp;term=Ritchey M">PubMed</a>
+    </div>
+    <div class="info-card-search info-card-search-google">
+        <a href="http://scholar.google.com/scholar?q=author:%22Ritchey Maureen%22">Google Scholar</a>
+    </div>
+</div>                                    </span>
+                                </span>
+                                <span class="al-author-name-more js-flyout-wrap">
+
+
+
+
+
+
+                                    <a class="linked-name js-linked-name-trigger" href="javascript:;">Florin Dolcos</a><span class='delimiter'>, </span>
+
+                                    <span class="al-author-info-wrap arrow-up">
+<div class="info-card-author authorInfo_OUP_ArticleTop_Info_Widget">
+    <div class="name-role-wrap">
+        <div class="info-card-name">
+    Florin Dolcos
+</div>
+
+    </div>
+
+    <div class="info-card-affilitation">
+        <div class="aff"><span class="label">1</span>Center for Cognitive Neuroscience</div><div class="aff"><span class="label">3</span>Brain Imaging and Analysis Center, Duke University, Durham, NC 27708, USA</div><div class="aff"><span class="label">4</span>Current address: Department of Psychiatry, University of Alberta, Edmonton, Alberta, T6G 2G3 Canada</div>
+    </div>
+
+    <div class="info-card-search-label">
+        Search for other works by this author on:
+    </div>
+
+<div class="info-card-search info-card-search-internal">
+    <a href="/cercor/search-results?f_Authors=Florin+Dolcos" rel="nofollow">Oxford Academic</a>
+</div>
+
+    <div class="info-card-search info-card-search-pubmed">
+        <a href="http://www.ncbi.nlm.nih.gov/pubmed?cmd=search&amp;term=Dolcos F">PubMed</a>
+    </div>
+    <div class="info-card-search info-card-search-google">
+        <a href="http://scholar.google.com/scholar?q=author:%22Dolcos Florin%22">Google Scholar</a>
+    </div>
+</div>                                    </span>
+                                </span>
+                                <span class="al-author-name-more js-flyout-wrap">
+
+
+
+
+
+
+                                    <a class="linked-name js-linked-name-trigger" href="javascript:;">Roberto Cabeza</a><span class='delimiter'></span>
+
+                                    <span class="al-author-info-wrap arrow-up">
+<div class="info-card-author authorInfo_OUP_ArticleTop_Info_Widget">
+    <div class="name-role-wrap">
+        <div class="info-card-name">
+    Roberto Cabeza
+</div>
+
+    </div>
+
+    <div class="info-card-affilitation">
+        <div class="aff"><span class="label">1</span>Center for Cognitive Neuroscience</div><div class="aff"><span class="label">2</span>Department of Psychology and Neuroscience</div>
+    </div>
+
+    <div class="info-card-search-label">
+        Search for other works by this author on:
+    </div>
+
+<div class="info-card-search info-card-search-internal">
+    <a href="/cercor/search-results?f_Authors=Roberto+Cabeza" rel="nofollow">Oxford Academic</a>
+</div>
+
+    <div class="info-card-search info-card-search-pubmed">
+        <a href="http://www.ncbi.nlm.nih.gov/pubmed?cmd=search&amp;term=Cabeza R">PubMed</a>
+    </div>
+    <div class="info-card-search info-card-search-google">
+        <a href="http://scholar.google.com/scholar?q=author:%22Cabeza Roberto%22">Google Scholar</a>
+    </div>
+</div>                                    </span>
+                                </span>
+
+                    </div>
+                </div>
+<div class="pub-history-wrap clearfix js-history-dropdown-wrap">
+
+        <div class="pub-history-row clearfix">
+            <div class="ww-citation-primary"><em>Cerebral Cortex</em>, Volume 18, Issue 11, November 2008, Pages 2494–2504, <a href='https://doi.org/10.1093/cercor/bhm262'>https://doi.org/10.1093/cercor/bhm262</a></div>
+        </div>
+        <div class="pub-history-row clearfix">
+            <div class="ww-citation-date-wrap">
+                <div class="citation-label">Published:</div>
+                <div class="citation-date">28 March 2008</div>
+            </div>
+        </div>
+    </div>
+    </div>
+</div>
+
+<script>
+    $(document).ready(function () {
+        $('.article-top-widget').on('click', '.ati-toggle-trigger', function () {
+            $(this).find('.icon-general-add, .icon-minus').toggleClass('icon-minus icon-general-add');
+            $(this).siblings('.ati-toggle-content').toggleClass('hide');
+        });
+
+        // In Chrome, an anchor tag with target="_blank" and a "mailto:" href opens a new tab/window as well as the email client
+        // I suspect this behavior will be corrected in the future
+        // Remove the target="_blank"
+        $('ul.wi-affiliationList').find('a[href^="mailto:"]').each(function () {
+            $(this).removeAttr('target');
+        });
+    });
+</script>
+
+ 
+    </div>
+    <div class="widget widget-ArticleLinks widget-instance-OUP_Article_Links_Widget">
+         
+    </div>
+
+
+        <div class="article-body js-content-body">
+            <div class="toolbar-wrap js-toolbar-wrap">
+                <div class="toolbar-inner-wrap">
+                    <ul id="Toolbar" role="navigation">
+    <li class="toolbar-item item-pdf js-item-pdf">
+        <a class="al-link pdf article-pdfLink" data-article-id="290170" href="/cercor/article-pdf/18/11/2494/819207/bhm262.pdf">
+            <img src=//oup.silverchair-cdn.com/UI/app/svg/pdf.svg alt="pdf" /><span class="pdf-link-text">PDF</span>
+        </a>
+    </li>
+                                                    <li class="toolbar-item item-link item-split-view">
+                                <a href="javascript:;"
+                                   class="split-view js-split-view st-split-view at-split-view"
+                                   target="">
+                                    <i class="icon-menu-split"></i>
+                                    Split View
+                                </a>
+                            </li>
+
+                        <li class="toolbar-item item-with-dropdown item-views">
+                            <a class="at-views-dropdown drop-trigger" href="javascript:;" data-dropdown="FilterDrop" aria-haspopup="true">
+                                <i class="icon-menu_views"></i>
+                                <div class="toolbar-label">
+                                    <div class="toolbar-text">Views</div>
+                                    <i class="icon-general-arrow-filled-down arrow-icon"></i>
+                                </div>
+                            </a>
+                            <ul id="ViewsDrop" class="f-dropdown" data-dropdown-content aria-label="submenu">
+                                <div class="arrow-up"></div>
+                                <li class="article-content-filter js-article-content-filter" data-content-filter="article-content">
+                                    <a href="javascript:;"><span>Article contents</span></a>
+                                </li>
+                                <li class="at-figures-tables article-content-filter js-article-content-filter" data-content-filter="figures-tables">
+                                    <a href="javascript:;"><span>Figures &amp; tables</span></a>
+                                </li>
+                                <li class="article-content-filter js-article-content-filter" data-content-filter="video">
+                                    <a href="javascript:;"><span>Video</span></a>
+                                </li>
+                                <li class="article-content-filter js-article-content-filter" data-content-filter="audio">
+                                    <a href="javascript:;"><span>Audio</span></a>
+                                </li>
+                                <li class="article-content-filter js-article-content-filter" data-content-filter="supplementary-data">
+                                    <a href="javascript:;"><span>Supplementary Data</span></a>
+                                </li>
+                            </ul>
+                        </li>
+
+
+                        <li class="toolbar-item item-cite js-item-cite">
+    <div class="widget widget-ToolboxGetCitation widget-instance-OUP_Get_Citation">
+        <a href="#" class="js-cite-button at-CiteButton" data-reveal-id="getCitation" data-reveal>
+    <i class="icon-read-more"></i>
+    <span>Cite</span>
+</a>
+
+<div id="getCitation" class="reveal-modal js-citation-modal" data-reveal>
+    <h3 class="modal-title">Cite</h3>
+        <div class="oxford-citation-text">
+            <p>Maureen Ritchey <span class='al-author-delim'>and others</span>,  Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation, <em>Cerebral Cortex</em>, Volume 18, Issue 11, November 2008, Pages 2494–2504, <a href="https://doi.org/10.1093/cercor/bhm262">https://doi.org/10.1093/cercor/bhm262</a></p>
+        </div>
+
+    <div class="citation-download-wrap">
+        <form action="/Citation/Download" method="get" id="citationModal">
+            <input type="hidden" name="resourceId" value="290170" />
+            <input type="hidden" name="resourceType" value="3" />
+            <label for="selectFormat" class="hide js-citation-format-label">Select Format</label>
+            <select required name="citationFormat" class="citation-download-format js-citation-format" id="selectFormat">
+                <option selected disabled >Select format</option>
+                        <option value="0" >.ris (Mendeley, Papers, Zotero)</option>
+                        <option value="1" >.enw (EndNote)</option>
+                        <option value="2" >.bibtex (BibTex)</option>
+                        <option value="3" >.txt (Medlars, RefWorks)</option>
+
+            </select>
+            <button class="btn citation-download-link disabled" type="submit">Download citation</button>
+        </form>
+    </div>
+
+    <a class="close-reveal-modal" href="javascript:;"><i class="icon-general-close"></i><span class="screenreader-text">Close</span></a>
+</div>
+ 
+    </div>
+
+                        </li>
+                        <li class="toolbar-item item-tools">
+    <div class="widget widget-ToolboxPermissions widget-instance-OUP_Get_Permissions">
+            <div class="module-widget">
+        <a href="https://s100.copyright.com/AppDispatchServlet?publisherName=OUP&amp;publication=1460-2199&amp;title=Role%20of%20Amygdala%20Connectivity%20in%20the%20Persistence%20of%20Emotional%20Memories%20Over%20Time%3A%20An%20Event-Related%20fMRI%20Investigation&amp;publicationDate=2008-03-28&amp;volumeNum=18&amp;issueNum=11&amp;author=Ritchey%2C%20Maureen%3B%20Dolcos%2C%20Florin&amp;startPage=2494&amp;endPage=2504&amp;contentId=10.1093%2Fcercor%2Fbhm262&amp;oa=&amp;copyright=Oxford%20University%20Press&amp;orderBeanReset=True" id="PermissionsLink" class="" target="_blank">
+            <i class="icon-menu_permissions">
+                <span class="screenreader-text">Permissions Icon</span>
+            </i>
+            Permissions
+        </a>
+    </div>
+ 
+    </div>
+
+                        </li>
+                        
+    <li class="toolbar-item item-with-dropdown item-share">
+        <a href="javascript:;" class="drop-trigger js-toolbar-dropdown at-ShareButton" data-dropdown="ShareDrop">
+            <i class="icon-menu_share"><span class="screenreader-text">Share Icon</span></i>
+            <span class="toolbar-label">
+                <span class="toolbar-text">Share</span>
+                <i class="arrow-icon icon-general-arrow-filled-down js-toolbar-arrow-icon"></i>
+            </span>
+        </a>
+        <ul id="ShareDrop" class="addthis_toolbox addthis_default_style addthis_20x20_style f-dropdown" data-dropdown-content>
+    <li>
+        <a class="st-custom-button addthis_button_facebook"
+           data-network="facebook"
+           data-title="Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation"
+           data-url="https://academic.oup.com/cercor/article/18/11/2494/290170"
+           data-email-subject="Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation"
+           href="javascript:;"><span>Facebook</span></a>
+    </li>
+    <li>
+        <a class="st-custom-button addthis_button_twitter"
+           data-network="twitter"
+           data-title="Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation"
+           data-url="https://academic.oup.com/cercor/article/18/11/2494/290170"
+           data-email-subject="Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation"
+           href="javascript:;"><span>Twitter</span></a>
+    </li>
+    <li>
+        <a class="st-custom-button addthis_button_linkedin"
+           data-network="linkedin"
+           data-title="Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation"
+           data-url="https://academic.oup.com/cercor/article/18/11/2494/290170"
+           data-email-subject="Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation"
+           href="javascript:;"><span>LinkedIn</span></a>
+    </li>
+    <li>
+        <a class="st-custom-button addthis_button_email"
+           data-network="email"
+           data-title="Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation"
+           data-url="https://academic.oup.com/cercor/article/18/11/2494/290170"
+           data-email-subject="Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation"
+           href="javascript:;"><span>Email</span></a>
+    </li>
+
+
+
+        </ul>
+    </li>
+
+                        
+                    </ul>
+                    <div class="toolbar-search">
+    <div class="widget widget-SitePageHeader widget-instance-OUP_ArticleToolbarSearchBox">
+        
+
+
+
+<div class="dropdown-panel-wrap">
+
+    
+    <div class="dropdown-panel mobile-search-dropdown">
+        <div class="mobile-search-inner-wrap">
+
+
+<div class="navbar-search">
+    <div class="mobile-microsite-search">
+            <label for="OUP_ArticleToolbarSearchBox-mobile-navbar-search-filter" class="screenreader-text js-mobile-navbar-search-filter-label">
+                Navbar Search Filter
+            </label>
+            <select class="mobile-navbar-search-filter js-mobile-navbar-search-filter at-navbar-search-filter" id="OUP_ArticleToolbarSearchBox-mobile-navbar-search-filter">
+
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="">Cerebral Cortex</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Issue">This issue</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Parent">Cerebral Cortex Journals</option>
+                    <optgroup class="navbar-search-optgroup" label="Search across Oxford Academic">
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/MED00385">Clinical Neuroscience</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/MED00310">Neurology</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/SCI01870">Neuroscience</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Books">Books</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Journals">Journals</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Umbrella">Oxford Academic</option>                    </optgroup>
+            </select>
+
+        <label for="OUP_ArticleToolbarSearchBox-mobile-microsite-search-term" class="screenreader-text js-mobile-microsite-search-term-label">
+            Mobile Enter search term
+        </label>
+        <input class="mobile-search-input mobile-microsite-search-term js-mobile-microsite-search-term at-microsite-search-term" type="text"
+               maxlength="255" placeholder="Search" id="OUP_ArticleToolbarSearchBox-mobile-microsite-search-term">
+
+        <a href="javascript:;" class="mobile-microsite-search-icon mobile-search-submit icon-menu_search">
+            <span class="screenreader-text">Search</span>
+        </a>
+
+    </div>
+</div>
+
+
+        </div>
+    </div>
+   
+    <div class="dropdown-panel mobile-nav-dropdown">
+
+    </div>
+
+</div>
+
+
+<div class="navbar">
+    <div class="center-inner-row">
+        <nav class="navbar-menu">
+
+        </nav>
+            <div class="navbar-search-container js-navbar-search-container">
+                <a href="javascript:;" class="navbar-search-close js_close-navsearch">Close</a>
+
+
+<div class="navbar-search">
+    <div class="microsite-search">
+            <label for="OUP_ArticleToolbarSearchBox-navbar-search-filter" class="screenreader-text js-navbar-search-filter-label">
+                Navbar Search Filter
+            </label>
+            <select class="navbar-search-filter js-navbar-search-filter at-navbar-search-filter" id="OUP_ArticleToolbarSearchBox-navbar-search-filter">
+
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="">Cerebral Cortex</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Issue">This issue</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Parent">Cerebral Cortex Journals</option>
+                    <optgroup class="navbar-search-optgroup" label="Search across Oxford Academic">
+<option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/MED00385">Clinical Neuroscience</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/MED00310">Neurology</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="AcademicSubjects/SCI01870">Neuroscience</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Books">Books</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Journals">Journals</option><option class="navbar-search-filter-option at-navbar-search-filter-option" value="Umbrella">Oxford Academic</option>                    </optgroup>
+            </select>
+
+        <label for="OUP_ArticleToolbarSearchBox-microsite-search-term" class="screenreader-text js-microsite-search-term-label">
+            Enter search term
+        </label>
+        <input class="navbar-search-input microsite-search-term js-microsite-search-term at-microsite-search-term" type="text"
+               maxlength="255" placeholder="Search" id="OUP_ArticleToolbarSearchBox-microsite-search-term">
+
+        <a href="javascript:;" class="microsite-search-icon navbar-search-submit icon-menu_search">
+            <span class="screenreader-text">Search</span>
+        </a>
+
+    </div>
+</div>
+
+                <div class="navbar-search-advanced"><a href="/cercor/advanced-search" class="advanced-search js-advanced-search">Advanced Search</a></div>
+            </div>            <div class="navbar-search-collapsed"><a href="javascript:;" class="icon-menu_search js_expand-navsearch"><span class="screenreader-text">Search Menu</span></a></div>
+    </div>
+</div>
+<input id="hfEnableOupOnlineProductsFeatures" name="hfEnableOupOnlineProductsFeatures" type="hidden" value="True" />
+
+<input id="routename" name="RouteName" type="hidden" value="cercor" /> 
+    </div>
+
+                    </div>
+                </div>
+            </div>
+            <div id="ContentTab" class="content active">
+    <div class="widget widget-ArticleFulltext widget-instance-OUP_Article_FullText_Widget">
+        <div class="module-widget">
+    <div class="widget-items" data-widgetname="ArticleFulltext">
+
+
+
+
+
+                    <h2 scrollto-destination=3674375 id="3674375" class="abstract-title js-splitscreen-abstract-title" >Abstract</h2>
+<section class="abstract"><p class="chapter-para">According to the consolidation hypothesis, enhanced memory for emotional information reflects the modulatory effect of the amygdala on the medial temporal lobe (MTL) memory system during consolidation. Although there is evidence that amygdala–MTL connectivity enhances memory for emotional stimuli, it remains unclear whether this enhancement increases over time, as consolidation processes unfold. To investigate this, we used functional magnetic resonance imaging to measure encoding activity predicting memory for emotionally negative and neutral pictures after short (20-min) versus long (1-week) delays. Memory measures distinguished between vivid remembering (recollection) and feelings of knowing (familiarity). Consistent with the consolidation hypothesis, the persistence of recollection over time (long divided by short) was greater for emotional than neutral pictures. Activity in the amygdala predicted subsequent memory to a greater extent for emotional than neutral pictures. Although this advantage did not vary with delay, the contribution of amygdala–MTL connectivity to subsequent memory for emotional items increased over time. Moreover, both this increase in connectivity and amygdala activity itself were correlated with individual differences in recollection persistence for emotional but not neutral pictures. These results suggest that the amygdala and its connectivity with the MTL are critical to sustaining emotional memories over time, consistent with the consolidation hypothesis.</p></section>                    <div class="article-metadata-panel clearfix at-ArticleMetadata"></div>
+<div class="kwd-group"><a class="kwd-part kwd-main" href="javascript:;" data-keyword="affect">affect</a>, <a class="kwd-part kwd-main" href="javascript:;" data-keyword="arousal">arousal</a>, <a class="kwd-part kwd-main" href="javascript:;" data-keyword="connectivity">connectivity</a>, <a class="kwd-part kwd-main" href="javascript:;" data-keyword="consolidation">consolidation</a>, <a class="kwd-part kwd-main" href="javascript:;" data-keyword="&quot;emotional memory&quot;">emotional memory</a></div><p class="chapter-para">The formation of emotional episodic memories, compared with nonemotional (neutral) memories, is characterized by at least 2 distinct advantages: increased resources during encoding (<span class="xrefLink" id="jumplink-bib12"></span><a href="javascript:;" reveal-id="bib12" data-open="bib12" class="link link-ref link-reveal xref-bibr">Dolcos et al. 2004a</a>; <span class="xrefLink" id="jumplink-bib22"></span><a href="javascript:;" reveal-id="bib22" data-open="bib22" class="link link-ref link-reveal xref-bibr">Kensinger 2004</a>) and arousal-driven enhancements leading to improved consolidation. According to the consolidation hypothesis, the latter effects reflect the modulatory influence of the amygdala on the medial temporal lobe (MTL) memory system, which boosts consolidation processes and the persistence of memories over time (<span class="xrefLink" id="jumplink-bib33"></span><a href="javascript:;" reveal-id="bib33" data-open="bib33" class="link link-ref link-reveal xref-bibr">McGaugh 2004</a>; <span class="xrefLink" id="jumplink-bib28"></span><a href="javascript:;" reveal-id="bib28" data-open="bib28" class="link link-ref link-reveal xref-bibr">LaBar and Cabeza 2006</a>).</p><p class="chapter-para">These neurohormonal changes within the amygdala–MTL network, which constitute the “direct” route to emotional memory, are accompanied by a host of other changes during item encoding, including increased attentional and perceptual processing resources allocated to emotional stimuli (<span class="xrefLink" id="jumplink-bib11"></span><a href="javascript:;" reveal-id="bib11" data-open="bib11" class="link link-ref link-reveal xref-bibr">Dolan and Vuilleumier 2003</a>). These cognitive and perceptual encoding enhancements exert an indirect influence over emotional memory strength and thus may be considered the “indirect” network supporting emotional memory. These “direct” and “indirect” networks are dissociable: whereas the direct network must be recruited by increased arousal, it has been suggested that components of the indirect network can be recruited by valence (whether an item is positive or negative) alone (<span class="xrefLink" id="jumplink-bib24"></span><a href="javascript:;" reveal-id="bib24" data-open="bib24" class="link link-ref link-reveal xref-bibr">Kensinger and Corkin 2004</a>). Furthermore, although both networks are activated during encoding, the impact of the direct network should become more apparent as consolidation processes unfold over time. By manipulating the time between encoding and retrieval, the present study highlights the role of the direct network in creating and sustaining emotional memories.</p><p class="chapter-para">Arousal enhances emotionally negative memories relative to neutral as time goes on, from 20 min to 1 week (<span class="xrefLink" id="jumplink-bib27"></span><a href="javascript:;" reveal-id="bib27" data-open="bib27" class="link link-ref link-reveal xref-bibr">Kleinsmith and Kaplan 1963</a>), from immediate to 1 h (<span class="xrefLink" id="jumplink-bib29"></span><a href="javascript:;" reveal-id="bib29" data-open="bib29" class="link link-ref link-reveal xref-bibr">LaBar and Phelps 1998</a>), from 1 day to 2 weeks (<span class="xrefLink" id="jumplink-bib3"></span><a href="javascript:;" reveal-id="bib3" data-open="bib3" class="link link-ref link-reveal xref-bibr">Anderson et al. 2006</a>), and from immediate to 24 h (<span class="xrefLink" id="jumplink-bib48"></span><a href="javascript:;" reveal-id="bib48" data-open="bib48" class="link link-ref link-reveal xref-bibr">Sharot and Phelps 2004</a>; <span class="xrefLink" id="jumplink-bib49"></span><a href="javascript:;" reveal-id="bib49" data-open="bib49" class="link link-ref link-reveal xref-bibr">Sharot and Yonelinas 2008</a>) after encoding. Indeed, emotional memory is particularly resilient to time, with laboratory enhancements being reported up to 1 year after encoding (<span class="xrefLink" id="jumplink-bib14"></span><a href="javascript:;" reveal-id="bib14" data-open="bib14" class="link link-ref link-reveal xref-bibr">Dolcos et al. 2005</a>). Emotional memories also tend to be accompanied by highly confident responding or a sense of reexperiencing (<span class="xrefLink" id="jumplink-bib37"></span><a href="javascript:;" reveal-id="bib37" data-open="bib37" class="link link-ref link-reveal xref-bibr">Ochsner 2000</a>; <span class="xrefLink" id="jumplink-bib23"></span><a href="javascript:;" reveal-id="bib23" data-open="bib23" class="link link-ref link-reveal xref-bibr">Kensinger and Corkin 2003</a>; <span class="xrefLink" id="jumplink-bib47"></span><a href="javascript:;" reveal-id="bib47" data-open="bib47" class="link link-ref link-reveal xref-bibr">Sharot et al. 2004</a>; <span class="xrefLink" id="jumplink-bib14"></span><a href="javascript:;" reveal-id="bib14" data-open="bib14" class="link link-ref link-reveal xref-bibr">Dolcos et al. 2005</a>), and these recollection benefits are also augmented relative to neutral over time (<span class="xrefLink" id="jumplink-bib3"></span><a href="javascript:;" reveal-id="bib3" data-open="bib3" class="link link-ref link-reveal xref-bibr">Anderson et al. 2006</a>; <span class="xrefLink" id="jumplink-bib49"></span><a href="javascript:;" reveal-id="bib49" data-open="bib49" class="link link-ref link-reveal xref-bibr">Sharot and Yonelinas 2008</a>).</p><p class="chapter-para">These behavioral results are consistent with the claim that consolidation serves to mediate emotional memory enhancements over the course of hours to days (<span class="xrefLink" id="jumplink-bib29"></span><a href="javascript:;" reveal-id="bib29" data-open="bib29" class="link link-ref link-reveal xref-bibr">LaBar and Phelps 1998</a>). Accordingly, postencoding consolidation manipulations influence memory after long (e.g., 24 h) but not after short (e.g., 1.5 h) delays (<span class="xrefLink" id="jumplink-bib4"></span><a href="javascript:;" reveal-id="bib4" data-open="bib4" class="link link-ref link-reveal xref-bibr">Bianchin et al. 1999</a>). The passage of time, then, should yield functional dissociations in the relative importance of encoding and consolidation effects to predicting subsequent retrieval of emotional memories (<span class="xrefLink" id="jumplink-bib19"></span><a href="javascript:;" reveal-id="bib19" data-open="bib19" class="link link-ref link-reveal xref-bibr">Hamann 2001</a>). One may predict that activity associated with arousal-mediated consolidation should increasingly distinguish between subsequently remembered and forgotten emotional items over time, whereas activity related to perceptual, attentional, or semantic encoding should make no improvement or even decay in its ability to make this distinction.</p><p class="chapter-para">Although consolidation occurs after encoding, emotional arousal during encoding initiates firing rate increases within the amygdala that can persist for up to 2 h after encoding (<span class="xrefLink" id="jumplink-bib41"></span><a href="javascript:;" reveal-id="bib41" data-open="bib41" class="link link-ref link-reveal xref-bibr">Pelletier et al. 2005</a>), spanning the period during which consolidation manipulations are particularly effective (<span class="xrefLink" id="jumplink-bib33"></span><a href="javascript:;" reveal-id="bib33" data-open="bib33" class="link link-ref link-reveal xref-bibr">McGaugh 2004</a>). Furthermore, it has been demonstrated that amygdala activity facilitates the induction and expression of hippocampal long-term potentiation, which may be the underlying mechanism of memory consolidation (<span class="xrefLink" id="jumplink-bib36"></span><a href="javascript:;" reveal-id="bib36" data-open="bib36" class="link link-ref link-reveal xref-bibr">Nakao et al. 2004</a>; <span class="xrefLink" id="jumplink-bib21"></span><a href="javascript:;" reveal-id="bib21" data-open="bib21" class="link link-ref link-reveal xref-bibr">Hu et al. 2007</a>). These effects are time sensitive: long-term potentiation benefits most when the amygdala and hippocampus are coactivated during acquisition or encoding. Thus, initial coactivation of these structures determines how much the memory trace will be strengthened and persist over time. These results give credence to the supposition that amygdala and MTL activity during encoding have implications for memory consolidation, consistent with previous interpretations of human data (<span class="xrefLink" id="jumplink-bib6"></span><a href="javascript:;" reveal-id="bib6" data-open="bib6" class="link link-ref link-reveal xref-bibr">Cahill et al. 1996</a>; <span class="xrefLink" id="jumplink-bib20"></span><a href="javascript:;" reveal-id="bib20" data-open="bib20" class="link link-ref link-reveal xref-bibr">Hamann et al. 1999</a>; <span class="xrefLink" id="jumplink-bib12"></span><a href="javascript:;" reveal-id="bib12" data-open="bib12" class="link link-ref link-reveal xref-bibr">Dolcos et al. 2004b</a>).</p><p class="chapter-para">One powerful way to study how encoding activity leads to successful memory is the subsequent memory paradigm (<span class="xrefLink" id="jumplink-bib38"></span><a href="javascript:;" reveal-id="bib38" data-open="bib38" class="link link-ref link-reveal xref-bibr">Paller and Wagner 2002</a>). This paradigm involves measuring a participant's brain activity while they encode a list of items. The results from a subsequent memory test are then applied to each participant's encoding data, classifying each encoding trial as a subsequently remembered or forgotten trial. Greater activity for remembered than forgotten trials is taken as <em>encoding success activity</em> (ESA) or encoding activity that leads to successful subsequent memory. Critically, this method enables the researcher to draw conclusions about within-subject, event-related activity that specifically predicts memory for that item. In comparison, correlations between an individual's encoding activity and overall memory score enable conclusions about across-subject, individual differences supporting later memory.</p><p class="chapter-para">Few studies have investigated the neural correlates supporting emotional memory or recollection changes over time. In 1 such study, positron emission tomography (PET) scans revealed that amygdala regional cerebral blood flow during encoding correlated with emotional recognition after a 4-week delay but not with emotional free recall after a 10-min delay (<span class="xrefLink" id="jumplink-bib20"></span><a href="javascript:;" reveal-id="bib20" data-open="bib20" class="link link-ref link-reveal xref-bibr">Hamann et al. 1999</a>). The authors attributed this effect to the role of consolidation, but due to limitations of the PET method, they were unable to look at event-related activity predicting subsequent memory. A later event-related functional magnetic resonance imaging (fMRI) investigation found that ventral amygdala activity during emotional picture viewing correlated with emotional memory after a 2-week delay whereas dorsal amygdala activity correlated with emotional memory immediately after encoding (<span class="xrefLink" id="jumplink-bib32"></span><a href="javascript:;" reveal-id="bib32" data-open="bib32" class="link link-ref link-reveal xref-bibr">Mackiewicz et al. 2006</a>). Because this experiment did not employ a subsequent memory design, these results are again derived from across-subject correlations. It remains to be seen how the amygdala participates at the trial level to identify which items will be remembered after short versus long delays. Furthermore, neither of these studies reported a corresponding behavioral effect, with improved emotional memory relative to neutral over time. Taken together, these results suggest that individual variations during emotional memory encoding are related to how well these traces persist over time, but the role of intertrial functional differences remains unclear.</p><p class="chapter-para">Another key consideration in this line of research is the dynamic nature of arousal-mediated consolidation, which depends on interactions between the amygdala and the MTL memory system. Emotional memory enhancements are contingent on coactivation of the amygdala with hippocampal (<span class="xrefLink" id="jumplink-bib46"></span><a href="javascript:;" reveal-id="bib46" data-open="bib46" class="link link-ref link-reveal xref-bibr">Roozendaal et al. 1999</a>) and parahippocampal (<span class="xrefLink" id="jumplink-bib45"></span><a href="javascript:;" reveal-id="bib45" data-open="bib45" class="link link-ref link-reveal xref-bibr">Roesler et al. 2002</a>) regions, and manipulations of either component can impact memory function (<span class="xrefLink" id="jumplink-bib35"></span><a href="javascript:;" reveal-id="bib35" data-open="bib35" class="link link-ref link-reveal xref-bibr">McIntyre et al. 2003</a>; <span class="xrefLink" id="jumplink-bib43"></span><a href="javascript:;" reveal-id="bib43" data-open="bib43" class="link link-ref link-reveal xref-bibr">Richardson et al. 2004</a>). This interactive relationship has also been observed at the level of functional neuroimaging: correlations between memory-related activity in the amygdala and that in the hippocampus (<span class="xrefLink" id="jumplink-bib12"></span><a href="javascript:;" reveal-id="bib12" data-open="bib12" class="link link-ref link-reveal xref-bibr">Dolcos et al. 2004b</a>; <span class="xrefLink" id="jumplink-bib24"></span><a href="javascript:;" reveal-id="bib24" data-open="bib24" class="link link-ref link-reveal xref-bibr">Kensinger and Corkin 2004</a>) and parahippocampal gyrus (PHG) (<span class="xrefLink" id="jumplink-bib26"></span><a href="javascript:;" reveal-id="bib26" data-open="bib26" class="link link-ref link-reveal xref-bibr">Kilpatrick and Cahill 2003</a>; <span class="xrefLink" id="jumplink-bib12"></span><a href="javascript:;" reveal-id="bib12" data-open="bib12" class="link link-ref link-reveal xref-bibr">Dolcos et al. 2004b</a>) are greater during emotional item encoding than neutral. The dynamic process of consolidation, then, may be best captured via connectivity analyses, rather than simple contrasts.</p><p class="chapter-para">The present study improves upon the previous literature by combining complementary methods to investigate the impact of study-test delay on encoding and consolidation-related activity supporting emotional memory. It employs a subsequent memory design to look at within-subject event-related activity and connectivity that distinguish between remembered and forgotten emotional items after short (20-min) versus long (1-week) delays, as well as across-subject differences that correlate with emotional memory persistence. We interrogate 3 main hypotheses: 1) activity in the amygdala and MTL memory system will be more predictive of long-delay emotional memory than short-delay emotional memory; 2) individuals who display greater amygdala responses to emotional stimuli during encoding will show greater preservation of recollection for emotional stimuli over time; and 3) functional connectivity between the amygdala and MTL memory system will be greatest for those items remembered at the long delay, representing the increasing importance of dynamic consolidation processes.</p>                    <h2 scrollto-destination=3674386 id="3674386" class="section-title js-splitscreen-section-title" >Methods</h2>
+                    <h3 scrollto-destination=3674387 id="3674387" class="section-title js-splitscreen-section-title" >Participants</h3>
+<p class="chapter-para">Nineteen young adults (9 female; mean age = 22.7 years, standard deviation [SD] = 3.2) participated in the study. Participants were healthy, right-handed, native English speakers, and with no disclosed history of neurological or psychiatric episodes. Participants gave written informed consent for a protocol approved by the Duke University Institutional Review Board. Due to image quality problems in their MRI scans, 2 of these participants were excluded from all analyses. Of the remaining 17 participants, 4 did not have enough trials (i.e., at least 10 per trial type) in each of the trial types of interest and thus could not be included in the fMRI analyses. All behavioral and neuroimaging analyses were conducted on the remaining 13 participants (7 female; mean age = 22.6 years, SD = 3.4).</p>                    <h3 scrollto-destination=3674389 id="3674389" class="section-title js-splitscreen-section-title" >Materials</h3>
+<p class="chapter-para">Stimuli consisted of 480 pictures. These were selected from the International Affective Picture System (<span class="xrefLink" id="jumplink-bib30"></span><a href="javascript:;" reveal-id="bib30" data-open="bib30" class="link link-ref link-reveal xref-bibr">Lang et al. 2001</a>) as well as from an in-house, standardized database (<span class="xrefLink" id="jumplink-bib50"></span><a href="javascript:;" reveal-id="bib50" data-open="bib50" class="link link-ref link-reveal xref-bibr">Yamasaki et al. 2002</a>) that allowed us to equate the pictures for visual complexity and content (e.g., human presence). Pictures were assigned on the basis of normative valence scores to emotionally negative (valence: 1.4–4) and neutral (valence: 4–6) conditions. In accordance with the picture selection procedure, valence scores (1 = negative, 5 = neutral, 9 = positive) were lower for negative (<em>M</em> = 2.75, SD = 0.69) than neutral pictures (<em>M</em> = 5.04, SD = 0.52; <em>t</em><sub>478</sub> = 41.22, <em>P</em> &lt; 0.001). Additionally, arousal scores (1 = calm, 9 = excited) were greater for emotional (<em>M</em> = 5.69, SD = 0.89) than neutral pictures (<em>M</em> = 3.82, SD = 0.80; <em>t</em><sub>478</sub> = 24.29, <em>P</em> &lt; 0.001).</p>                    <h3 scrollto-destination=3674391 id="3674391" class="section-title js-splitscreen-section-title" >Procedure</h3>
+<p class="chapter-para">Participants encoded pictures in the scanner, and their recognition memory for these pictures was tested after 2 different delays. During encoding, participants viewed 160 emotionally negative and 160 neutral pictures while functional MR images were recorded. The pictures were presented in color for 1 s, followed by a noise mask for 200 ms. Trials were separated by an intertrial fixation period that was quasi-exponentially distributed between 3 and 9 s, with a mean of 4750 ms, allowing for event-related fMRI analyses. Participants were instructed to indicate as soon as possible whether each picture was of an indoor or outdoor scene, and responses were collected until the onset of the next stimulus. The encoding session consisted of 5 functional runs, across which emotional and neutral pictures were evenly divided. To avoid the induction of long-lasting mood states, the pictures within each block were pseudorandomized so that no more than 3 pictures of the same valence were consecutively presented. Block presentation order was counterbalanced across subjects.</p><p class="chapter-para">Twenty minutes after encoding, participants completed a recognition task for half of these pictures (80 emotional negative, 80 neutral) outside of the scanner. An additional 40 emotionally negative and 40 neutral pictures were presented as distracters. These pictures were presented for 1 s, followed by a 1500-ms fixation, during which participants were instructed to respond whether the item was old or new. Then a confidence screen appeared for 1500 ms, instructing the participants to rate their confidence on a 3-point scale, from 1 meaning “not sure” to 3 meaning “very sure.” Trials were separated by a 1500-ms fixation period, and confidence responses were recorded until the onset of the next stimulus. This 2-step response procedure yielded 6 possible recognition response options (i.e., from “very sure new” to “very sure old”). All pictures were presented in gray scale in order to attenuate memory performance. One week later, participants were tested for their recognition of the remaining study items (80 emotionally negative, 80 neutral), also outside of the scanner. Study items were randomly assigned to 2 retrieval lists, and these lists were counterbalanced across subjects for whether they were presented at the 20-min or 1-week delay. Recognition sessions at each delay were identical in design.</p>                    <h3 scrollto-destination=3674394 id="3674394" class="section-title js-splitscreen-section-title" >Behavioral Analyses</h3>
+<p class="chapter-para">To measure overall differences in memory between conditions, <em>d</em>‘ scores were evaluated for each trial type. Recollection and familiarity estimates were derived for each subject according to a dual-process receiver operating characteristic (ROC) curve-fitting procedure (<span class="xrefLink" id="jumplink-bib51"></span><a href="javascript:;" reveal-id="bib51" data-open="bib51" class="link link-ref link-reveal xref-bibr">Yonelinas et al. 1998</a>). This model assumes that recollection and familiarity independently contribute to memory performance but are not mutually exclusive. In order to generate the ROCs, recognition data were rescaled from 1, indicating a highly confident “new” response, to 6, indicating a highly confident “old” response. Hit and false alarm rates were plotted according to this confidence scale, forming an ROC for each subject and condition. By fitting these data points to a function relating them to dual-process memory performance, we obtained parameter estimates of recollection and familiarity for each ROC. Estimates from each delay were then combined into a single measure by dividing the long-delay estimate by the corresponding short-delay estimate, yielding a measure of memories’ resistance to forgetting or “persistence.” For example, if a participant had a <em>d</em>‘ of 2.4 after a short delay and a <em>d</em>‘ of 1.2 after a long delay, the resulting “persistence score” was 0.5. A persistence score of 1 corresponds to the case when memory performance after a long delay is as high as memory performance after a short delay. Persistence scores were calculated for memory performance overall and separately for recollection (<em>recollection persistence score</em>) and for familiarity (<em>familiarity persistence score</em>). These 3 persistence scores were separately calculated for emotional and neutral pictures.</p>                    <h3 scrollto-destination=3674396 id="3674396" class="section-title js-splitscreen-section-title" >fMRI Methods</h3>
+                    <h4 scrollto-destination=3674397 id="3674397" class="section-title js-splitscreen-section-title" >Scanning</h4>
+<p class="chapter-para">Images were collected using a 4-T GE scanner. Stimuli were presented using liquid crystal display goggles (Resonance Technology, Northridge, CA), and behavioral responses were recorded using a 4-button fiber optic response box (Resonance Technology). Scanner noise was reduced with earplugs, and head motion was minimized using foam pads and a headband. Anatomical scanning started with a T2-weighted sagittal localizer series. The anterior commissure (AC) and posterior commissure (PC) were identified in the midsagittal slice, and 34 contiguous oblique slices were prescribed parallel to the AC–PC plane. High-resolution T1-weighted structural images were collected with a 500-ms repetition time (TR), a 14-ms echo time (TE), a 24-cm field of view (FOV), a 256<sup>2</sup> matrix, 68 slices, and a slice thickness of 1.9 mm. Functional images were acquired using an inverse spiral sequence with a 2-s TR, a 31-ms TE, a 24-cm FOV, a 64<sup>2</sup> matrix, and a 60° flip angle. Thirty-four contiguous slices were acquired with the same slice prescription as the anatomical images. Slice thickness was 3.8 mm, resulting in 3.75 × 3.75 × 3.8 mm voxels.</p>                    <h4 scrollto-destination=3674399 id="3674399" class="section-title js-splitscreen-section-title" >fMRI Analyses</h4>
+<p class="chapter-para">Preprocessing and data analyses were performed using SPM2 software implemented in Matlab (www.fil.ion.ucl.ac.uk/spm/). After discarding the 1st 6 volumes, the functional images were slice timing corrected and motion corrected and then spatially normalized to the Montreal Neurological Institute template and spatially smoothed using an 8-mm isotropic Gaussian kernel, and resliced to a resolution of 3.75 × 3.75 × 3.8 mm voxels. For each subject, evoked hemodynamic responses to event types were modeled with a delta (stick) function corresponding to stimulus presentation convolved with a canonical hemodynamic response function within the context of the general linear model (GLM), as implemented in SPM2. Confounding factors (head motion, magnetic field drift) were also included in the model.</p>                    <h4 scrollto-destination=3674401 id="3674401" class="section-title js-splitscreen-section-title" >Effects of Arousal on Encoding Activity Predicting Memory at Short and Long Delays</h4>
+<p class="chapter-para">The subsequent memory paradigm (<span class="xrefLink" id="jumplink-bib38"></span><a href="javascript:;" reveal-id="bib38" data-open="bib38" class="link link-ref link-reveal xref-bibr">Paller and Wagner 2002</a>) was employed to identify ESA, which was defined as greater activity for pictures that were remembered rather than forgotten in subsequent memory tests. Eight main trial types were modeled, representing all possible combinations of arousal (emotional vs. neutral pictures), delay (short vs. long delays), and subsequent retrieval (hit vs. miss trials). Long-delay misses were disregarded in all fMRI analyses because this trial type is ambiguously related to short-delay hits and misses. That is, this trial type represents items that, had they been tested at the short delay, may have been classified as either short-delay hits or misses. However, because we did not retest any items, it is unclear which items would have fallen which way. Thus, both short- and long-delay hits were compared with a common baseline, short-delay misses.</p><p class="chapter-para">To find ESA regardless of delay, short- and long-delay hits were collapsed and compared with short-delay misses for each emotion type, yielding ESA for emotional and neutral pictures for each participant. A random-effects paired <em>t</em>-test then revealed which regions showed a greater ESA for emotional than neutral pictures. This <em>t</em>-test (<em>P</em> = 0.05, extent threshold = 5 functional voxels) was inclusively masked with ESA for emotional pictures at <em>P</em> = 0.05, pulling out only those regions that contribute differentially to the encoding of emotional stimuli. Although probabilities are not completely independent, this procedure results in a threshold that approaches the joint probability estimate of <em>P</em> = 0.0025 (<span class="xrefLink" id="jumplink-bib17"></span><a href="javascript:;" reveal-id="bib17" data-open="bib17" class="link link-ref link-reveal xref-bibr">Fisher 1950</a>; <span class="xrefLink" id="jumplink-bib31"></span><a href="javascript:;" reveal-id="bib31" data-open="bib31" class="link link-ref link-reveal xref-bibr">Lazar et al. 2002</a>).</p><p class="chapter-para">To assess the interaction between arousal and delay, contrasts between short- and long-delay hits for each emotion type were generated for each subject. Because short- and long-delay hits share a common baseline, this is functionally equivalent to comparing the subsequent memory effect at the short delay with that at the long delay for each emotion type. Paired <em>t</em>-tests compared this delay effect for emotional and neutral. These <em>t</em>-tests (<em>P</em> = 0.05, extent threshold = 5 voxels) were inclusively masked at <em>P</em> = 0.05 with the corresponding delay effect (e.g., long-delay emotional hits &gt; short-delay emotional hits) and subsequent memory effect (e.g., long-delay emotional hits &gt; short-delay emotional misses) as to isolate those memory-related areas that distinguish between emotional short- and long-delay hits but not between neutral short- and long-delay hits. Because of the triple threshold, the joint probability of these activations can be estimated as approaching <em>P</em> = 0.000125.</p>                    <h4 scrollto-destination=3674405 id="3674405" class="section-title js-splitscreen-section-title" >Individual Differences Associated with Sustained Recollection</h4>
+<p class="chapter-para">In order to track regions whose activity correlated with individual differences in sustained recollection, we implemented the simple regression model in SPM2. Parametric maps contrasting all emotional or neutral items versus baseline were taken as the dependent variables for each subject, and their corresponding measures of sustained recollection served as covariates. Resulting regression maps for each emotion type were thresholded at <em>P</em> = 0.05 with extent threshold = 5 voxels within the MTL and at <em>P</em> = 0.001 with extent threshold = 5 voxels outside of the MTL. The probability threshold was lower in the MTL because we can reasonably expect to see recollection-related activity within these regions. The conjunction of these maps (via inclusive masking, both at <em>P</em> = 0.05, extent threshold = 10 voxels) was also taken to reveal general sustained recollection effects. The joint probability of this conjunction can be estimated as approaching <em>P</em> = 0.0025.</p>                    <h4 scrollto-destination=3674407 id="3674407" class="section-title js-splitscreen-section-title" >Functional Connectivity Analyses</h4>
+<p class="chapter-para">Amygdala regions identified in the previous regression analysis were further interrogated via individual trial analysis to examine the functional network of brain regions correlated with activity in this region. We created a GLM in which each individual trial was modeled by a separate covariate, yielding different parameter estimates for each individual trial and for each individual subject. The validity of the use of this design has been confirmed in previous studies (<span class="xrefLink" id="jumplink-bib44"></span><a href="javascript:;" reveal-id="bib44" data-open="bib44" class="link link-ref link-reveal xref-bibr">Rissman et al. 2004</a>; <span class="xrefLink" id="jumplink-bib8"></span><a href="javascript:;" reveal-id="bib8" data-open="bib8" class="link link-ref link-reveal xref-bibr">Daselaar, Fleck, and Cabeza 2006</a>; <span class="xrefLink" id="jumplink-bib9"></span><a href="javascript:;" reveal-id="bib9" data-open="bib9" class="link link-ref link-reveal xref-bibr">Daselaar, Fleck, Dobbins, et al. 2006</a>). Parameter estimates from our peak amygdala voxel were correlated with trial-specific parameter estimates from all other voxels, generating correlation maps for each of our trial types of interest: emotional short-delay hits, emotional long-delay hits, neutral short-delay hits, and neutral long-delay hits. The correlation data was normalized via the Fisher transform (<span class="xrefLink" id="jumplink-bib16"></span><a href="javascript:;" reveal-id="bib16" data-open="bib16" class="link link-ref link-reveal xref-bibr">Fisher 1921</a>), resulting in connectivity <em>z</em> maps.</p><p class="chapter-para">In order to assess differences in functional connectivity between our trial types, connectivity <em>z</em> maps for short- and long-delay hits were statistically compared with each other for each subject. Data from the <em>z</em> maps were 1st subtracted from each other, then divided by the standard error of the difference, <span class="inline-formula no-formula-id"><img class="contentFigures" src="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/m_cercorbhm262fx1_ht.gif?Expires=1689492105&amp;Signature=j~HplR1aPuhaVkzaJHd9X5GuYmZztZTuNI4vQjPD3DjeX9zgWEPht-ewTBSLWtQ6KuOaer2vP6KGIqyUWuDXAaFsEfv6zGVdpXIX~tom6OGktnzxXJC0o1uHnC1wIxb~UIH3ogo6PlpMPRPqksWwDfAkdNfNE05kLnOcsCgNBr-sU2bMrsOfSA9Rzu33odXE94UQ8L4Mnnt4iTRNtFVkXK~U8Qqc297f6JM-MCrNlkiOPLmKDUmKGzQN~xLwaVbk9Hke7O4dwm5hbVxS7M7rXC319uYh8-tj31KwZe7G97HEXL-YKoTQA3a15ae8SfZNtdfqVHqqZwyFOqvufuWUeQ__&amp;Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" alt="forumla" data-path-from-xml="cercorbhm262fx1_ht.gif" /></span> This yielded <em>z</em> maps representing the difference in connectivity associated with subsequent hits at each delay. These connectivity difference maps for emotional versus neutral were compared with a paired <em>t</em>-test (<em>P</em> = 0.05, extent threshold = 4 voxels within the MTL, 10 voxels elsewhere), inclusively masked with corresponding group effect (e.g., long-delay emotional hit &gt; short-delay emotional hit connectivity) at <em>P</em> = 0.05 (approaching the joint probability of <em>P</em> = 0.0025). This is consistent with the way in which we assessed the interaction of emotion and delay in our ESA analyses. In this way, we were able to isolate, for example, regions exhibiting greater amygdala connectivity for subsequent long-delay hits than for short-delay hits but only for emotional items. Individual differences in connectivity were assessed outside of SPM by exporting the difference map values for a specified functional ROI and correlating them with sustained recollection measures for each subject.</p>                    <h2 scrollto-destination=3674410 id="3674410" class="section-title js-splitscreen-section-title" >Results</h2>
+                    <h3 scrollto-destination=3674411 id="3674411" class="section-title js-splitscreen-section-title" >Behavioral Results</h3>
+<p class="chapter-para">Persistence scores were calculated by dividing long-delay <em>d</em>‘ scores by short-delay <em>d</em>‘ scores for each individual (see Methods). Although persistence scores did not show emotion effects overall, <em>P</em> &gt; 0.1 (<span class="xrefLink" id="jumplink-fig1"></span><a href="javascript:;" data-modal-source-id="fig1" class="link xref-fig">Fig. 1</a>), differences were found when persistence scores were separately calculated for recollection and familiarity. As illustrated by <span class="xrefLink" id="jumplink-fig1"></span><a href="javascript:;" data-modal-source-id="fig1" class="link xref-fig">Figure 1</a>, whereas recollection persistence scores were greater for emotional than neutral pictures, <em>t</em><sub>12</sub> = 2.75, <em>P</em> = 0.017, familiarity persistence scores did not differ as a function of emotion, <em>P</em> &gt; 0.1 (<span class="xrefLink" id="jumplink-fig1"></span><a href="javascript:;" data-modal-source-id="fig1" class="link xref-fig">Fig. 1</a>). These results are consistent with evidence that the memory-enhancing effect of emotion is driven mainly by recollection rather than familiarity (<span class="xrefLink" id="jumplink-bib37"></span><a href="javascript:;" reveal-id="bib37" data-open="bib37" class="link link-ref link-reveal xref-bibr">Ochsner 2000</a>; <span class="xrefLink" id="jumplink-bib23"></span><a href="javascript:;" reveal-id="bib23" data-open="bib23" class="link link-ref link-reveal xref-bibr">Kensinger and Corkin 2003</a>; <span class="xrefLink" id="jumplink-bib14"></span><a href="javascript:;" reveal-id="bib14" data-open="bib14" class="link link-ref link-reveal xref-bibr">Dolcos et al. 2005</a>) and expand this evidence by showing that recollection benefits increase over time.</p>                    <a id="3674413" scrollto-destination="3674413"></a>
+<div data-id="fig1" data-content-id="fig1" class="fig fig-section js-fig-section" swap-content-for-modal="true"><div class="label fig-label">Figure 1.</div><div class="graphic-wrap"><img class="content-image" src="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/m_cercorbhm262f01_ht.jpeg?Expires=1689492105&amp;Signature=BQ9uaYnNptNULcUHO7GJcBUol0ZGQaChSsCpUnx6mDbKJzyF9eMfnY0bIToVFdAcVi0U-p8uyfM785OLSezNr20DMIpAGUq-b3DJ8zV9MxFk6c95UDuKmeVIlvQwpcA838kVwKeWplfK1Hm00O5c2n~3v8DC3Bbu8vaxZX7JuHmNWp9FVtiuzy1zSfoyYw9kRpRIG4U5F2sPKos2vuShN5ZbvjiG0AMdOUEKxZALqyDQK8PRgigDk8Gp0-Wsi1jTLTi8MJiA74C6jqT23cFm3s6ZFKkEyWyOZ9BQ61UoskdWm7jmChhqfJG82jvzhV5J3uMVUIAdXbqXIe~twEeyyg__&amp;Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" alt="Behavioral results. Memory at each delay was assessed using the corrected recognition score d‘, and recollection and familiarity estimates were obtained via a dual-process ROC curve-fitting procedure (Yonelinas et al. 1998). Persistence scores for memory, recollection, and familiarity were then calculated by dividing long-delay estimates by their associated short-delay estimates (e.g., emotional memory persistence is equivalent to emotional long-delay d‘ divided by emotional short-delay d‘). Recollection persistence scores were significantly greater for emotional than neutral items, suggesting an emotional recollection effect. Error bars indicate standard error of the mean. *Significant at P = 0.05." data-path-from-xml="cercorbhm262f01_ht.jpeg" /><div class="fig-orig original-slide"><a class="fig-view-orig js-view-large at-figureViewLarge openInAnotherWindow" href="/view-large/figure/3674413/cercorbhm262f01_ht.jpeg" data-path-from-xml="cercorbhm262f01_ht.jpeg" target="_blank">Open in new tab</a><a data-section="3674413" href="/DownloadFile/DownloadImage.aspx?image=https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/cercorbhm262f01_ht.jpeg?Expires=1689492105&Signature=ly7WtVPGsPIeoq3OEmle6vrNevTF16LsO7akCIOoTI1S8yQxyIgxb~c0sf3SxhtyPMLHdJJKGjYy6UlLe9yy8OXUe8srGnKLe804pIVnNhu3vQaQEp3~35fxfW3YcglHP5DcbaFqHYTrpgWHjMIWiAwAFmmSyo7ROPKeeRV5-Jh2MQU0oTmV2x6OSuHHqAuEG9cUi0SV5MX~uRcGPlcZLrev5Q8-M-s5312Q1-nXFcY~UM2uBEFq89S8RyrtvuJmXpN~jF-ZyM8Y9MXSTNSzMNuXoUknFmWumoG6SUl3z3zNzgJqjCh9eeD~f05GeWeoQgGe11ZNa5YjGsWBO19i-A__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA&sec=3674413&ar=290170&xsltPath=~/UI/app/XSLT&imagename=&siteId=5122" class="download-slide" data-path-from-xml="cercorbhm262f01_ht.jpeg">Download slide</a></div></div><div class="caption fig-caption"><p class="chapter-para">Behavioral results. Memory at each delay was assessed using the corrected recognition score <em>d</em>‘, and recollection and familiarity estimates were obtained via a dual-process ROC curve-fitting procedure (Yonelinas et al. 1998). Persistence scores for memory, recollection, and familiarity were then calculated by dividing long-delay estimates by their associated short-delay estimates (e.g., emotional memory persistence is equivalent to emotional long-delay <em>d</em>‘ divided by emotional short-delay <em>d</em>‘). Recollection persistence scores were significantly greater for emotional than neutral items, suggesting an emotional recollection effect. Error bars indicate standard error of the mean. *Significant at <em>P</em> = 0.05.</p></div></div>                    <h3 scrollto-destination=3674414 id="3674414" class="section-title js-splitscreen-section-title" >Imaging Results</h3>
+                    <h4 scrollto-destination=3674415 id="3674415" class="section-title js-splitscreen-section-title" >Encoding Activity Predicting Memory for Emotional and Neutral Pictures After Short Versus Long Delays</h4>
+<p class="chapter-para">Analyses comparing ESA (remembered &gt; forgotten) for emotional versus neutral pictures were 1st performed collapsed over delay and then as function of delay (i.e., emotional–neutral × short–long interaction). Greater ESA for emotional than neutral stimuli collapsed over delays was found in bilateral amygdalae and the left inferior frontal gyrus (see <span class="xrefLink" id="jumplink-fig2"></span><a href="javascript:;" data-modal-source-id="fig2" class="link xref-fig">Fig. 2</a>), among other brain regions (see <span class="xrefLink" id="jumplink-tbl1"></span><a href="javascript:;" reveal-id="tbl1" data-open="tbl1" class="link link-reveal link-table xref-fig">Table 1</a>). Unexpectedly, no regions survived our interaction analysis, suggesting that ESA for emotional items does not vary by delay. Thus, the results did not support our 1st prediction that activity in the amygdala and MTL memory system would be more predictive of memory after a long delay than after a short delay in the case of emotional pictures. Instead, ESA for emotional pictures was comparable for short- and long-delay memory (see <span class="xrefLink" id="jumplink-fig2"></span><a href="javascript:;" data-modal-source-id="fig2" class="link xref-fig">Fig. 2</a>).</p>                    <a id="3674417" scrollto-destination="3674417"></a>
+<div content-id="tbl1" class="table-modal table-full-width-wrap"><div class="table-wrap table-wide"><div class="table-wrap-title" id="tbl1" data-id="tbl1"><span class="label">Table 1</span><div class="caption"><p class="chapter-para">ESA (remembered &gt; forgotten) collapsed over delay</p></div> </div><div class="table-overflow"><table role="table"><thead><tr><td> </td><td>BA </td><td>Hem </td><td colspan="4">Coordinates (T and T)<hr /> </td><td>Voxels </td></tr><tr><td> </td><td> </td><td> </td><td><em>x</em> </td><td><em>y</em> </td><td><em>z</em> </td><td><em>t</em> </td><td> </td></tr></thead><tbody><tr><td>ESA emotional &gt; ESA neutral </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    MTL </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Amygdala/PHG </td><td char=".">28 </td><td>R </td><td char=".">26 </td><td char=".">3 </td><td char=".">−23 </td><td char=".">3.31 </td><td char=".">12 </td></tr><tr><td>    Amygdala/PHG </td><td char=".">34 </td><td>L </td><td char=".">−19 </td><td char=".">3 </td><td char=".">−19 </td><td char=".">2.86 </td><td char=".">5 </td></tr><tr><td>    Inferior frontal gyrus </td><td char=".">45 </td><td>L </td><td char=".">−48 </td><td char=".">29 </td><td char=".">6 </td><td char=".">2.58 </td><td char=".">5 </td></tr><tr><td>    Inferior temporal gyrus </td><td char=".">37 </td><td>L </td><td char=".">−56 </td><td char=".">−48 </td><td char=".">−17 </td><td char=".">2.24 </td><td char=".">5 </td></tr><tr><td>    Angular gyrus </td><td char=".">39 </td><td>R </td><td char=".">37 </td><td char=".">−64 </td><td char=".">35 </td><td char=".">3.06 </td><td char=".">44 </td></tr><tr><td>ESA neutral &gt; ESA emotional </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Hippocampus </td><td> </td><td>R </td><td char=".">30 </td><td char=".">−33 </td><td char=".">−2 </td><td char=".">4.72 </td><td char=".">19 </td></tr><tr><td>    Cingulate gyrus </td><td char=".">24 </td><td>R </td><td char=".">4 </td><td char=".">22 </td><td char=".">−4 </td><td char=".">4.79 </td><td char=".">16 </td></tr><tr><td> </td><td char=".">24 </td><td>L </td><td char=".">−19 </td><td char=".">−13 </td><td char=".">39 </td><td char=".">2.52 </td><td char=".">14 </td></tr><tr><td>    Caudate </td><td> </td><td>L </td><td char=".">−11 </td><td char=".">18 </td><td char=".">3 </td><td char=".">4.43 </td><td char=".">10 </td></tr><tr><td> </td><td> </td><td>R </td><td char=".">15 </td><td char=".">12 </td><td char=".">17 </td><td char=".">3.62 </td><td char=".">18 </td></tr><tr><td>    Lentiform nucleus </td><td> </td><td>L </td><td char=".">−26 </td><td char=".">−18 </td><td char=".">4 </td><td char=".">2.53 </td><td char=".">7 </td></tr><tr><td>    Temporal </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Middle temporal gyrus </td><td char=".">21 </td><td>R </td><td char=".">63 </td><td char=".">−33 </td><td char=".">5 </td><td char=".">3.86 </td><td char=".">5 </td></tr><tr><td> </td><td char=".">21 </td><td>R </td><td char=".">45 </td><td char=".">−54 </td><td char=".">3 </td><td char=".">2.18 </td><td char=".">6 </td></tr><tr><td>    Inferior temporal gyrus/fusiform gyrus </td><td char=".">37 </td><td>L </td><td char=".">−37 </td><td char=".">−51 </td><td char=".">−7 </td><td char=".">4.96 </td><td char=".">66 </td></tr><tr><td>    Cerebellum </td><td> </td><td>R </td><td char=".">33 </td><td char=".">−52 </td><td char=".">−23 </td><td char=".">2.15 </td><td char=".">6 </td></tr><tr><td>    Occipital </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Fusiform gyrus </td><td char=".">37 </td><td>L </td><td char=".">−37 </td><td char=".">−59 </td><td char=".">−16 </td><td char=".">2.71 </td><td char=".">9 </td></tr><tr><td>    Middle occipital gyrus </td><td char=".">19 </td><td>R </td><td char=".">30 </td><td char=".">−76 </td><td char=".">11 </td><td char=".">3.6 </td><td char=".">6 </td></tr></tbody></table></div><div class="table-modal"><table><thead><tr><td> </td><td>BA </td><td>Hem </td><td colspan="4">Coordinates (T and T)<hr /> </td><td>Voxels </td></tr><tr><td> </td><td> </td><td> </td><td><em>x</em> </td><td><em>y</em> </td><td><em>z</em> </td><td><em>t</em> </td><td> </td></tr></thead><tbody><tr><td>ESA emotional &gt; ESA neutral </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    MTL </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Amygdala/PHG </td><td char=".">28 </td><td>R </td><td char=".">26 </td><td char=".">3 </td><td char=".">−23 </td><td char=".">3.31 </td><td char=".">12 </td></tr><tr><td>    Amygdala/PHG </td><td char=".">34 </td><td>L </td><td char=".">−19 </td><td char=".">3 </td><td char=".">−19 </td><td char=".">2.86 </td><td char=".">5 </td></tr><tr><td>    Inferior frontal gyrus </td><td char=".">45 </td><td>L </td><td char=".">−48 </td><td char=".">29 </td><td char=".">6 </td><td char=".">2.58 </td><td char=".">5 </td></tr><tr><td>    Inferior temporal gyrus </td><td char=".">37 </td><td>L </td><td char=".">−56 </td><td char=".">−48 </td><td char=".">−17 </td><td char=".">2.24 </td><td char=".">5 </td></tr><tr><td>    Angular gyrus </td><td char=".">39 </td><td>R </td><td char=".">37 </td><td char=".">−64 </td><td char=".">35 </td><td char=".">3.06 </td><td char=".">44 </td></tr><tr><td>ESA neutral &gt; ESA emotional </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Hippocampus </td><td> </td><td>R </td><td char=".">30 </td><td char=".">−33 </td><td char=".">−2 </td><td char=".">4.72 </td><td char=".">19 </td></tr><tr><td>    Cingulate gyrus </td><td char=".">24 </td><td>R </td><td char=".">4 </td><td char=".">22 </td><td char=".">−4 </td><td char=".">4.79 </td><td char=".">16 </td></tr><tr><td> </td><td char=".">24 </td><td>L </td><td char=".">−19 </td><td char=".">−13 </td><td char=".">39 </td><td char=".">2.52 </td><td char=".">14 </td></tr><tr><td>    Caudate </td><td> </td><td>L </td><td char=".">−11 </td><td char=".">18 </td><td char=".">3 </td><td char=".">4.43 </td><td char=".">10 </td></tr><tr><td> </td><td> </td><td>R </td><td char=".">15 </td><td char=".">12 </td><td char=".">17 </td><td char=".">3.62 </td><td char=".">18 </td></tr><tr><td>    Lentiform nucleus </td><td> </td><td>L </td><td char=".">−26 </td><td char=".">−18 </td><td char=".">4 </td><td char=".">2.53 </td><td char=".">7 </td></tr><tr><td>    Temporal </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Middle temporal gyrus </td><td char=".">21 </td><td>R </td><td char=".">63 </td><td char=".">−33 </td><td char=".">5 </td><td char=".">3.86 </td><td char=".">5 </td></tr><tr><td> </td><td char=".">21 </td><td>R </td><td char=".">45 </td><td char=".">−54 </td><td char=".">3 </td><td char=".">2.18 </td><td char=".">6 </td></tr><tr><td>    Inferior temporal gyrus/fusiform gyrus </td><td char=".">37 </td><td>L </td><td char=".">−37 </td><td char=".">−51 </td><td char=".">−7 </td><td char=".">4.96 </td><td char=".">66 </td></tr><tr><td>    Cerebellum </td><td> </td><td>R </td><td char=".">33 </td><td char=".">−52 </td><td char=".">−23 </td><td char=".">2.15 </td><td char=".">6 </td></tr><tr><td>    Occipital </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Fusiform gyrus </td><td char=".">37 </td><td>L </td><td char=".">−37 </td><td char=".">−59 </td><td char=".">−16 </td><td char=".">2.71 </td><td char=".">9 </td></tr><tr><td>    Middle occipital gyrus </td><td char=".">19 </td><td>R </td><td char=".">30 </td><td char=".">−76 </td><td char=".">11 </td><td char=".">3.6 </td><td char=".">6 </td></tr></tbody></table></div><div class="table-wrap-foot"><span id="fn-"></span><div content-id="" class="footnote"><span class="fn"><p class="chapter-para">Note: BA, Brodmann area; Hem, hemisphere; t, statistical <em>t</em> value; R, right; L, left; Talairach and Tournoux (T and T) coordinates reported.</p></span></div></div><div class="&#xA;          graphic-wrap&#xA;          "><a class="fig-view-orig at-tableViewLarge openInAnotherWindow btn js-view-large" target="_blank" href="/view-large/3674417">
+          Open in new tab
+        </a></div></div></div><div class="table-full-width-wrap"><div class="table-wrap table-wide"><div class="table-wrap-title" id="tbl1" data-id="tbl1"><span class="label">Table 1</span><div class="caption"><p class="chapter-para">ESA (remembered &gt; forgotten) collapsed over delay</p></div> </div><div class="table-overflow"><table role="table"><thead><tr><td> </td><td>BA </td><td>Hem </td><td colspan="4">Coordinates (T and T)<hr /> </td><td>Voxels </td></tr><tr><td> </td><td> </td><td> </td><td><em>x</em> </td><td><em>y</em> </td><td><em>z</em> </td><td><em>t</em> </td><td> </td></tr></thead><tbody><tr><td>ESA emotional &gt; ESA neutral </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    MTL </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Amygdala/PHG </td><td char=".">28 </td><td>R </td><td char=".">26 </td><td char=".">3 </td><td char=".">−23 </td><td char=".">3.31 </td><td char=".">12 </td></tr><tr><td>    Amygdala/PHG </td><td char=".">34 </td><td>L </td><td char=".">−19 </td><td char=".">3 </td><td char=".">−19 </td><td char=".">2.86 </td><td char=".">5 </td></tr><tr><td>    Inferior frontal gyrus </td><td char=".">45 </td><td>L </td><td char=".">−48 </td><td char=".">29 </td><td char=".">6 </td><td char=".">2.58 </td><td char=".">5 </td></tr><tr><td>    Inferior temporal gyrus </td><td char=".">37 </td><td>L </td><td char=".">−56 </td><td char=".">−48 </td><td char=".">−17 </td><td char=".">2.24 </td><td char=".">5 </td></tr><tr><td>    Angular gyrus </td><td char=".">39 </td><td>R </td><td char=".">37 </td><td char=".">−64 </td><td char=".">35 </td><td char=".">3.06 </td><td char=".">44 </td></tr><tr><td>ESA neutral &gt; ESA emotional </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Hippocampus </td><td> </td><td>R </td><td char=".">30 </td><td char=".">−33 </td><td char=".">−2 </td><td char=".">4.72 </td><td char=".">19 </td></tr><tr><td>    Cingulate gyrus </td><td char=".">24 </td><td>R </td><td char=".">4 </td><td char=".">22 </td><td char=".">−4 </td><td char=".">4.79 </td><td char=".">16 </td></tr><tr><td> </td><td char=".">24 </td><td>L </td><td char=".">−19 </td><td char=".">−13 </td><td char=".">39 </td><td char=".">2.52 </td><td char=".">14 </td></tr><tr><td>    Caudate </td><td> </td><td>L </td><td char=".">−11 </td><td char=".">18 </td><td char=".">3 </td><td char=".">4.43 </td><td char=".">10 </td></tr><tr><td> </td><td> </td><td>R </td><td char=".">15 </td><td char=".">12 </td><td char=".">17 </td><td char=".">3.62 </td><td char=".">18 </td></tr><tr><td>    Lentiform nucleus </td><td> </td><td>L </td><td char=".">−26 </td><td char=".">−18 </td><td char=".">4 </td><td char=".">2.53 </td><td char=".">7 </td></tr><tr><td>    Temporal </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Middle temporal gyrus </td><td char=".">21 </td><td>R </td><td char=".">63 </td><td char=".">−33 </td><td char=".">5 </td><td char=".">3.86 </td><td char=".">5 </td></tr><tr><td> </td><td char=".">21 </td><td>R </td><td char=".">45 </td><td char=".">−54 </td><td char=".">3 </td><td char=".">2.18 </td><td char=".">6 </td></tr><tr><td>    Inferior temporal gyrus/fusiform gyrus </td><td char=".">37 </td><td>L </td><td char=".">−37 </td><td char=".">−51 </td><td char=".">−7 </td><td char=".">4.96 </td><td char=".">66 </td></tr><tr><td>    Cerebellum </td><td> </td><td>R </td><td char=".">33 </td><td char=".">−52 </td><td char=".">−23 </td><td char=".">2.15 </td><td char=".">6 </td></tr><tr><td>    Occipital </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Fusiform gyrus </td><td char=".">37 </td><td>L </td><td char=".">−37 </td><td char=".">−59 </td><td char=".">−16 </td><td char=".">2.71 </td><td char=".">9 </td></tr><tr><td>    Middle occipital gyrus </td><td char=".">19 </td><td>R </td><td char=".">30 </td><td char=".">−76 </td><td char=".">11 </td><td char=".">3.6 </td><td char=".">6 </td></tr></tbody></table></div><div class="table-modal"><table><thead><tr><td> </td><td>BA </td><td>Hem </td><td colspan="4">Coordinates (T and T)<hr /> </td><td>Voxels </td></tr><tr><td> </td><td> </td><td> </td><td><em>x</em> </td><td><em>y</em> </td><td><em>z</em> </td><td><em>t</em> </td><td> </td></tr></thead><tbody><tr><td>ESA emotional &gt; ESA neutral </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    MTL </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Amygdala/PHG </td><td char=".">28 </td><td>R </td><td char=".">26 </td><td char=".">3 </td><td char=".">−23 </td><td char=".">3.31 </td><td char=".">12 </td></tr><tr><td>    Amygdala/PHG </td><td char=".">34 </td><td>L </td><td char=".">−19 </td><td char=".">3 </td><td char=".">−19 </td><td char=".">2.86 </td><td char=".">5 </td></tr><tr><td>    Inferior frontal gyrus </td><td char=".">45 </td><td>L </td><td char=".">−48 </td><td char=".">29 </td><td char=".">6 </td><td char=".">2.58 </td><td char=".">5 </td></tr><tr><td>    Inferior temporal gyrus </td><td char=".">37 </td><td>L </td><td char=".">−56 </td><td char=".">−48 </td><td char=".">−17 </td><td char=".">2.24 </td><td char=".">5 </td></tr><tr><td>    Angular gyrus </td><td char=".">39 </td><td>R </td><td char=".">37 </td><td char=".">−64 </td><td char=".">35 </td><td char=".">3.06 </td><td char=".">44 </td></tr><tr><td>ESA neutral &gt; ESA emotional </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Hippocampus </td><td> </td><td>R </td><td char=".">30 </td><td char=".">−33 </td><td char=".">−2 </td><td char=".">4.72 </td><td char=".">19 </td></tr><tr><td>    Cingulate gyrus </td><td char=".">24 </td><td>R </td><td char=".">4 </td><td char=".">22 </td><td char=".">−4 </td><td char=".">4.79 </td><td char=".">16 </td></tr><tr><td> </td><td char=".">24 </td><td>L </td><td char=".">−19 </td><td char=".">−13 </td><td char=".">39 </td><td char=".">2.52 </td><td char=".">14 </td></tr><tr><td>    Caudate </td><td> </td><td>L </td><td char=".">−11 </td><td char=".">18 </td><td char=".">3 </td><td char=".">4.43 </td><td char=".">10 </td></tr><tr><td> </td><td> </td><td>R </td><td char=".">15 </td><td char=".">12 </td><td char=".">17 </td><td char=".">3.62 </td><td char=".">18 </td></tr><tr><td>    Lentiform nucleus </td><td> </td><td>L </td><td char=".">−26 </td><td char=".">−18 </td><td char=".">4 </td><td char=".">2.53 </td><td char=".">7 </td></tr><tr><td>    Temporal </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Middle temporal gyrus </td><td char=".">21 </td><td>R </td><td char=".">63 </td><td char=".">−33 </td><td char=".">5 </td><td char=".">3.86 </td><td char=".">5 </td></tr><tr><td> </td><td char=".">21 </td><td>R </td><td char=".">45 </td><td char=".">−54 </td><td char=".">3 </td><td char=".">2.18 </td><td char=".">6 </td></tr><tr><td>    Inferior temporal gyrus/fusiform gyrus </td><td char=".">37 </td><td>L </td><td char=".">−37 </td><td char=".">−51 </td><td char=".">−7 </td><td char=".">4.96 </td><td char=".">66 </td></tr><tr><td>    Cerebellum </td><td> </td><td>R </td><td char=".">33 </td><td char=".">−52 </td><td char=".">−23 </td><td char=".">2.15 </td><td char=".">6 </td></tr><tr><td>    Occipital </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Fusiform gyrus </td><td char=".">37 </td><td>L </td><td char=".">−37 </td><td char=".">−59 </td><td char=".">−16 </td><td char=".">2.71 </td><td char=".">9 </td></tr><tr><td>    Middle occipital gyrus </td><td char=".">19 </td><td>R </td><td char=".">30 </td><td char=".">−76 </td><td char=".">11 </td><td char=".">3.6 </td><td char=".">6 </td></tr></tbody></table></div><div class="table-wrap-foot"><span id="fn-"></span><div content-id="" class="footnote"><span class="fn"><p class="chapter-para">Note: BA, Brodmann area; Hem, hemisphere; t, statistical <em>t</em> value; R, right; L, left; Talairach and Tournoux (T and T) coordinates reported.</p></span></div></div><div class="&#xA;          graphic-wrap&#xA;          "><a class="fig-view-orig at-tableViewLarge openInAnotherWindow btn js-view-large" target="_blank" href="/view-large/3674417">
+          Open in new tab
+        </a></div></div></div>                    <a id="3674418" scrollto-destination="3674418"></a>
+<div data-id="fig2" data-content-id="fig2" class="fig fig-section js-fig-section" swap-content-for-modal="true"><div class="label fig-label">Figure 2.</div><div class="graphic-wrap"><img class="content-image" src="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/m_cercorbhm262f02_4c.jpeg?Expires=1689492105&amp;Signature=0rqsBHxWhQISsPyCwIAx-WbOGAe8FFri672BgbXH-DjcAiVMK~rMITh32EjeEn8T~Z5ehRZft9ny614-ipuZklqil3Igy8gCgYGyDzk3AyIFNl3mMlIFBQh2c09Jq-0QGx3p3ARrQlujnHC9LmiJIE7KPndLpatAe4tPeakVBKxi5L0OveM5qx6N-K3ww4Wj2P751vybTqEvW-XSBWR5fbC94gEc5wF7gqFHxddZiLgdch6436rXRmOT3~qbLpnZXYL6FJ7tqvkxuUKoQo9GY-Zt5ajdrTHINxfou3Aby7y6rlwSil0Rgs0Mws1hXl7zFx~QUTYw6xFVICu5EYgRpw__&amp;Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" alt="ESA for emotional items. Areas that show greater ESA for emotional (Emo) than neutral (Neut) items include (a) bilateral amygdalae and (b) left inferior frontal gyrus (IFG). Bar graphs represent functional ESA estimates, that is, group-averaged contrasts between hits at each delay (short and long) and short-delay misses. Error bars indicate standard error of the mean. See Table 1 for coordinates." data-path-from-xml="cercorbhm262f02_4c.jpeg" /><div class="fig-orig original-slide"><a class="fig-view-orig js-view-large at-figureViewLarge openInAnotherWindow" href="/view-large/figure/3674418/cercorbhm262f02_4c.jpeg" data-path-from-xml="cercorbhm262f02_4c.jpeg" target="_blank">Open in new tab</a><a data-section="3674418" href="/DownloadFile/DownloadImage.aspx?image=https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/cercorbhm262f02_4c.jpeg?Expires=1689492105&Signature=4psdAFtFwqcFL46Ki95ZEi9D32toWTZlMGot5XLko6fEshOZ3caZ8sBn-w5fktVgS4vTnioCMnmlnwkRpYQrNvHLUw4HBkxAq4PkCHPZ-Fi4ZfDbV5kfoRIyng5i5OFVxrrQ8Gv8irxQi8UYjKjLDqbiEBy4idWR4KFeEEvvqzDcILlywy3n0t0IMEMJA~~wN5zH7Xf0L35zOC3Ckf0eY7NZ18COrVHLDezKGCuIWs3EJ58MIikF44YWalAwhG~lsiWPwwJiSWwfnJrHuEBFe0tlcJ3cgTCdvfynpQKKwBucqfowXyE0d9M18dUY2J~YIQ8AGM-liBrmXLLXvZUMQQ__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA&sec=3674418&ar=290170&xsltPath=~/UI/app/XSLT&imagename=&siteId=5122" class="download-slide" data-path-from-xml="cercorbhm262f02_4c.jpeg">Download slide</a></div></div><div class="caption fig-caption"><p class="chapter-para">ESA for emotional items. Areas that show greater ESA for emotional (Emo) than neutral (Neut) items include (<em>a</em>) bilateral amygdalae and (<em>b</em>) left inferior frontal gyrus (IFG). Bar graphs represent functional ESA estimates, that is, group-averaged contrasts between hits at each delay (short and long) and short-delay misses. Error bars indicate standard error of the mean. See <span class="xrefLink" id="jumplink-tbl1"></span><a href="javascript:;" reveal-id="tbl1" data-open="tbl1" class="link link-reveal link-table xref-fig">Table 1</a> for coordinates.</p></div></div>                    <h4 scrollto-destination=3674419 id="3674419" class="section-title js-splitscreen-section-title" >Individual Differences Associated with Recollection Persistence for Emotional Stimuli</h4>
+<p class="chapter-para">To identify activity more directly associated with consolidation processes leading to recollection after a long delay, individual recollection persistence scores (long divided by short) were entered as a regressor in a whole-brain analysis. Consistent with our 2nd prediction, 1 of the brain regions showing significant correlations between encoding activity and recollection persistence scores was the amygdala (see <span class="xrefLink" id="jumplink-tbl2"></span><a href="javascript:;" reveal-id="tbl2" data-open="tbl2" class="link link-reveal link-table xref-fig">Table 2</a>). Moreover, left amygdala activity predicted recollection persistence scores in the case of emotional pictures but not in the case of neutral pictures (see <span class="xrefLink" id="jumplink-fig3"></span><a href="javascript:;" data-modal-source-id="fig3" class="link xref-fig">Fig. 3</a>). This suggests that people with greater amygdala response to emotional items during encoding are more likely to maintain strong, recollective memory traces for these items over time. Recollection persistence scores for emotional stimuli were also correlated with activity in the left fusiform gyrus (<span class="xrefLink" id="jumplink-tbl2"></span><a href="javascript:;" reveal-id="tbl2" data-open="tbl2" class="link link-reveal link-table xref-fig">Table 2</a>). Recollection persistence scores for neutral stimuli were not correlated with any regions, even using a more lenient threshold (<em>P</em> = 0.005 outside MTL). The conjunction of emotional and neutral regression maps revealed 2 regions predictive of recollection persistence scores for both emotional and neutral stimuli: left fusiform gyrus and posterior left inferior frontal gyrus. Thus, the left amygdala was involved in predicting recollection persistence scores only for emotional items.</p>                    <a id="3674421" scrollto-destination="3674421"></a>
+<div content-id="tbl2" class="table-modal table-full-width-wrap"><div class="table-wrap table-wide"><div class="table-wrap-title" id="tbl2" data-id="tbl2"><span class="label">Table 2</span><div class="caption"><p class="chapter-para">Activity predicting individual differences in recollection persistence</p></div> </div><div class="table-overflow"><table role="table"><thead><tr><td> </td><td>BA </td><td>Hem </td><td colspan="4">Coordinates (T and T)<hr /> </td><td>Voxels </td></tr><tr><td> </td><td> </td><td> </td><td><em>x</em> </td><td><em>y</em> </td><td><em>z</em> </td><td><em>t</em> </td><td> </td></tr></thead><tbody><tr><td colspan="3">Correlations with recollection persistence for emotional stimuli </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Amygdala </td><td> </td><td>L </td><td char=".">−22 </td><td char=".">−4 </td><td char=".">−13 </td><td char=".">2.85 </td><td char=".">11 </td></tr><tr><td>    Fusiform gyrus </td><td char=".">19 </td><td>L </td><td char=".">−37 </td><td char=".">−77 </td><td char=".">−9 </td><td char=".">5.31 </td><td char=".">9 </td></tr><tr><td colspan="8">Correlations with recollection persistence for both emotional and neutral stimuli </td></tr><tr><td>    Inferior frontal gyrus </td><td char=".">6 </td><td>L </td><td char=".">−45 </td><td char=".">2 </td><td char=".">35 </td><td char=".">3.93 </td><td char=".">10 </td></tr><tr><td>    Fusiform gyrus </td><td char=".">19 </td><td>L </td><td char=".">−37 </td><td char=".">−77 </td><td char=".">−9 </td><td char=".">5.31 </td><td char=".">15 </td></tr></tbody></table></div><div class="table-modal"><table><thead><tr><td> </td><td>BA </td><td>Hem </td><td colspan="4">Coordinates (T and T)<hr /> </td><td>Voxels </td></tr><tr><td> </td><td> </td><td> </td><td><em>x</em> </td><td><em>y</em> </td><td><em>z</em> </td><td><em>t</em> </td><td> </td></tr></thead><tbody><tr><td colspan="3">Correlations with recollection persistence for emotional stimuli </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Amygdala </td><td> </td><td>L </td><td char=".">−22 </td><td char=".">−4 </td><td char=".">−13 </td><td char=".">2.85 </td><td char=".">11 </td></tr><tr><td>    Fusiform gyrus </td><td char=".">19 </td><td>L </td><td char=".">−37 </td><td char=".">−77 </td><td char=".">−9 </td><td char=".">5.31 </td><td char=".">9 </td></tr><tr><td colspan="8">Correlations with recollection persistence for both emotional and neutral stimuli </td></tr><tr><td>    Inferior frontal gyrus </td><td char=".">6 </td><td>L </td><td char=".">−45 </td><td char=".">2 </td><td char=".">35 </td><td char=".">3.93 </td><td char=".">10 </td></tr><tr><td>    Fusiform gyrus </td><td char=".">19 </td><td>L </td><td char=".">−37 </td><td char=".">−77 </td><td char=".">−9 </td><td char=".">5.31 </td><td char=".">15 </td></tr></tbody></table></div><div class="table-wrap-foot"><span id="fn-"></span><div content-id="" class="footnote"><span class="fn"><p class="chapter-para">Note: BA, Brodmann area; Hem, hemisphere; <em>t</em>, statistical <em>t</em> value; L, left; Talairach and Tournoux (T and T) coordinates reported.</p></span></div></div><div class="&#xA;          graphic-wrap&#xA;          "><a class="fig-view-orig at-tableViewLarge openInAnotherWindow btn js-view-large" target="_blank" href="/view-large/3674421">
+          Open in new tab
+        </a></div></div></div><div class="table-full-width-wrap"><div class="table-wrap table-wide"><div class="table-wrap-title" id="tbl2" data-id="tbl2"><span class="label">Table 2</span><div class="caption"><p class="chapter-para">Activity predicting individual differences in recollection persistence</p></div> </div><div class="table-overflow"><table role="table"><thead><tr><td> </td><td>BA </td><td>Hem </td><td colspan="4">Coordinates (T and T)<hr /> </td><td>Voxels </td></tr><tr><td> </td><td> </td><td> </td><td><em>x</em> </td><td><em>y</em> </td><td><em>z</em> </td><td><em>t</em> </td><td> </td></tr></thead><tbody><tr><td colspan="3">Correlations with recollection persistence for emotional stimuli </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Amygdala </td><td> </td><td>L </td><td char=".">−22 </td><td char=".">−4 </td><td char=".">−13 </td><td char=".">2.85 </td><td char=".">11 </td></tr><tr><td>    Fusiform gyrus </td><td char=".">19 </td><td>L </td><td char=".">−37 </td><td char=".">−77 </td><td char=".">−9 </td><td char=".">5.31 </td><td char=".">9 </td></tr><tr><td colspan="8">Correlations with recollection persistence for both emotional and neutral stimuli </td></tr><tr><td>    Inferior frontal gyrus </td><td char=".">6 </td><td>L </td><td char=".">−45 </td><td char=".">2 </td><td char=".">35 </td><td char=".">3.93 </td><td char=".">10 </td></tr><tr><td>    Fusiform gyrus </td><td char=".">19 </td><td>L </td><td char=".">−37 </td><td char=".">−77 </td><td char=".">−9 </td><td char=".">5.31 </td><td char=".">15 </td></tr></tbody></table></div><div class="table-modal"><table><thead><tr><td> </td><td>BA </td><td>Hem </td><td colspan="4">Coordinates (T and T)<hr /> </td><td>Voxels </td></tr><tr><td> </td><td> </td><td> </td><td><em>x</em> </td><td><em>y</em> </td><td><em>z</em> </td><td><em>t</em> </td><td> </td></tr></thead><tbody><tr><td colspan="3">Correlations with recollection persistence for emotional stimuli </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Amygdala </td><td> </td><td>L </td><td char=".">−22 </td><td char=".">−4 </td><td char=".">−13 </td><td char=".">2.85 </td><td char=".">11 </td></tr><tr><td>    Fusiform gyrus </td><td char=".">19 </td><td>L </td><td char=".">−37 </td><td char=".">−77 </td><td char=".">−9 </td><td char=".">5.31 </td><td char=".">9 </td></tr><tr><td colspan="8">Correlations with recollection persistence for both emotional and neutral stimuli </td></tr><tr><td>    Inferior frontal gyrus </td><td char=".">6 </td><td>L </td><td char=".">−45 </td><td char=".">2 </td><td char=".">35 </td><td char=".">3.93 </td><td char=".">10 </td></tr><tr><td>    Fusiform gyrus </td><td char=".">19 </td><td>L </td><td char=".">−37 </td><td char=".">−77 </td><td char=".">−9 </td><td char=".">5.31 </td><td char=".">15 </td></tr></tbody></table></div><div class="table-wrap-foot"><span id="fn-"></span><div content-id="" class="footnote"><span class="fn"><p class="chapter-para">Note: BA, Brodmann area; Hem, hemisphere; <em>t</em>, statistical <em>t</em> value; L, left; Talairach and Tournoux (T and T) coordinates reported.</p></span></div></div><div class="&#xA;          graphic-wrap&#xA;          "><a class="fig-view-orig at-tableViewLarge openInAnotherWindow btn js-view-large" target="_blank" href="/view-large/3674421">
+          Open in new tab
+        </a></div></div></div>                    <a id="3674422" scrollto-destination="3674422"></a>
+<div data-id="fig3" data-content-id="fig3" class="fig fig-section js-fig-section" swap-content-for-modal="true"><div class="label fig-label">Figure 3.</div><div class="graphic-wrap"><img class="content-image" src="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/m_cercorbhm262f03_4c.jpeg?Expires=1689492105&amp;Signature=gqBkUj8z2w0z7xuNEx3Md~dGlzcXiNl960EZhRVYI~vRyxGN6wPwkSbDbK-wIrctqbZdFkkTbYVyCiproZBUimHyolM0XPVOn7RDq-CrZFZ6vi4KA6jSo-0j0a2K4CafLCXtc3CdeHez4Fnl~CFB7Jm2zbHDE5u0Zf2DQxwesn14gM7FYbPK3GO9TczMmbH4MUytCUUvsIsi9ybXUtxjxC2q7n0CgmWNv5pybi4cpxe9l9jSyloVy5UZxjCE3sHWR6o9msAGXHkK4DZzN-5f4xuoyBR~k43GN9KwVTYMoasNpLAmxdf1ZOUbFstjFaOfDec8Lz2mXAtexw-wClGl0g__&amp;Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" alt="Activity-associated individual differences in recollection persistence for emotional stimuli. (a) Left amygdala region whose activity correlates across subjects with individual differences in recollection persistence for emotional items. See Table 2 for coordinates. (b) Scatterplot depicting the relationship between individual recollection persistence scores for emotional stimuli and mean activity in the left amygdala region in response to emotional pictures. (c) Scatterplot depicting the relationship between individual recollection persistence scores for neutral stimuli and mean activity in the left amygdala region in response to neutral pictures." data-path-from-xml="cercorbhm262f03_4c.jpeg" /><div class="fig-orig original-slide"><a class="fig-view-orig js-view-large at-figureViewLarge openInAnotherWindow" href="/view-large/figure/3674422/cercorbhm262f03_4c.jpeg" data-path-from-xml="cercorbhm262f03_4c.jpeg" target="_blank">Open in new tab</a><a data-section="3674422" href="/DownloadFile/DownloadImage.aspx?image=https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/cercorbhm262f03_4c.jpeg?Expires=1689492105&Signature=WtjaZ63mWyA2vYzFjauNurSPo9j7HUYA~x75mxJ6kw65lKVVLoWd2EJWOTzHqPbDLM81~I4xzTbtQz~iTM3Ezf9cdQPTl7gOIjvH4WXMFTZIcr30or2WwVGC608ZxiIyEZGTPfU68m~fw5SaIxpjKwOFNRkeqXiNCz8QbufgMhLEUtYLNnT5N6nTsSPZtWwl7ZCYMyw7ohZryj-bJyiTE3YSExKnufxeEXcYxOfYudH9xbFBQJhT0D5cF32~GOdU34W-6QM5FXsajMSBV4s3E3dcxHcp6uwTnb4ThK3mlueimptgiSnvRL3-jJB0kvCgveBA0TdtzLYF70jPvmlYFQ__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA&sec=3674422&ar=290170&xsltPath=~/UI/app/XSLT&imagename=&siteId=5122" class="download-slide" data-path-from-xml="cercorbhm262f03_4c.jpeg">Download slide</a></div></div><div class="caption fig-caption"><p class="chapter-para">Activity-associated individual differences in recollection persistence for emotional stimuli. (<em>a</em>) Left amygdala region whose activity correlates across subjects with individual differences in recollection persistence for emotional items. See <span class="xrefLink" id="jumplink-tbl2"></span><a href="javascript:;" reveal-id="tbl2" data-open="tbl2" class="link link-reveal link-table xref-fig">Table 2</a> for coordinates. (<em>b</em>) Scatterplot depicting the relationship between individual recollection persistence scores for emotional stimuli and mean activity in the left amygdala region in response to emotional pictures. (<em>c</em>) Scatterplot depicting the relationship between individual recollection persistence scores for neutral stimuli and mean activity in the left amygdala region in response to neutral pictures.</p></div></div>                    <h4 scrollto-destination=3674423 id="3674423" class="section-title js-splitscreen-section-title" >Functional Connectivity Distinguishing between Remembered Items at Short Versus Long Delays</h4>
+<p class="chapter-para">The peak amygdala voxel identified by the preceding regression analysis (<span class="xrefLink" id="jumplink-fig3"></span><a href="javascript:;" data-modal-source-id="fig3" class="link xref-fig">Fig. 3</a>) was taken as the seed voxel for an analysis that identified connections between the left amygdala and the rest of the brain that predicted subsequent memory as a function of emotion and delay. Consistent with our 3rd prediction, 1 of the regions where amygdala connectivity modulated the persistence of emotional memory over time was found within MTL (see <span class="xrefLink" id="jumplink-tbl3"></span><a href="javascript:;" reveal-id="tbl3" data-open="tbl3" class="link link-reveal link-table xref-fig">Table 3</a>). As illustrated by <span class="xrefLink" id="jumplink-fig4"></span><a href="javascript:;" data-modal-source-id="fig4" class="link xref-fig">Figure 4</a>, greater connectivity between the amygdala and bilateral anterior parahippocampal regions predicted emotional memory after a long delay compared with a short delay, and this effect was specific to emotional items (<span class="xrefLink" id="jumplink-fig4"></span><a href="javascript:;" data-modal-source-id="fig4" class="link xref-fig">Fig. 4</a>). The peak of the left parahippocampal cluster appears to fall medially within entorhinal cortex, whereas the right parahippocampal cluster is closest to the intersection of entorhinal and perirhinal cortices. No MTL regions showed the opposite pattern of connectivity, with greater connectivity predicting memory for emotional stimuli after a short rather than long delay. Outside of the MTL, greater connectivity between the amygdala and right parietal and medial frontal regions also predicted memory for emotional stimuli after a long delay to a greater extent than memory after a short delay (<span class="xrefLink" id="jumplink-tbl3"></span><a href="javascript:;" reveal-id="tbl3" data-open="tbl3" class="link link-reveal link-table xref-fig">Table 3</a>). In the reverse analysis, compared with memory after a long delay, memory for emotional pictures after a short delay was predicted by greater encoding connectivity between the amygdala and the left medial frontal gyrus.</p>                    <a id="3674425" scrollto-destination="3674425"></a>
+<div content-id="tbl3" class="table-modal table-full-width-wrap"><div class="table-wrap table-wide"><div class="table-wrap-title" id="tbl3" data-id="tbl3"><span class="label">Table 3</span><div class="caption"><p class="chapter-para">Regions exhibiting emotion- and delay-specific connectivity with amygdala</p></div> </div><div class="table-overflow"><table role="table"><thead><tr><td> </td><td>BA </td><td>Hem </td><td colspan="4">Coordinates (T and T)<hr /> </td><td>Voxels </td></tr><tr><td> </td><td> </td><td> </td><td><em>x</em> </td><td><em>y</em> </td><td><em>z</em> </td><td><em>t</em> </td><td> </td></tr></thead><tbody><tr><td colspan="8">Emotional long- versus short-delay hits &gt; neutral long- versus short-delay hits </td></tr><tr><td>    MTL </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    PHG </td><td char=".">28 </td><td>R </td><td char=".">30 </td><td char=".">−1 </td><td char=".">−26 </td><td char=".">3.49 </td><td char=".">5 </td></tr><tr><td> </td><td char=".">28, 34 </td><td>L </td><td char=".">−19 </td><td char=".">−8 </td><td char=".">−22 </td><td char=".">2.07 </td><td char=".">4 </td></tr><tr><td>    Medial frontal gyrus </td><td char=".">8 </td><td>R/L </td><td char=".">7 </td><td char=".">38 </td><td char=".">37 </td><td char=".">2.54 </td><td char=".">30 </td></tr><tr><td>    Parietal </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Postcentral gyrus </td><td char=".">2 </td><td>R </td><td char=".">59 </td><td char=".">−24 </td><td char=".">36 </td><td char=".">4.26 </td><td char=".">15 </td></tr><tr><td>    Inferior parietal lobule </td><td char=".">40 </td><td>R </td><td char=".">56 </td><td char=".">−38 </td><td char=".">37 </td><td char=".">2.85 </td><td char=".">12 </td></tr><tr><td colspan="8">Emotional short- versus long-delay hits &gt; neutral short- versus long-delay hits </td></tr><tr><td>    Medial frontal gyrus </td><td char=".">9 </td><td>L </td><td char=".">−19 </td><td char=".">44 </td><td char=".">15 </td><td char=".">3.4 </td><td char=".">18 </td></tr></tbody></table></div><div class="table-modal"><table><thead><tr><td> </td><td>BA </td><td>Hem </td><td colspan="4">Coordinates (T and T)<hr /> </td><td>Voxels </td></tr><tr><td> </td><td> </td><td> </td><td><em>x</em> </td><td><em>y</em> </td><td><em>z</em> </td><td><em>t</em> </td><td> </td></tr></thead><tbody><tr><td colspan="8">Emotional long- versus short-delay hits &gt; neutral long- versus short-delay hits </td></tr><tr><td>    MTL </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    PHG </td><td char=".">28 </td><td>R </td><td char=".">30 </td><td char=".">−1 </td><td char=".">−26 </td><td char=".">3.49 </td><td char=".">5 </td></tr><tr><td> </td><td char=".">28, 34 </td><td>L </td><td char=".">−19 </td><td char=".">−8 </td><td char=".">−22 </td><td char=".">2.07 </td><td char=".">4 </td></tr><tr><td>    Medial frontal gyrus </td><td char=".">8 </td><td>R/L </td><td char=".">7 </td><td char=".">38 </td><td char=".">37 </td><td char=".">2.54 </td><td char=".">30 </td></tr><tr><td>    Parietal </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Postcentral gyrus </td><td char=".">2 </td><td>R </td><td char=".">59 </td><td char=".">−24 </td><td char=".">36 </td><td char=".">4.26 </td><td char=".">15 </td></tr><tr><td>    Inferior parietal lobule </td><td char=".">40 </td><td>R </td><td char=".">56 </td><td char=".">−38 </td><td char=".">37 </td><td char=".">2.85 </td><td char=".">12 </td></tr><tr><td colspan="8">Emotional short- versus long-delay hits &gt; neutral short- versus long-delay hits </td></tr><tr><td>    Medial frontal gyrus </td><td char=".">9 </td><td>L </td><td char=".">−19 </td><td char=".">44 </td><td char=".">15 </td><td char=".">3.4 </td><td char=".">18 </td></tr></tbody></table></div><div class="table-wrap-foot"><span id="fn-"></span><div content-id="" class="footnote"><span class="fn"><p class="chapter-para">Note: BA, Brodmann area; Hem, hemisphere; <em>t</em>, statistical <em>t</em> value; R, right; L, left; Talairach and Tournoux (T and T) coordinates reported.</p></span></div></div><div class="&#xA;          graphic-wrap&#xA;          "><a class="fig-view-orig at-tableViewLarge openInAnotherWindow btn js-view-large" target="_blank" href="/view-large/3674425">
+          Open in new tab
+        </a></div></div></div><div class="table-full-width-wrap"><div class="table-wrap table-wide"><div class="table-wrap-title" id="tbl3" data-id="tbl3"><span class="label">Table 3</span><div class="caption"><p class="chapter-para">Regions exhibiting emotion- and delay-specific connectivity with amygdala</p></div> </div><div class="table-overflow"><table role="table"><thead><tr><td> </td><td>BA </td><td>Hem </td><td colspan="4">Coordinates (T and T)<hr /> </td><td>Voxels </td></tr><tr><td> </td><td> </td><td> </td><td><em>x</em> </td><td><em>y</em> </td><td><em>z</em> </td><td><em>t</em> </td><td> </td></tr></thead><tbody><tr><td colspan="8">Emotional long- versus short-delay hits &gt; neutral long- versus short-delay hits </td></tr><tr><td>    MTL </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    PHG </td><td char=".">28 </td><td>R </td><td char=".">30 </td><td char=".">−1 </td><td char=".">−26 </td><td char=".">3.49 </td><td char=".">5 </td></tr><tr><td> </td><td char=".">28, 34 </td><td>L </td><td char=".">−19 </td><td char=".">−8 </td><td char=".">−22 </td><td char=".">2.07 </td><td char=".">4 </td></tr><tr><td>    Medial frontal gyrus </td><td char=".">8 </td><td>R/L </td><td char=".">7 </td><td char=".">38 </td><td char=".">37 </td><td char=".">2.54 </td><td char=".">30 </td></tr><tr><td>    Parietal </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Postcentral gyrus </td><td char=".">2 </td><td>R </td><td char=".">59 </td><td char=".">−24 </td><td char=".">36 </td><td char=".">4.26 </td><td char=".">15 </td></tr><tr><td>    Inferior parietal lobule </td><td char=".">40 </td><td>R </td><td char=".">56 </td><td char=".">−38 </td><td char=".">37 </td><td char=".">2.85 </td><td char=".">12 </td></tr><tr><td colspan="8">Emotional short- versus long-delay hits &gt; neutral short- versus long-delay hits </td></tr><tr><td>    Medial frontal gyrus </td><td char=".">9 </td><td>L </td><td char=".">−19 </td><td char=".">44 </td><td char=".">15 </td><td char=".">3.4 </td><td char=".">18 </td></tr></tbody></table></div><div class="table-modal"><table><thead><tr><td> </td><td>BA </td><td>Hem </td><td colspan="4">Coordinates (T and T)<hr /> </td><td>Voxels </td></tr><tr><td> </td><td> </td><td> </td><td><em>x</em> </td><td><em>y</em> </td><td><em>z</em> </td><td><em>t</em> </td><td> </td></tr></thead><tbody><tr><td colspan="8">Emotional long- versus short-delay hits &gt; neutral long- versus short-delay hits </td></tr><tr><td>    MTL </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    PHG </td><td char=".">28 </td><td>R </td><td char=".">30 </td><td char=".">−1 </td><td char=".">−26 </td><td char=".">3.49 </td><td char=".">5 </td></tr><tr><td> </td><td char=".">28, 34 </td><td>L </td><td char=".">−19 </td><td char=".">−8 </td><td char=".">−22 </td><td char=".">2.07 </td><td char=".">4 </td></tr><tr><td>    Medial frontal gyrus </td><td char=".">8 </td><td>R/L </td><td char=".">7 </td><td char=".">38 </td><td char=".">37 </td><td char=".">2.54 </td><td char=".">30 </td></tr><tr><td>    Parietal </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td><td> </td></tr><tr><td>    Postcentral gyrus </td><td char=".">2 </td><td>R </td><td char=".">59 </td><td char=".">−24 </td><td char=".">36 </td><td char=".">4.26 </td><td char=".">15 </td></tr><tr><td>    Inferior parietal lobule </td><td char=".">40 </td><td>R </td><td char=".">56 </td><td char=".">−38 </td><td char=".">37 </td><td char=".">2.85 </td><td char=".">12 </td></tr><tr><td colspan="8">Emotional short- versus long-delay hits &gt; neutral short- versus long-delay hits </td></tr><tr><td>    Medial frontal gyrus </td><td char=".">9 </td><td>L </td><td char=".">−19 </td><td char=".">44 </td><td char=".">15 </td><td char=".">3.4 </td><td char=".">18 </td></tr></tbody></table></div><div class="table-wrap-foot"><span id="fn-"></span><div content-id="" class="footnote"><span class="fn"><p class="chapter-para">Note: BA, Brodmann area; Hem, hemisphere; <em>t</em>, statistical <em>t</em> value; R, right; L, left; Talairach and Tournoux (T and T) coordinates reported.</p></span></div></div><div class="&#xA;          graphic-wrap&#xA;          "><a class="fig-view-orig at-tableViewLarge openInAnotherWindow btn js-view-large" target="_blank" href="/view-large/3674425">
+          Open in new tab
+        </a></div></div></div>                    <a id="3674426" scrollto-destination="3674426"></a>
+<div data-id="fig4" data-content-id="fig4" class="fig fig-section js-fig-section" swap-content-for-modal="true"><div class="label fig-label">Figure 4.</div><div class="graphic-wrap"><img class="content-image" src="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/m_cercorbhm262f04_4c.jpeg?Expires=1689492105&amp;Signature=lO-k-EMpCoDaIBBojW-fsG~JkMDbpUM5JklQmRkkzbS1klf907J87RuCCrA9cyOew0dwfcBqdJxHfB5AdluP7QsR~Hdv3q~4ht1n7s56N5uCXSMhq8L6oz3bZpjjFI0ZPohmnxVT7YC2nwkQRDeD7KvQ6ObbCn4GSR81s0qc9Saqhdj~kjddj8XMt-XdwqQNo5f4DrPiGh-7K9jpvL~t5Y2bdCFS5DALLwigg~o58qd7rbBRDl8CPiVS1ANjntDelTxA4m6DiVtT~gwHx-s98l-Ejz90oa~v3PykHyT-FJg-AMPndod8L4SlkPFRSDrI2o630qwZkNiGZvVgCtqmYQ__&amp;Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" alt="Functional connectivity with the amygdala. (a) Bilateral anterior parahippocampal regions whose connectivity with the amygdala interacts with emotion and delay, such that connectivity during long-delay hits is greater than during short-delay hits, but only for emotional items. See Table 3 for coordinates. (b) Scatterplot depicting the relationship between mean single-trial activation estimates (i.e., beta weights) from the indicated right PHG region and the seed amygdala voxel across emotional long-delay hits. These data points were extracted from an individual representative participant for display purposes." data-path-from-xml="cercorbhm262f04_4c.jpeg" /><div class="fig-orig original-slide"><a class="fig-view-orig js-view-large at-figureViewLarge openInAnotherWindow" href="/view-large/figure/3674426/cercorbhm262f04_4c.jpeg" data-path-from-xml="cercorbhm262f04_4c.jpeg" target="_blank">Open in new tab</a><a data-section="3674426" href="/DownloadFile/DownloadImage.aspx?image=https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/cercorbhm262f04_4c.jpeg?Expires=1689492105&Signature=GWC6~r4X08DRARnQ9BAgAtfcH6xMq3vLyW7WJ-LulDRACIer3n7sP1TyZHBlyd2hHjzDxsaU0ffwJLRLWF4KGfw6ouhDNQgh4gVDh01Q9TEPlJXBOlFakKNUgA0yzubClxxA3RCskjlH7mQafw-cdYxu1ix5j7GS-jCicWlNxP-mha4F7Jhv2lFY0OF6J2gNJxR0-0uUgwjhVUxGCQWPaOtaym8PddLhM77F4jHBvWzhHuTBnUBS2Guaa6w0obk~JBfvZXl~T2KvaDKrm2zZo5QouJBDCpDBSUDhnXy14AYI~N9UlUlYaUp4sfIcNV94ohcBM1Qu-89rt8AxD5h-uA__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA&sec=3674426&ar=290170&xsltPath=~/UI/app/XSLT&imagename=&siteId=5122" class="download-slide" data-path-from-xml="cercorbhm262f04_4c.jpeg">Download slide</a></div></div><div class="caption fig-caption"><p class="chapter-para">Functional connectivity with the amygdala. (<em>a</em>) Bilateral anterior parahippocampal regions whose connectivity with the amygdala interacts with emotion and delay, such that connectivity during long-delay hits is greater than during short-delay hits, but only for emotional items. See <span class="xrefLink" id="jumplink-tbl3"></span><a href="javascript:;" reveal-id="tbl3" data-open="tbl3" class="link link-reveal link-table xref-fig">Table 3</a> for coordinates. (<em>b</em>) Scatterplot depicting the relationship between mean single-trial activation estimates (i.e., beta weights) from the indicated right PHG region and the seed amygdala voxel across emotional long-delay hits. These data points were extracted from an individual representative participant for display purposes.</p></div></div><p class="chapter-para">To investigate this pattern of amygdala–MTL connectivity further, <em>z</em> scores representing the difference between connectivity associated with long- versus short-delay emotional hits were extracted from each identified parahippocampal region. Note that positive values indicate greater connectivity associated with long- than short-delay memory. These connectivity differences correlated across subjects with individual differences in recollection persistence scores for emotional stimuli but not recollection persistence scores for neutral stimuli (<span class="xrefLink" id="jumplink-fig5"></span><a href="javascript:;" data-modal-source-id="fig5" class="link xref-fig">Fig. 5</a>). This suggests that individuals whose memory for emotional stimuli after a long delay is predicted by greater amygdala–parahippocampal connectivity during encoding show better preservation of recollection for these stimuli after a long delay. These results give further support to the prediction that greater amygdala–MTL connectivity during encoding makes memories for emotional stimuli more resistant to forgetting, consistent with the hypothesis that emotional arousal enhances consolidation processes.</p>                    <a id="3674428" scrollto-destination="3674428"></a>
+<div data-id="fig5" data-content-id="fig5" class="fig fig-section js-fig-section" swap-content-for-modal="true"><div class="label fig-label">Figure 5.</div><div class="graphic-wrap"><img class="content-image" src="https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/m_cercorbhm262f05_ht.jpeg?Expires=1689492105&amp;Signature=0HaLKEAlwVRTC2w~c2rhrgbOBREafbMT8iRhbCPsg3UIHXMxXRf4~J~rcF~Od~QZwSdE3KdftR9nv9nLke-GqEM6T-6Caca-6TtOFwaGUR~wPFDKqKwRPZz40Mb0b953tT--ov~JZ0P6uVgC-WrVYVqdZoGaZyFgtlCuCmOPepxzB44D8nSYQHEq0jU4J3WvxtmiZxjv-Yj6rhGbtyjCQT3Glz-OFHDqYJXMdTqrnwRAM4aqMh6iqLiBQBo3DsrHdY-Kv0BHuO7gZXxz47gLuvrQFfAX4-Hmuce2opS3RQhkBBmaVbrayVZjcgr8DC5Pqw72h~eTp8ZDxY2bDyxLtQ__&amp;Key-Pair-Id=APKAIE5G5CRDK6RD3PGA" alt="Functional connectivity differences associated with emotional recollection persistence. (a) In these across-subject scatterplots, the y-axis denotes the difference in connectivity between the amygdala and left or right PHG during emotional long- versus short-delay hits. The x-axis indicates individual recollection persistence scores for emotional stimuli. Note that increasing levels of emotional recollection persistence are associated with increasing disparity between connectivity supporting emotional memory after long versus short delays. (b) In these across-subject scatterplots, the y-axis denotes the difference in connectivity between the amygdala and left or right PHG during neutral long- versus short-delay hits. The x-axis indicates individual recollection persistence scores for neutral stimuli. Note that there is no relationship between connectivity differences and neutral recollection persistence." data-path-from-xml="cercorbhm262f05_ht.jpeg" /><div class="fig-orig original-slide"><a class="fig-view-orig js-view-large at-figureViewLarge openInAnotherWindow" href="/view-large/figure/3674428/cercorbhm262f05_ht.jpeg" data-path-from-xml="cercorbhm262f05_ht.jpeg" target="_blank">Open in new tab</a><a data-section="3674428" href="/DownloadFile/DownloadImage.aspx?image=https://oup.silverchair-cdn.com/oup/backfile/Content_public/Journal/cercor/18/11/10.1093/cercor/bhm262/2/cercorbhm262f05_ht.jpeg?Expires=1689492105&Signature=z~z9634YmabdG3FuwbSaBK4WG3-igMw8YQ06X9I9Lnv0V9cdZlk-Re6u1n7qIg9Idd0pNO~T0O2WAIWmS7R6sjMXMM1dgnbqFmBzhawA~S6CW91tsrfXn6-aSv-I3PBM7l4GWJ4cuKqssA-~vN1wN8cY3nEGMwH~j7lAVJOPkfD6z2RwmzQz4UwxEQXl9ZWLPZQxFEMYW~kPIKKyaY8o0r4Vx1YzWqzMYMnDysJw3kjT7vFimsWxdK3wzVcSb3eAE~10FGu1RmfJSPFvPD7Mgww3fPZ1MyyCsX~fulQKDZ~pWgfd~fDvDgs7tki1nHx~hTT6oBOscYBrGfGsA8g2XA__&Key-Pair-Id=APKAIE5G5CRDK6RD3PGA&sec=3674428&ar=290170&xsltPath=~/UI/app/XSLT&imagename=&siteId=5122" class="download-slide" data-path-from-xml="cercorbhm262f05_ht.jpeg">Download slide</a></div></div><div class="caption fig-caption"><p class="chapter-para">Functional connectivity differences associated with emotional recollection persistence. (<em>a</em>) In these across-subject scatterplots, the <em>y</em>-axis denotes the difference in connectivity between the amygdala and left or right PHG during emotional long- versus short-delay hits. The <em>x</em>-axis indicates individual recollection persistence scores for emotional stimuli. Note that increasing levels of emotional recollection persistence are associated with increasing disparity between connectivity supporting emotional memory after long versus short delays. (<em>b</em>) In these across-subject scatterplots, the <em>y</em>-axis denotes the difference in connectivity between the amygdala and left or right PHG during neutral long- versus short-delay hits. The <em>x</em>-axis indicates individual recollection persistence scores for neutral stimuli. Note that there is no relationship between connectivity differences and neutral recollection persistence.</p></div></div>                    <h2 scrollto-destination=3674429 id="3674429" class="section-title js-splitscreen-section-title" >Discussion</h2>
+<p class="chapter-para">The present study investigated how encoding activity predicting subsequent emotional memory is modulated by study-test delay. Participants were scanned while encoding emotional and neutral pictures, and recognition memory for nonoverlapping sets of these items was tested 20 min and 1 week after encoding. The experiment yielded 3 main findings. First, activity in the amygdala predicted emotional memory but not neutral memory, and this pattern was similar for emotional memory after both short and long delays. Second, corresponding to our behavioral finding of greater recollection persistence for emotional than neutral stimuli, activity in the left amygdala correlated with individual differences in the persistence of recollection over time for emotional but not neutral stimuli. Finally, greater connectivity between the left amygdala and bilateral anterior MTL memory regions during encoding predicted memory for emotional stimuli after a long delay to a greater extent than memory after a short delay. We discuss these 3 main results in turn.</p>                    <h3 scrollto-destination=3674431 id="3674431" class="section-title js-splitscreen-section-title" >ESA is Not Modulated by the Interaction of Emotion and Delay</h3>
+<p class="chapter-para">When collapsed over delay, ESA for emotional pictures revealed a network of regions including bilateral amygdalae and left inferior frontal gyrus. This finding is consistent with extensive evidence that the amygdala is critical to the formation of emotional memories (<span class="xrefLink" id="jumplink-bib6"></span><a href="javascript:;" reveal-id="bib6" data-open="bib6" class="link link-ref link-reveal xref-bibr">Cahill et al. 1996</a>; <span class="xrefLink" id="jumplink-bib29"></span><a href="javascript:;" reveal-id="bib29" data-open="bib29" class="link link-ref link-reveal xref-bibr">LaBar and Phelps 1998</a>; <span class="xrefLink" id="jumplink-bib20"></span><a href="javascript:;" reveal-id="bib20" data-open="bib20" class="link link-ref link-reveal xref-bibr">Hamann et al<em>.</em> 1999</a>; <span class="xrefLink" id="jumplink-bib7"></span><a href="javascript:;" reveal-id="bib7" data-open="bib7" class="link link-ref link-reveal xref-bibr">Canli et al. 2000</a>; <span class="xrefLink" id="jumplink-bib12"></span><a href="javascript:;" reveal-id="bib12" data-open="bib12" class="link link-ref link-reveal xref-bibr">Dolcos et al. 2004b</a>) and that the left prefrontal cortex contributes to superior encoding for emotional stimuli (<span class="xrefLink" id="jumplink-bib12"></span><a href="javascript:;" reveal-id="bib12" data-open="bib12" class="link link-ref link-reveal xref-bibr">Dolcos et al. 2004a</a>; <span class="xrefLink" id="jumplink-bib24"></span><a href="javascript:;" reveal-id="bib24" data-open="bib24" class="link link-ref link-reveal xref-bibr">Kensinger and Corkin 2004</a>). Contrary to our predictions, however, we did not find any differences in ESA for short- versus long-delay memory that were unique to emotional stimuli. This suggests that our emotional memory network contributes equally well during encoding to recognition memory shortly after encoding as well as 1 week later. In other words, basic activity estimates do not reveal any functional differences corresponding to our behavioral finding that recollection for emotional items is relatively preserved over time.</p><p class="chapter-para">We had originally expected that long-delay hits would be the more targeted product of consolidation than short-delay hits and that there would be greater ESA associated with ensuing consolidation for long- than short-delay hits. It is possible that we did not find any such regions because of consolidation's dynamic nature: arousal-mediated consolidation is the product of interactions between the amygdala and MTL memory system (<span class="xrefLink" id="jumplink-bib33"></span><a href="javascript:;" reveal-id="bib33" data-open="bib33" class="link link-ref link-reveal xref-bibr">McGaugh 2004</a>) and might not be captured sufficiently by basic activity estimates. This idea will be addressed further in our discussion of functional connectivity results.</p>                    <h3 scrollto-destination=3674434 id="3674434" class="section-title js-splitscreen-section-title" >Amygdala Activity Predicts Individual Differences in Recollection Persistence for Emotional Stimuli</h3>
+<p class="chapter-para">Activity in the left amygdala in response to viewing emotional pictures was significantly correlated with individual differences in recollection persistence for emotional stimuli, our most behaviorally salient measure of temporal changes in emotional memory. This relationship was unique to emotional items; in fact, no MTL regions were significantly correlated with the persistence of recollection for neutral stimuli. Because our recollection persistence scores divide long-delay recollection by short-delay recollection, baseline memory variability across subjects is ameliorated, such that this measure corresponds most truly to differences that develop across the 1-week delay. Thus, our results imply that individuals who exhibit relatively strong amygdala activation in response to emotional items are less likely to forget these items after a 1-week delay. This finding is consistent with the finding that patients lacking functional amygdalae do not show enhancements in the emotional memory effect over time (<span class="xrefLink" id="jumplink-bib29"></span><a href="javascript:;" reveal-id="bib29" data-open="bib29" class="link link-ref link-reveal xref-bibr">LaBar and Phelps 1998</a>).</p><p class="chapter-para">These results successfully replicate and improve upon previous investigations into the interaction of emotion and delay in determining ESA. Across-subject correlations between amygdala activity and long- but not short-delay emotional memory are consistent with the results of previous studies (<span class="xrefLink" id="jumplink-bib20"></span><a href="javascript:;" reveal-id="bib20" data-open="bib20" class="link link-ref link-reveal xref-bibr">Hamann et al. 1999</a>; <span class="xrefLink" id="jumplink-bib32"></span><a href="javascript:;" reveal-id="bib32" data-open="bib32" class="link link-ref link-reveal xref-bibr">Mackiewicz et al. 2006</a>), but until now, these correlations have not been linked to behavioral changes in emotional memory over time. The present study is the 1st to pinpoint encoding activity in the left amygdala as specifically predictive of emotional recollection, in particular, the degree to which recollection for emotional stimuli persists over time. Thus, our results more strongly argue for amygdala activity as the catalyst for the temporal persistence of emotional memory, an interpretation compatible with the consolidation hypothesis (<span class="xrefLink" id="jumplink-bib33"></span><a href="javascript:;" reveal-id="bib33" data-open="bib33" class="link link-ref link-reveal xref-bibr">McGaugh 2004</a>).</p>                    <h3 scrollto-destination=3674437 id="3674437" class="section-title js-splitscreen-section-title" >Functional Connectivity between Amygdala and MTL Memory System Supports Emotional Memory After Long Delay</h3>
+<p class="chapter-para">Functional connectivity analyses revealed that the degree to which connectivity between the left amygdala and bilateral anterior MTL memory regions predicted subsequent memory was determined by both emotion and delay. Specifically, connectivity between these regions during encoding predicted memory for emotional pictures after a long delay rather than after a short delay, and this effect was greater for emotional than for neutral items. Although previous neuroimaging studies have shown that amygdala–MTL connectivity during encoding is associated with successful emotional memory encoding (<span class="xrefLink" id="jumplink-bib20"></span><a href="javascript:;" reveal-id="bib20" data-open="bib20" class="link link-ref link-reveal xref-bibr">Hamann et al. 1999</a>; <span class="xrefLink" id="jumplink-bib26"></span><a href="javascript:;" reveal-id="bib26" data-open="bib26" class="link link-ref link-reveal xref-bibr">Kilpatrick and Cahill 2003</a>; <span class="xrefLink" id="jumplink-bib12"></span><a href="javascript:;" reveal-id="bib12" data-open="bib12" class="link link-ref link-reveal xref-bibr">Dolcos et al. 2004b</a>; <span class="xrefLink" id="jumplink-bib24"></span><a href="javascript:;" reveal-id="bib24" data-open="bib24" class="link link-ref link-reveal xref-bibr">Kensinger and Corkin 2004</a>), this is the 1st study to demonstrate that the beneficial influence of this connectivity heightens over time. Furthermore, the enhancing effect of amygdala–MTL connectivity on memory for emotional stimuli after a long delay was significantly correlated with individual differences in recollection persistence scores for emotional stimuli. This finding directly links connectivity findings at the group level to individual differences in emotional memory performance.</p><p class="chapter-para">Taken together, these connectivity results can also be interpreted under the consolidation hypothesis, which posits that emotional memories benefit from arousal-mediated interactions between the amygdala and MTL memory system that act to improve memory consolidation (<span class="xrefLink" id="jumplink-bib33"></span><a href="javascript:;" reveal-id="bib33" data-open="bib33" class="link link-ref link-reveal xref-bibr">McGaugh 2004</a>). Because consolidation unfolds across time, its role in predicting emotional memory should grow stronger over time, echoing the pattern of connectivity observed here.</p><p class="chapter-para">The present results fit well with findings from animal studies of consolidation, although it should be noted that the latter typically investigate consolidation via posttraining behavioral or pharmacological manipulations. In the present study, we examined consolidation processes as they began during the encoding phase and distinguished these processes from other encoding processes by measuring the persistence of memory traces over time. However, it is possible that the present results could be attributed to differences in memory strength established during encoding itself. For example, emotional stimuli evoked greater ESA than neutral stimuli in left inferior frontal gyrus, a region often associated with semantic encoding (<span class="xrefLink" id="jumplink-bib18"></span><a href="javascript:;" reveal-id="bib18" data-open="bib18" class="link link-ref link-reveal xref-bibr">Gabrieli et al. 1998</a>). This encoding benefit and others may have resulted in superior memory strength for emotional items, causing the emotional memories to decay more slowly than neutral memories over time. Thus, although we frame the present results in terms of consolidation, we acknowledge that memory strength differences could influence ESA and connectivity contributing to emotional memory changes over time.</p><p class="chapter-para">Interestingly, the MTL memory regions showing emotion- and delay-specific connectivity with the amygdala are bilaterally located within the anterior PHG, not within the hippocampus proper. In particular, these regions appear to be centered either within entorhinal cortex or near the border between entorhinal and perirhinal cortices. Although its connectivity with the hippocampus has been emphasized within the literature, the amygdala interacts with the hippocampus via its projections to entorhinal cortex (<span class="xrefLink" id="jumplink-bib39"></span><a href="javascript:;" reveal-id="bib39" data-open="bib39" class="link link-ref link-reveal xref-bibr">Pare et al. 1995</a>). These regions are likewise involved in arousal-mediated consolidation (<span class="xrefLink" id="jumplink-bib34"></span><a href="javascript:;" reveal-id="bib34" data-open="bib34" class="link link-ref link-reveal xref-bibr">McGaugh et al. 2002</a>; <span class="xrefLink" id="jumplink-bib45"></span><a href="javascript:;" reveal-id="bib45" data-open="bib45" class="link link-ref link-reveal xref-bibr">Roesler et al. 2002</a>; <span class="xrefLink" id="jumplink-bib35"></span><a href="javascript:;" reveal-id="bib35" data-open="bib35" class="link link-ref link-reveal xref-bibr">McIntyre et al. 2003</a>). In particular, the anterior PHG is a site of information transfer from neocortex to the hippocampus, and amygdala activity facilitates correspondence between perirhinal and entorhinal cortex, an improvement associated with learning (<span class="xrefLink" id="jumplink-bib40"></span><a href="javascript:;" reveal-id="bib40" data-open="bib40" class="link link-ref link-reveal xref-bibr">Paz et al. 2006</a>). Moreover, our finding is consistent with previous functional neuroimaging evidence that correlations between amygdala and entorhinal activity during encoding predict subsequent emotional memory compared with neutral memory (<span class="xrefLink" id="jumplink-bib12"></span><a href="javascript:;" reveal-id="bib12" data-open="bib12" class="link link-ref link-reveal xref-bibr">Dolcos et al. 2004b</a>; see also <span class="xrefLink" id="jumplink-bib26"></span><a href="javascript:;" reveal-id="bib26" data-open="bib26" class="link link-ref link-reveal xref-bibr">Kilpatrick and Cahill 2003</a>).</p><p class="chapter-para">An interesting question for future research is whether the specific MTL subregions modulated by amygdala connectivity vary depending on the particular type of episodic memory investigated. For example, there is evidence that encoding activity in the hippocampus predicts better subsequent recollection, whereas encoding activity in anterior parahippocampal regions predicts greater subsequent familiarity (<span class="xrefLink" id="jumplink-bib42"></span><a href="javascript:;" reveal-id="bib42" data-open="bib42" class="link link-ref link-reveal xref-bibr">Ranganath et al. 2004</a>). A similar dissociation exists within the emotional memory literature, with hippocampal ESA corresponding to incidental source memory and anterior parahippocampal and amygdala ESA for item-only memory (<span class="xrefLink" id="jumplink-bib25"></span><a href="javascript:;" reveal-id="bib25" data-open="bib25" class="link link-ref link-reveal xref-bibr">Kensinger and Schacter 2006</a>). Although the present finding that amygdala connectivity with anterior parahippocampal regions is associated with individual differences in emotional recollection may seem inconsistent with these findings, it is important to note that the anterior parahippocampal region most strongly associated with item encoding is the perirhinal cortex rather than the entorhinal cortex (<span class="xrefLink" id="jumplink-bib10"></span><a href="javascript:;" reveal-id="bib10" data-open="bib10" class="link link-ref link-reveal xref-bibr">Davachi et al. 2003</a>). In contrast, the entorhinal cortex is assumed to have memory functions intimately related to the hippocampus (<span class="xrefLink" id="jumplink-bib1"></span><a href="javascript:;" reveal-id="bib1" data-open="bib1" class="link link-ref link-reveal xref-bibr">Aggleton and Brown 1999</a>), and it is assumed to support the encoding of contextual information (<span class="xrefLink" id="jumplink-bib15"></span><a href="javascript:;" reveal-id="bib15" data-open="bib15" class="link link-ref link-reveal xref-bibr">Eichenbaum et al. 2007</a>).</p>                    <h3 scrollto-destination=3674443 id="3674443" class="section-title js-splitscreen-section-title" >Caveats</h3>
+<p class="chapter-para">The present results should be treated with 2 main caveats. First, because we chose to simplify the design by employing only negative and neutral stimuli, we cannot distinguish between the contributions of valence and arousal to the present results. However, previous research has shown that the amygdala responds primarily to arousal (<span class="xrefLink" id="jumplink-bib2"></span><a href="javascript:;" reveal-id="bib2" data-open="bib2" class="link link-ref link-reveal xref-bibr">Anderson et al. 2003</a>; <span class="xrefLink" id="jumplink-bib12"></span><a href="javascript:;" reveal-id="bib12" data-open="bib12" class="link link-ref link-reveal xref-bibr">Dolcos et al. 2004b</a>; <span class="xrefLink" id="jumplink-bib24"></span><a href="javascript:;" reveal-id="bib24" data-open="bib24" class="link link-ref link-reveal xref-bibr">Kensinger and Corkin 2004</a>), a dimension shared by both positive and negative stimuli. Furthermore, the amygdala–MTL network predicts memory for both emotionally negative and positive stimuli (<span class="xrefLink" id="jumplink-bib20"></span><a href="javascript:;" reveal-id="bib20" data-open="bib20" class="link link-ref link-reveal xref-bibr">Hamann et al. 1999</a>). Therefore, we predict that the inclusion of positive pictures would not qualitatively change the results in the amygdala and MTL or their interpretation and that these results are generalizable to both emotionally negative and positive memories.</p><p class="chapter-para">Second, the present results do not address the issue of sex differences in emotional memory. Previous evidence indicates that emotional memory effects are lateralized by sex, with the left amygdala predicting emotional memory enhancements for females and the right amygdala for males (for a review see <span class="xrefLink" id="jumplink-bib5"></span><a href="javascript:;" reveal-id="bib5" data-open="bib5" class="link link-ref link-reveal xref-bibr">Cahill 2003</a>). Preliminary analyses have failed to reveal any influence of sex on the present results (data not reported). However, because sex differences were not of primary interest in the present study, this null result should be treated with caution; it could be ascribed to low statistical power due to relatively small sample sizes for males and females. Future investigations should attempt to verify whether or not sex plays a role in determining patterns of amygdala–MTL connectivity in support of emotional memory.</p>                    <h3 scrollto-destination=3674446 id="3674446" class="section-title js-splitscreen-section-title" >Conclusions</h3>
+<p class="chapter-para">The present study investigated how encoding activity and functional connectivity differentially predicts emotional memory after short versus long delays. We report 3 main findings: 1) ESA for emotional items is similar for short- and long-delay memory; 2) activity in the left amygdala predicts individual differences in emotional recollection persistence; and 3) functional connectivity between the left amygdala and bilateral anterior PHG is greater for emotional items remembered after 1 week than those remembered after 20 min. These results suggest that amygdala activity, along with its connectivity with the MTL memory system, sustain emotional memory enhancements over time. This interpretation is consistent with the consolidation hypothesis, which emphasizes the role of amygdala–MTL interactions in promoting emotional memory consolidation.</p>                    <h2 scrollto-destination=3674448 id="3674448" class="section-title js-splitscreen-section-title" >Funding</h2>
+<p class="chapter-para">National Institutes of Health (2P01 NS41328-06); Natural Sciences and Engineering Research Council of Canada (NSERC Postdoctoral Fellowship to F.D.); Canadian Psychiatric Research Foundation (CPRF Award to F.D.); National Alliance for Research on Schizophrenia and Depression (NARSAD Young Investigator Award to F.D.).</p><p class="chapter-para"><em>Conflict of Interest</em>: None declared.</p>                    <h2 scrollto-destination=3674452 id="3674452" class="backreferences-title js-splitscreen-backreferences-title" >References</h2>
+<div class="ref-list js-splitview-ref-list"><div content-id="bib1" class="js-splitview-ref-item" data-legacy-id="bib1"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib1" href="javascript:;" aria-label="jumplink-bib1" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib1" class="ref-content " data-id="bib1"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Aggleton</div> <div class="given-names">JP</div></div>,  <div class="name"><div class="surname">Brown</div> <div class="given-names">MW</div></div>. </span><div class="article-title">Episodic memory, amnesia and the hippocampal-anterior thalamic axis</div>, <div class="source ">Behav Brain Sci</div>, <div class="year">1999</div>, vol. <div class="volume">22</div> (pg. <div class="fpage">425</div>-<div class="lpage">444</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Episodic%20memory%2C%20amnesia%20and%20the%20hippocampal-anterior%20thalamic%20axis&amp;author=JP%20Aggleton&amp;author=MW%20Brown&amp;publication_year=1999&amp;journal=Behav%20Brain%20Sci&amp;volume=22&amp;pages=425-444" target="_blank">Google Scholar</a></span></p><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/11301518" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=article&amp;atitle=Episodic+memory%2c+amnesia+and+the+hippocampal-anterior+thalamic+axis&amp;aulast=Aggleton&amp;title=Behav+Brain+Sci&amp;date=1999&amp;spage=425&amp;epage=444&amp;volume=22" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Episodic%20memory%2C%20amnesia%20and%20the%20hippocampal-anterior%20thalamic%20axis&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib2" class="js-splitview-ref-item" data-legacy-id="bib2"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib2" href="javascript:;" aria-label="jumplink-bib2" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib2" class="ref-content " data-id="bib2"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Anderson</div> <div class="given-names">AK</div></div>,  <div class="name"><div class="surname">Christoff</div> <div class="given-names">K</div></div>,  <div class="name"><div class="surname">Stappen</div> <div class="given-names">I</div></div>,  <div class="name"><div class="surname">Panitz</div> <div class="given-names">D</div></div>,  <div class="name"><div class="surname">Ghahremani</div> <div class="given-names">DG</div></div>,  <div class="name"><div class="surname">Glover</div> <div class="given-names">G</div></div>,  <div class="name"><div class="surname">Gabrieli</div> <div class="given-names">JDE</div></div>,  <div class="name"><div class="surname">Sobel</div> <div class="given-names">N</div></div>. </span><div class="article-title">Dissociated neural representations of intensity and valence in human olfaction</div>, <div class="source ">Nat Neurosci</div>, <div class="year">2003</div>, vol. <div class="volume">6</div> (pg. <div class="fpage">196</div>-<div class="lpage">202</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Dissociated%20neural%20representations%20of%20intensity%20and%20valence%20in%20human%20olfaction&amp;author=AK%20Anderson&amp;author=K%20Christoff&amp;author=I%20Stappen&amp;author=D%20Panitz&amp;author=DG%20Ghahremani&amp;author=G%20Glover&amp;author=JDE%20Gabrieli&amp;author=N%20Sobel&amp;publication_year=2003&amp;journal=Nat%20Neurosci&amp;volume=6&amp;pages=196-202" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1038/nn1001" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1038%2Fnn1001" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1038%2Fnn1001"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12536208" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Dissociated%20neural%20representations%20of%20intensity%20and%20valence%20in%20human%20olfaction&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib3" class="js-splitview-ref-item" data-legacy-id="bib3"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib3" href="javascript:;" aria-label="jumplink-bib3" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib3" class="ref-content " data-id="bib3"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Anderson</div> <div class="given-names">AK</div></div>,  <div class="name"><div class="surname">Yamaguchi</div> <div class="given-names">Y</div></div>,  <div class="name"><div class="surname">Grabski</div> <div class="given-names">W</div></div>,  <div class="name"><div class="surname">Lacka</div> <div class="given-names">D</div></div>. </span><div class="article-title">Emotional memories are not all created equal: evidence for selective memory enhancement</div>, <div class="source ">Learn Mem</div>, <div class="year">2006</div>, vol. <div class="volume">13</div> (pg. <div class="fpage">711</div>-<div class="lpage">718</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Emotional%20memories%20are%20not%20all%20created%20equal%3A%20evidence%20for%20selective%20memory%20enhancement&amp;author=AK%20Anderson&amp;author=Y%20Yamaguchi&amp;author=W%20Grabski&amp;author=D%20Lacka&amp;publication_year=2006&amp;journal=Learn%20Mem&amp;volume=13&amp;pages=711-718" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1101/lm.388906" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1101%2Flm.388906" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1101%2Flm.388906"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/17101871" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Emotional%20memories%20are%20not%20all%20created%20equal%3A%20evidence%20for%20selective%20memory%20enhancement&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib4" class="js-splitview-ref-item" data-legacy-id="bib4"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib4" href="javascript:;" aria-label="jumplink-bib4" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib4" class="ref-content " data-id="bib4"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Bianchin</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Mello e Souza</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Medina</div> <div class="given-names">JH</div></div>,  <div class="name"><div class="surname">Izquierdo</div> <div class="given-names">I</div></div>. </span><div class="article-title">The amygdala is involved in the modulation of long-term memory, but not in working or short-term memory</div>, <div class="source ">Neurobiol Learn Mem</div>, <div class="year">1999</div>, vol. <div class="volume">71</div> (pg. <div class="fpage">127</div>-<div class="lpage">131</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20amygdala%20is%20involved%20in%20the%20modulation%20of%20long-term%20memory%2C%20but%20not%20in%20working%20or%20short-term%20memory&amp;author=M%20Bianchin&amp;author=T%20Mello%20e%20Souza&amp;author=JH%20Medina&amp;author=I%20Izquierdo&amp;publication_year=1999&amp;journal=Neurobiol%20Learn%20Mem&amp;volume=71&amp;pages=127-131" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1006/nlme.1998.3881" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1006%2Fnlme.1998.3881" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1006%2Fnlme.1998.3881"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/10082635" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20amygdala%20is%20involved%20in%20the%20modulation%20of%20long-term%20memory%2C%20but%20not%20in%20working%20or%20short-term%20memory&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib5" class="js-splitview-ref-item" data-legacy-id="bib5"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib5" href="javascript:;" aria-label="jumplink-bib5" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib5" class="ref-content " data-id="bib5"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Cahill</div> <div class="given-names">L</div></div>. </span><div class="article-title">Sex-related influences on the neurobiology of emotionally influenced memory</div>, <div class="source ">Ann N Y Acad Sci</div>, <div class="year">2003</div>, vol. <div class="volume">985</div> (pg. <div class="fpage">163</div>-<div class="lpage">173</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Sex-related%20influences%20on%20the%20neurobiology%20of%20emotionally%20influenced%20memory&amp;author=L%20Cahill&amp;publication_year=2003&amp;journal=Ann%20N%20Y%20Acad%20Sci&amp;volume=985&amp;pages=163-173" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1111/j.1749-6632.2003.tb07080.x" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1111%2Fj.1749-6632.2003.tb07080.x" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1111%2Fj.1749-6632.2003.tb07080.x"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12724157" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Sex-related%20influences%20on%20the%20neurobiology%20of%20emotionally%20influenced%20memory&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib6" class="js-splitview-ref-item" data-legacy-id="bib6"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib6" href="javascript:;" aria-label="jumplink-bib6" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib6" class="ref-content " data-id="bib6"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Cahill</div> <div class="given-names">L</div></div>,  <div class="name"><div class="surname">Haier</div> <div class="given-names">RJ</div></div>,  <div class="name"><div class="surname">Fallon</div> <div class="given-names">J</div></div>,  <div class="name"><div class="surname">Alkire</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Tang</div> <div class="given-names">C</div></div>,  <div class="name"><div class="surname">Keator</div> <div class="given-names">D</div></div>,  <div class="name"><div class="surname">Wu</div> <div class="given-names">J</div></div>,  <div class="name"><div class="surname">McGaugh</div> <div class="given-names">JL</div></div>. </span><div class="article-title">Amygdala activity at encoding correlated with long-term, free recall of emotional information</div>, <div class="source ">Proc Natl Acad Sci USA</div>, <div class="year">1996</div>, vol. <div class="volume">93</div> (pg. <div class="fpage">8016</div>-<div class="lpage">8021</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Amygdala%20activity%20at%20encoding%20correlated%20with%20long-term%2C%20free%20recall%20of%20emotional%20information&amp;author=L%20Cahill&amp;author=RJ%20Haier&amp;author=J%20Fallon&amp;author=M%20Alkire&amp;author=C%20Tang&amp;author=D%20Keator&amp;author=J%20Wu&amp;author=JL%20McGaugh&amp;publication_year=1996&amp;journal=Proc%20Natl%20Acad%20Sci%20USA&amp;volume=93&amp;pages=8016-8021" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1073/pnas.93.15.8016" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1073%2Fpnas.93.15.8016" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1073%2Fpnas.93.15.8016"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/8755595" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Amygdala%20activity%20at%20encoding%20correlated%20with%20long-term%2C%20free%20recall%20of%20emotional%20information&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib7" class="js-splitview-ref-item" data-legacy-id="bib7"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib7" href="javascript:;" aria-label="jumplink-bib7" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib7" class="ref-content " data-id="bib7"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Canli</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Zhao</div> <div class="given-names">Z</div></div>,  <div class="name"><div class="surname">Brewer</div> <div class="given-names">J</div></div>,  <div class="name"><div class="surname">Gabrieli</div> <div class="given-names">JDE</div></div>,  <div class="name"><div class="surname">Cahill</div> <div class="given-names">L</div></div>. </span><div class="article-title">Event-related activation in the human amygdala associates with later memory for individual emotional experience</div>, <div class="source ">J Neurosci</div>, <div class="year">2000</div>, vol. <div class="volume">20</div> pg. <div class="fpage">5</div> <!--citationLinks: case 2--><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Event-related%20activation%20in%20the%20human%20amygdala%20associates%20with%20later%20memory%20for%20individual%20emotional%20experience&amp;author=T%20Canli&amp;author=Z%20Zhao&amp;author=J%20Brewer&amp;author=JDE%20Gabrieli&amp;author=L%20Cahill&amp;publication_year=2000&amp;journal=J%20Neurosci&amp;volume=20&amp;pages=5" target="_blank">Google Scholar</a></span></p><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=article&amp;atitle=Event-related+activation+in+the+human+amygdala+associates+with+later+memory+for+individual+emotional+experience&amp;aulast=Canli&amp;title=J+Neurosci&amp;date=2000&amp;spage=5&amp;volume=20" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Event-related%20activation%20in%20the%20human%20amygdala%20associates%20with%20later%20memory%20for%20individual%20emotional%20experience&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib8" class="js-splitview-ref-item" data-legacy-id="bib8"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib8" href="javascript:;" aria-label="jumplink-bib8" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib8" class="ref-content " data-id="bib8"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Daselaar</div> <div class="given-names">SM</div></div>,  <div class="name"><div class="surname">Fleck</div> <div class="given-names">MS</div></div>,  <div class="name"><div class="surname">Cabeza</div> <div class="given-names">R</div></div>. </span><div class="article-title">Triple dissociation in the medial temporal lobes: recollection, familiarity, and novelty</div>, <div class="source ">J Neurophysiol</div>, <div class="year">2006</div>, vol. <div class="volume">96</div> (pg. <div class="fpage">1902</div>-<div class="lpage">1911</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Triple%20dissociation%20in%20the%20medial%20temporal%20lobes%3A%20recollection%2C%20familiarity%2C%20and%20novelty&amp;author=SM%20Daselaar&amp;author=MS%20Fleck&amp;author=R%20Cabeza&amp;publication_year=2006&amp;journal=J%20Neurophysiol&amp;volume=96&amp;pages=1902-1911" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1152/jn.01029.2005" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1152%2Fjn.01029.2005" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1152%2Fjn.01029.2005"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/16738210" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Triple%20dissociation%20in%20the%20medial%20temporal%20lobes%3A%20recollection%2C%20familiarity%2C%20and%20novelty&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib9" class="js-splitview-ref-item" data-legacy-id="bib9"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib9" href="javascript:;" aria-label="jumplink-bib9" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib9" class="ref-content " data-id="bib9"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Daselaar</div> <div class="given-names">SM</div></div>,  <div class="name"><div class="surname">Fleck</div> <div class="given-names">MS</div></div>,  <div class="name"><div class="surname">Dobbins</div> <div class="given-names">I</div></div>,  <div class="name"><div class="surname">Madden</div> <div class="given-names">DJ</div></div>,  <div class="name"><div class="surname">Cabeza</div> <div class="given-names">R</div></div>. </span><div class="article-title">Effects of healthy aging on hippocampal and rhinal memory functions: an event-related fMRI study</div>, <div class="source ">Cereb Cortex</div>, <div class="year">2006</div>, vol. <div class="volume">16</div> (pg. <div class="fpage">1771</div>-<div class="lpage">1782</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Effects%20of%20healthy%20aging%20on%20hippocampal%20and%20rhinal%20memory%20functions%3A%20an%20event-related%20fMRI%20study&amp;author=SM%20Daselaar&amp;author=MS%20Fleck&amp;author=I%20Dobbins&amp;author=DJ%20Madden&amp;author=R%20Cabeza&amp;publication_year=2006&amp;journal=Cereb%20Cortex&amp;volume=16&amp;pages=1771-1782" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1093/cercor/bhj112" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1093%2Fcercor%2Fbhj112" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1093%2Fcercor%2Fbhj112"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/16421332" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Effects%20of%20healthy%20aging%20on%20hippocampal%20and%20rhinal%20memory%20functions%3A%20an%20event-related%20fMRI%20study&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib10" class="js-splitview-ref-item" data-legacy-id="bib10"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib10" href="javascript:;" aria-label="jumplink-bib10" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib10" class="ref-content " data-id="bib10"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Davachi</div> <div class="given-names">L</div></div>,  <div class="name"><div class="surname">Mitchell</div> <div class="given-names">JP</div></div>,  <div class="name"><div class="surname">Wagner</div> <div class="given-names">AD</div></div>. </span><div class="article-title">Multiple routes to memory: distinct medial temporal lobe processes build item and source memories</div>, <div class="source ">Proc Natl Acad Sci USA</div>, <div class="year">2003</div>, vol. <div class="volume">100</div> (pg. <div class="fpage">2157</div>-<div class="lpage">2162</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Multiple%20routes%20to%20memory%3A%20distinct%20medial%20temporal%20lobe%20processes%20build%20item%20and%20source%20memories&amp;author=L%20Davachi&amp;author=JP%20Mitchell&amp;author=AD%20Wagner&amp;publication_year=2003&amp;journal=Proc%20Natl%20Acad%20Sci%20USA&amp;volume=100&amp;pages=2157-2162" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1073/pnas.0337195100" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1073%2Fpnas.0337195100" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1073%2Fpnas.0337195100"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12578977" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Multiple%20routes%20to%20memory%3A%20distinct%20medial%20temporal%20lobe%20processes%20build%20item%20and%20source%20memories&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib11" class="js-splitview-ref-item" data-legacy-id="bib11"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib11" href="javascript:;" aria-label="jumplink-bib11" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib11" class="ref-content " data-id="bib11"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Dolan</div> <div class="given-names">RJ</div></div>,  <div class="name"><div class="surname">Vuilleumier</div> <div class="given-names">P</div></div>. </span><div class="article-title">Amygdala automaticity in emotional processing</div>, <div class="source ">Ann N Y Acad Sci</div>, <div class="year">2003</div>, vol. <div class="volume">985</div> (pg. <div class="fpage">348</div>-<div class="lpage">355</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Amygdala%20automaticity%20in%20emotional%20processing&amp;author=RJ%20Dolan&amp;author=P%20Vuilleumier&amp;publication_year=2003&amp;journal=Ann%20N%20Y%20Acad%20Sci&amp;volume=985&amp;pages=348-355" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1111/j.1749-6632.2003.tb07093.x" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1111%2Fj.1749-6632.2003.tb07093.x" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1111%2Fj.1749-6632.2003.tb07093.x"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12724170" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Amygdala%20automaticity%20in%20emotional%20processing&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib12" class="js-splitview-ref-item" data-legacy-id="bib12"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib12" href="javascript:;" aria-label="jumplink-bib12" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib12" class="ref-content " data-id="bib12"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Dolcos</div> <div class="given-names">F</div></div>,  <div class="name"><div class="surname">LaBar</div> <div class="given-names">KS</div></div>,  <div class="name"><div class="surname">Cabeza</div> <div class="given-names">R</div></div>. </span><div class="article-title">Dissociable effects of arousal and valence on prefrontal activity indexing emotional evaluation and subsequent memory: an event-related fMRI study</div>, <div class="source ">Neuroimage</div>, <div class="year">2004</div>, vol. <div class="volume">23</div> (pg. <div class="fpage">64</div>-<div class="lpage">74</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Dissociable%20effects%20of%20arousal%20and%20valence%20on%20prefrontal%20activity%20indexing%20emotional%20evaluation%20and%20subsequent%20memory%3A%20an%20event-related%20fMRI%20study&amp;author=F%20Dolcos&amp;author=KS%20LaBar&amp;author=R%20Cabeza&amp;publication_year=2004&amp;journal=Neuroimage&amp;volume=23&amp;pages=64-74" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/j.neuroimage.2004.05.015" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2Fj.neuroimage.2004.05.015" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2Fj.neuroimage.2004.05.015"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15325353" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Dissociable%20effects%20of%20arousal%20and%20valence%20on%20prefrontal%20activity%20indexing%20emotional%20evaluation%20and%20subsequent%20memory%3A%20an%20event-related%20fMRI%20study&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib13" class="js-splitview-ref-item" data-legacy-id="bib13"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib13" href="javascript:;" aria-label="jumplink-bib13" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib13" class="ref-content " data-id="bib13"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Dolcos</div> <div class="given-names">F</div></div>,  <div class="name"><div class="surname">LaBar</div> <div class="given-names">KS</div></div>,  <div class="name"><div class="surname">Cabeza</div> <div class="given-names">R</div></div>. </span><div class="article-title">Interaction between the amygdala and the medial temporal lobe memory system predicts better memory for emotional events</div>, <div class="source ">Neuron</div>, <div class="year">2004</div>, vol. <div class="volume">42</div> (pg. <div class="fpage">855</div>-<div class="lpage">863</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Interaction%20between%20the%20amygdala%20and%20the%20medial%20temporal%20lobe%20memory%20system%20predicts%20better%20memory%20for%20emotional%20events&amp;author=F%20Dolcos&amp;author=KS%20LaBar&amp;author=R%20Cabeza&amp;publication_year=2004&amp;journal=Neuron&amp;volume=42&amp;pages=855-863" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/S0896-6273(04)00289-2" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2FS0896-6273(04)00289-2" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2FS0896-6273(04)00289-2"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15182723" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Interaction%20between%20the%20amygdala%20and%20the%20medial%20temporal%20lobe%20memory%20system%20predicts%20better%20memory%20for%20emotional%20events&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib14" class="js-splitview-ref-item" data-legacy-id="bib14"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib14" href="javascript:;" aria-label="jumplink-bib14" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib14" class="ref-content " data-id="bib14"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Dolcos</div> <div class="given-names">F</div></div>,  <div class="name"><div class="surname">LaBar</div> <div class="given-names">KS</div></div>,  <div class="name"><div class="surname">Cabeza</div> <div class="given-names">R</div></div>. </span><div class="article-title">Remembering one year later: role of the amygdala and medial temporal lobe memory system in retrieving emotional memories</div>, <div class="source ">Proc Natl Acad Sci USA</div>, <div class="year">2005</div>, vol. <div class="volume">102</div> (pg. <div class="fpage">2626</div>-<div class="lpage">2631</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Remembering%20one%20year%20later%3A%20role%20of%20the%20amygdala%20and%20medial%20temporal%20lobe%20memory%20system%20in%20retrieving%20emotional%20memories&amp;author=F%20Dolcos&amp;author=KS%20LaBar&amp;author=R%20Cabeza&amp;publication_year=2005&amp;journal=Proc%20Natl%20Acad%20Sci%20USA&amp;volume=102&amp;pages=2626-2631" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1073/pnas.0409848102" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1073%2Fpnas.0409848102" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1073%2Fpnas.0409848102"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15703295" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Remembering%20one%20year%20later%3A%20role%20of%20the%20amygdala%20and%20medial%20temporal%20lobe%20memory%20system%20in%20retrieving%20emotional%20memories&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib15" class="js-splitview-ref-item" data-legacy-id="bib15"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib15" href="javascript:;" aria-label="jumplink-bib15" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib15" class="ref-content " data-id="bib15"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Eichenbaum</div> <div class="given-names">H</div></div>,  <div class="name"><div class="surname">Yonelinas</div> <div class="given-names">AP</div></div>,  <div class="name"><div class="surname">Ranganath</div> <div class="given-names">C</div></div>. </span><div class="article-title">The medial temporal lobe and recognition memory</div>, <div class="source ">Annu Rev Neurosci</div>, <div class="year">2007</div>, vol. <div class="volume">30</div> (pg. <div class="fpage">123</div>-<div class="lpage">152</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20medial%20temporal%20lobe%20and%20recognition%20memory&amp;author=H%20Eichenbaum&amp;author=AP%20Yonelinas&amp;author=C%20Ranganath&amp;publication_year=2007&amp;journal=Annu%20Rev%20Neurosci&amp;volume=30&amp;pages=123-152" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1146/annurev.neuro.30.051606.094328" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1146%2Fannurev.neuro.30.051606.094328" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1146%2Fannurev.neuro.30.051606.094328"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/17417939" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20medial%20temporal%20lobe%20and%20recognition%20memory&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib16" class="js-splitview-ref-item" data-legacy-id="bib16"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib16" href="javascript:;" aria-label="jumplink-bib16" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib16" class="ref-content " data-id="bib16"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Fisher</div> <div class="given-names">RA</div></div>. </span><div class="article-title">On the “probable error” of a coefficient of correlation deduced from a small sample</div>, <div class="source ">Metron</div>, <div class="year">1921</div>, vol. <div class="volume">1</div> (pg. <div class="fpage">3</div>-<div class="lpage">32</div>)<!--citationLinks: case 2--><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=On%20the%20%E2%80%9Cprobable%20error%E2%80%9D%20of%20a%20coefficient%20of%20correlation%20deduced%20from%20a%20small%20sample&amp;author=RA%20Fisher&amp;publication_year=1921&amp;journal=Metron&amp;volume=1&amp;pages=3-32" target="_blank">Google Scholar</a></span></p><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=article&amp;atitle=On+the+%e2%80%9cprobable+error%e2%80%9d+of+a+coefficient+of+correlation+deduced+from+a+small+sample&amp;aulast=Fisher&amp;title=Metron&amp;date=1921&amp;spage=3&amp;epage=32&amp;volume=1" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:On%20the%20%E2%80%9Cprobable%20error%E2%80%9D%20of%20a%20coefficient%20of%20correlation%20deduced%20from%20a%20small%20sample&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib17" class="js-splitview-ref-item" data-legacy-id="bib17"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib17" href="javascript:;" aria-label="jumplink-bib17" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib17" class="ref-content " data-id="bib17"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Fisher</div> <div class="given-names">RA</div></div>. </span>, <div class="source ">Statistical methods for research workers</div>, <div class="year">1950</div><div class="publisher-loc">London</div><div class="publisher-name">Oliver and Boyd</div>pg. <div class="fpage">354</div> <!--citationLinks: case 2--><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Statistical%20methods%20for%20research%20workers&amp;author=RA%20Fisher&amp;publication_year=1950&amp;book=Statistical%20methods%20for%20research%20workers" target="_blank">Google Scholar</a></span></p><p class="citation-links-compatibility"><span class="google-preview-ref-link js-google-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.google.com/search?q=Statistical%20methods%20for%20research%20workers&amp;btnG=Search+Books&amp;tbm=bks&amp;tbo=1" target="_blank">Google Preview</a></span></p><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=book&amp;title=Statistical+methods+for+research+workers&amp;aulast=Fisher&amp;date=1950&amp;spage=354" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Statistical%20methods%20for%20research%20workers&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p><div class="copac-reference-ref-link js-copac-preview-ref-link" style="display:none" data-pubtype="book"><span class="inst-copac"><a class="openInAnotherWindow" target="_blank" href="http://copac.ac.uk/search?ti=Statistical%20methods%20for%20research%20workers">COPAC</a></span></div> </div></div></div></div></div><div content-id="bib18" class="js-splitview-ref-item" data-legacy-id="bib18"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib18" href="javascript:;" aria-label="jumplink-bib18" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib18" class="ref-content " data-id="bib18"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Gabrieli</div> <div class="given-names">JD</div></div>,  <div class="name"><div class="surname">Poldrack</div> <div class="given-names">RA</div></div>,  <div class="name"><div class="surname">Desmond</div> <div class="given-names">JE</div></div>. </span><div class="article-title">The role of left prefrontal cortex in language and memory</div>, <div class="source ">Proc Natl Acad Sci USA</div>, <div class="year">1998</div>, vol. <div class="volume">95</div> (pg. <div class="fpage">906</div>-<div class="lpage">913</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20role%20of%20left%20prefrontal%20cortex%20in%20language%20and%20memory&amp;author=JD%20Gabrieli&amp;author=RA%20Poldrack&amp;author=JE%20Desmond&amp;publication_year=1998&amp;journal=Proc%20Natl%20Acad%20Sci%20USA&amp;volume=95&amp;pages=906-913" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1073/pnas.95.3.906" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1073%2Fpnas.95.3.906" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1073%2Fpnas.95.3.906"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/9448258" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20role%20of%20left%20prefrontal%20cortex%20in%20language%20and%20memory&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib19" class="js-splitview-ref-item" data-legacy-id="bib19"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib19" href="javascript:;" aria-label="jumplink-bib19" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib19" class="ref-content " data-id="bib19"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Hamann</div> <div class="given-names">SB</div></div>. </span><div class="article-title">Cognitive and neural mechanisms of emotional memory</div>, <div class="source ">Trends Cogn Sci</div>, <div class="year">2001</div>, vol. <div class="volume">5</div> (pg. <div class="fpage">394</div>-<div class="lpage">400</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Cognitive%20and%20neural%20mechanisms%20of%20emotional%20memory&amp;author=SB%20Hamann&amp;publication_year=2001&amp;journal=Trends%20Cogn%20Sci&amp;volume=5&amp;pages=394-400" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/S1364-6613(00)01707-1" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2FS1364-6613(00)01707-1" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2FS1364-6613(00)01707-1"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/11520704" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Cognitive%20and%20neural%20mechanisms%20of%20emotional%20memory&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib20" class="js-splitview-ref-item" data-legacy-id="bib20"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib20" href="javascript:;" aria-label="jumplink-bib20" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib20" class="ref-content " data-id="bib20"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Hamann</div> <div class="given-names">SB</div></div>,  <div class="name"><div class="surname">Ely</div> <div class="given-names">TD</div></div>,  <div class="name"><div class="surname">Grafton</div> <div class="given-names">ST</div></div>,  <div class="name"><div class="surname">Kilts</div> <div class="given-names">CD</div></div>. </span><div class="article-title">Amygdala activity related to enhanced memory for pleasant and aversive stimuli</div>, <div class="source ">Nat Neurosci</div>, <div class="year">1999</div>, vol. <div class="volume">2</div> (pg. <div class="fpage">289</div>-<div class="lpage">293</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Amygdala%20activity%20related%20to%20enhanced%20memory%20for%20pleasant%20and%20aversive%20stimuli&amp;author=SB%20Hamann&amp;author=TD%20Ely&amp;author=ST%20Grafton&amp;author=CD%20Kilts&amp;publication_year=1999&amp;journal=Nat%20Neurosci&amp;volume=2&amp;pages=289-293" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1038/6404" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1038%2F6404" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1038%2F6404"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/10195224" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Amygdala%20activity%20related%20to%20enhanced%20memory%20for%20pleasant%20and%20aversive%20stimuli&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib21" class="js-splitview-ref-item" data-legacy-id="bib21"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib21" href="javascript:;" aria-label="jumplink-bib21" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib21" class="ref-content " data-id="bib21"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Hu</div> <div class="given-names">H</div></div>,  <div class="name"><div class="surname">Real</div> <div class="given-names">E</div></div>,  <div class="name"><div class="surname">Takamiya</div> <div class="given-names">K</div></div>,  <div class="name"><div class="surname">Kang</div> <div class="given-names">MG</div></div>,  <div class="name"><div class="surname">Ledoux</div> <div class="given-names">J</div></div>,  <div class="name"><div class="surname">Huganir</div> <div class="given-names">RL</div></div>,  <div class="name"><div class="surname">Malinow</div> <div class="given-names">R</div></div>. </span><div class="article-title">Emotion enhances learning via norepinephrine regulation of AMPA-receptor trafficking</div>, <div class="source ">Cell</div>, <div class="year">2007</div>, vol. <div class="volume">131</div> (pg. <div class="fpage">160</div>-<div class="lpage">173</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Emotion%20enhances%20learning%20via%20norepinephrine%20regulation%20of%20AMPA-receptor%20trafficking&amp;author=H%20Hu&amp;author=E%20Real&amp;author=K%20Takamiya&amp;author=MG%20Kang&amp;author=J%20Ledoux&amp;author=RL%20Huganir&amp;author=R%20Malinow&amp;publication_year=2007&amp;journal=Cell&amp;volume=131&amp;pages=160-173" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/j.cell.2007.09.017" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2Fj.cell.2007.09.017" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2Fj.cell.2007.09.017"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/17923095" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Emotion%20enhances%20learning%20via%20norepinephrine%20regulation%20of%20AMPA-receptor%20trafficking&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib22" class="js-splitview-ref-item" data-legacy-id="bib22"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib22" href="javascript:;" aria-label="jumplink-bib22" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib22" class="ref-content " data-id="bib22"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Kensinger</div> <div class="given-names">EA</div></div>. </span><div class="article-title">Remembering emotional experiences: the contribution of valence and arousal</div>, <div class="source ">Rev Neurosci</div>, <div class="year">2004</div>, vol. <div class="volume">15</div> (pg. <div class="fpage">241</div>-<div class="lpage">253</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Remembering%20emotional%20experiences%3A%20the%20contribution%20of%20valence%20and%20arousal&amp;author=EA%20Kensinger&amp;publication_year=2004&amp;journal=Rev%20Neurosci&amp;volume=15&amp;pages=241-253" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1515/REVNEURO.2004.15.4.241" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1515%2FREVNEURO.2004.15.4.241" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1515%2FREVNEURO.2004.15.4.241"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15526549" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Remembering%20emotional%20experiences%3A%20the%20contribution%20of%20valence%20and%20arousal&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib23" class="js-splitview-ref-item" data-legacy-id="bib23"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib23" href="javascript:;" aria-label="jumplink-bib23" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib23" class="ref-content " data-id="bib23"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Kensinger</div> <div class="given-names">EA</div></div>,  <div class="name"><div class="surname">Corkin</div> <div class="given-names">S</div></div>. </span><div class="article-title">Memory enhancement for emotional words: are emotional words more vividly remembered than neutral words?</div>, <div class="source ">Mem Cognit</div>, <div class="year">2003</div>, vol. <div class="volume">31</div> (pg. <div class="fpage">1169</div>-<div class="lpage">1180</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Memory%20enhancement%20for%20emotional%20words%3A%20are%20emotional%20words%20more%20vividly%20remembered%20than%20neutral%20words%3F&amp;author=EA%20Kensinger&amp;author=S%20Corkin&amp;publication_year=2003&amp;journal=Mem%20Cognit&amp;volume=31&amp;pages=1169-1180" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.3758/BF03195800" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.3758%2FBF03195800" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.3758%2FBF03195800"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15058678" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Memory%20enhancement%20for%20emotional%20words%3A%20are%20emotional%20words%20more%20vividly%20remembered%20than%20neutral%20words%3F&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib24" class="js-splitview-ref-item" data-legacy-id="bib24"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib24" href="javascript:;" aria-label="jumplink-bib24" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib24" class="ref-content " data-id="bib24"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Kensinger</div> <div class="given-names">EA</div></div>,  <div class="name"><div class="surname">Corkin</div> <div class="given-names">S</div></div>. </span><div class="article-title">Two routes to emotional memory: distinct neural processes for valence and arousal</div>, <div class="source ">Proc Natl Acad Sci USA</div>, <div class="year">2004</div>, vol. <div class="volume">101</div> (pg. <div class="fpage">3310</div>-<div class="lpage">3315</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Two%20routes%20to%20emotional%20memory%3A%20distinct%20neural%20processes%20for%20valence%20and%20arousal&amp;author=EA%20Kensinger&amp;author=S%20Corkin&amp;publication_year=2004&amp;journal=Proc%20Natl%20Acad%20Sci%20USA&amp;volume=101&amp;pages=3310-3315" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1073/pnas.0306408101" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1073%2Fpnas.0306408101" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1073%2Fpnas.0306408101"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/14981255" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Two%20routes%20to%20emotional%20memory%3A%20distinct%20neural%20processes%20for%20valence%20and%20arousal&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib25" class="js-splitview-ref-item" data-legacy-id="bib25"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib25" href="javascript:;" aria-label="jumplink-bib25" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib25" class="ref-content " data-id="bib25"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Kensinger</div> <div class="given-names">EA</div></div>,  <div class="name"><div class="surname">Schacter</div> <div class="given-names">DL</div></div>. </span><div class="article-title">Amygdala activity is associated with the successful encoding of item, but not source, information for positive and negative stimuli</div>, <div class="source ">J Neurosci</div>, <div class="year">2006</div>, vol. <div class="volume">26</div> (pg. <div class="fpage">2564</div>-<div class="lpage">2570</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Amygdala%20activity%20is%20associated%20with%20the%20successful%20encoding%20of%20item%2C%20but%20not%20source%2C%20information%20for%20positive%20and%20negative%20stimuli&amp;author=EA%20Kensinger&amp;author=DL%20Schacter&amp;publication_year=2006&amp;journal=J%20Neurosci&amp;volume=26&amp;pages=2564-2570" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1523/JNEUROSCI.5241-05.2006" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1523%2FJNEUROSCI.5241-05.2006" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1523%2FJNEUROSCI.5241-05.2006"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/16510734" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Amygdala%20activity%20is%20associated%20with%20the%20successful%20encoding%20of%20item%2C%20but%20not%20source%2C%20information%20for%20positive%20and%20negative%20stimuli&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib26" class="js-splitview-ref-item" data-legacy-id="bib26"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib26" href="javascript:;" aria-label="jumplink-bib26" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib26" class="ref-content " data-id="bib26"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Kilpatrick</div> <div class="given-names">L</div></div>,  <div class="name"><div class="surname">Cahill</div> <div class="given-names">L</div></div>. </span><div class="article-title">Amygdala modulation of parahippocampal and frontal regions during emotionally influenced memory storage</div>, <div class="source ">Neuroimage</div>, <div class="year">2003</div>, vol. <div class="volume">20</div> (pg. <div class="fpage">2091</div>-<div class="lpage">2099</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Amygdala%20modulation%20of%20parahippocampal%20and%20frontal%20regions%20during%20emotionally%20influenced%20memory%20storage&amp;author=L%20Kilpatrick&amp;author=L%20Cahill&amp;publication_year=2003&amp;journal=Neuroimage&amp;volume=20&amp;pages=2091-2099" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/j.neuroimage.2003.08.006" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2Fj.neuroimage.2003.08.006" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2Fj.neuroimage.2003.08.006"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/14683713" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Amygdala%20modulation%20of%20parahippocampal%20and%20frontal%20regions%20during%20emotionally%20influenced%20memory%20storage&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib27" class="js-splitview-ref-item" data-legacy-id="bib27"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib27" href="javascript:;" aria-label="jumplink-bib27" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib27" class="ref-content " data-id="bib27"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Kleinsmith</div> <div class="given-names">LJ</div></div>,  <div class="name"><div class="surname">Kaplan</div> <div class="given-names">S</div></div>. </span><div class="article-title">Paired-associate learning as a function of arousal and interpolated interval</div>, <div class="source ">J Exp Psychol</div>, <div class="year">1963</div>, vol. <div class="volume">65</div> (pg. <div class="fpage">190</div>-<div class="lpage">193</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Paired-associate%20learning%20as%20a%20function%20of%20arousal%20and%20interpolated%20interval&amp;author=LJ%20Kleinsmith&amp;author=S%20Kaplan&amp;publication_year=1963&amp;journal=J%20Exp%20Psychol&amp;volume=65&amp;pages=190-193" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1037/h0040288" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1037%2Fh0040288" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1037%2Fh0040288"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/14033436" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Paired-associate%20learning%20as%20a%20function%20of%20arousal%20and%20interpolated%20interval&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib28" class="js-splitview-ref-item" data-legacy-id="bib28"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib28" href="javascript:;" aria-label="jumplink-bib28" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib28" class="ref-content " data-id="bib28"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">LaBar</div> <div class="given-names">KS</div></div>,  <div class="name"><div class="surname">Cabeza</div> <div class="given-names">R</div></div>. </span><div class="article-title">Cognitive neuroscience of emotional memory</div>, <div class="source ">Nat Rev Neurosci</div>, <div class="year">2006</div>, vol. <div class="volume">7</div> (pg. <div class="fpage">54</div>-<div class="lpage">64</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Cognitive%20neuroscience%20of%20emotional%20memory&amp;author=KS%20LaBar&amp;author=R%20Cabeza&amp;publication_year=2006&amp;journal=Nat%20Rev%20Neurosci&amp;volume=7&amp;pages=54-64" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1038/nrn1825" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1038%2Fnrn1825" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1038%2Fnrn1825"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/16371950" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Cognitive%20neuroscience%20of%20emotional%20memory&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib29" class="js-splitview-ref-item" data-legacy-id="bib29"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib29" href="javascript:;" aria-label="jumplink-bib29" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib29" class="ref-content " data-id="bib29"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">LaBar</div> <div class="given-names">KS</div></div>,  <div class="name"><div class="surname">Phelps</div> <div class="given-names">EA</div></div>. </span><div class="article-title">Arousal-mediated memory consolidation: role of the medial temporal lobe in humans</div>, <div class="source ">Psychol Sci</div>, <div class="year">1998</div>, vol. <div class="volume">9</div> (pg. <div class="fpage">490</div>-<div class="lpage">493</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Arousal-mediated%20memory%20consolidation%3A%20role%20of%20the%20medial%20temporal%20lobe%20in%20humans&amp;author=KS%20LaBar&amp;author=EA%20Phelps&amp;publication_year=1998&amp;journal=Psychol%20Sci&amp;volume=9&amp;pages=490-493" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1111/1467-9280.00090" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1111%2F1467-9280.00090" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1111%2F1467-9280.00090"> </span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Arousal-mediated%20memory%20consolidation%3A%20role%20of%20the%20medial%20temporal%20lobe%20in%20humans&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib30" class="js-splitview-ref-item" data-legacy-id="bib30"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib30" href="javascript:;" aria-label="jumplink-bib30" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib30" class="ref-content " data-id="bib30"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Lang</div> <div class="given-names">PJ</div></div>,  <div class="name"><div class="surname">Bradley</div> <div class="given-names">MM</div></div>,  <div class="name"><div class="surname">Cuthbert</div> <div class="given-names">BN</div></div>. </span>, <div class="source ">International Affective Picture System (IAPS): Instruction Manual and Affective Ratings</div>, <div class="year">2001</div><div class="publisher-loc">Gainesville, FL</div><div class="publisher-name">The Center for Research in Psychophysiology, University of Florida.</div> <div class="comment">Report No.: A-5</div><!--citationLinks: case 2--><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=International%20Affective%20Picture%20System%20%28IAPS%29%3A%20Instruction%20Manual%20and%20Affective%20Ratings&amp;author=PJ%20Lang&amp;author=MM%20Bradley&amp;author=BN%20Cuthbert&amp;publication_year=2001&amp;book=International%20Affective%20Picture%20System%20%28IAPS%29%3A%20Instruction%20Manual%20and%20Affective%20Ratings" target="_blank">Google Scholar</a></span></p><p class="citation-links-compatibility"><span class="google-preview-ref-link js-google-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.google.com/search?q=International%20Affective%20Picture%20System%20%28IAPS%29%3A%20Instruction%20Manual%20and%20Affective%20Ratings&amp;btnG=Search+Books&amp;tbm=bks&amp;tbo=1" target="_blank">Google Preview</a></span></p><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=book&amp;title=International+Affective+Picture+System+(IAPS)%3a+Instruction+Manual+and+Affective+Ratings&amp;aulast=Lang&amp;date=2001" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:International%20Affective%20Picture%20System%20%28IAPS%29%3A%20Instruction%20Manual%20and%20Affective%20Ratings&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p><div class="copac-reference-ref-link js-copac-preview-ref-link" style="display:none" data-pubtype="book"><span class="inst-copac"><a class="openInAnotherWindow" target="_blank" href="http://copac.ac.uk/search?ti=International%20Affective%20Picture%20System%20%28IAPS%29%3A%20Instruction%20Manual%20and%20Affective%20Ratings">COPAC</a></span></div> </div></div></div></div></div><div content-id="bib31" class="js-splitview-ref-item" data-legacy-id="bib31"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib31" href="javascript:;" aria-label="jumplink-bib31" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib31" class="ref-content " data-id="bib31"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Lazar</div> <div class="given-names">NA</div></div>,  <div class="name"><div class="surname">Luna</div> <div class="given-names">B</div></div>,  <div class="name"><div class="surname">Sweeney</div> <div class="given-names">JA</div></div>,  <div class="name"><div class="surname">Eddy</div> <div class="given-names">WF</div></div>. </span><div class="article-title">Combining brains: a survey of methods for statistical pooling of information</div>, <div class="source ">Neuroimage</div>, <div class="year">2002</div>, vol. <div class="volume">16</div> (pg. <div class="fpage">538</div>-<div class="lpage">550</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Combining%20brains%3A%20a%20survey%20of%20methods%20for%20statistical%20pooling%20of%20information&amp;author=NA%20Lazar&amp;author=B%20Luna&amp;author=JA%20Sweeney&amp;author=WF%20Eddy&amp;publication_year=2002&amp;journal=Neuroimage&amp;volume=16&amp;pages=538-550" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1006/nimg.2002.1107" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1006%2Fnimg.2002.1107" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1006%2Fnimg.2002.1107"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12030836" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Combining%20brains%3A%20a%20survey%20of%20methods%20for%20statistical%20pooling%20of%20information&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib32" class="js-splitview-ref-item" data-legacy-id="bib32"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib32" href="javascript:;" aria-label="jumplink-bib32" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib32" class="ref-content " data-id="bib32"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Mackiewicz</div> <div class="given-names">KL</div></div>,  <div class="name"><div class="surname">Sarinopoulos</div> <div class="given-names">I</div></div>,  <div class="name"><div class="surname">Cleven</div> <div class="given-names">KL</div></div>,  <div class="name"><div class="surname">Nitschke</div> <div class="given-names">JB</div></div>. </span><div class="article-title">The effect of anticipation and the specificity of sex differences for amygdala and hippocampus function in emotional memory</div>, <div class="source ">Proc Natl Acad Sci USA</div>, <div class="year">2006</div>, vol. <div class="volume">103</div> (pg. <div class="fpage">14200</div>-<div class="lpage">14205</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20effect%20of%20anticipation%20and%20the%20specificity%20of%20sex%20differences%20for%20amygdala%20and%20hippocampus%20function%20in%20emotional%20memory&amp;author=KL%20Mackiewicz&amp;author=I%20Sarinopoulos&amp;author=KL%20Cleven&amp;author=JB%20Nitschke&amp;publication_year=2006&amp;journal=Proc%20Natl%20Acad%20Sci%20USA&amp;volume=103&amp;pages=14200-14205" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1073/pnas.0601648103" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1073%2Fpnas.0601648103" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1073%2Fpnas.0601648103"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/16963565" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20effect%20of%20anticipation%20and%20the%20specificity%20of%20sex%20differences%20for%20amygdala%20and%20hippocampus%20function%20in%20emotional%20memory&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib33" class="js-splitview-ref-item" data-legacy-id="bib33"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib33" href="javascript:;" aria-label="jumplink-bib33" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib33" class="ref-content " data-id="bib33"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">McGaugh</div> <div class="given-names">JL</div></div>. </span><div class="article-title">The amygdala modulates the consolidation of memories of emotionally arousing experiences</div>, <div class="source ">Annu Rev Neurosci</div>, <div class="year">2004</div>, vol. <div class="volume">27</div> (pg. <div class="fpage">1</div>-<div class="lpage">28</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=The%20amygdala%20modulates%20the%20consolidation%20of%20memories%20of%20emotionally%20arousing%20experiences&amp;author=JL%20McGaugh&amp;publication_year=2004&amp;journal=Annu%20Rev%20Neurosci&amp;volume=27&amp;pages=1-28" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1146/annurev.neuro.27.070203.144157" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1146%2Fannurev.neuro.27.070203.144157" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1146%2Fannurev.neuro.27.070203.144157"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15217324" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:The%20amygdala%20modulates%20the%20consolidation%20of%20memories%20of%20emotionally%20arousing%20experiences&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib34" class="js-splitview-ref-item" data-legacy-id="bib34"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib34" href="javascript:;" aria-label="jumplink-bib34" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib34" class="ref-content " data-id="bib34"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">McGaugh</div> <div class="given-names">JL</div></div>,  <div class="name"><div class="surname">McIntyre</div> <div class="given-names">CK</div></div>,  <div class="name"><div class="surname">Power</div> <div class="given-names">AE</div></div>. </span><div class="article-title">Amygdala modulation of memory consolidation: interaction with other brain systems</div>, <div class="source ">Neurobiol Learn Mem</div>, <div class="year">2002</div>, vol. <div class="volume">78</div> (pg. <div class="fpage">539</div>-<div class="lpage">552</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Amygdala%20modulation%20of%20memory%20consolidation%3A%20interaction%20with%20other%20brain%20systems&amp;author=JL%20McGaugh&amp;author=CK%20McIntyre&amp;author=AE%20Power&amp;publication_year=2002&amp;journal=Neurobiol%20Learn%20Mem&amp;volume=78&amp;pages=539-552" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1006/nlme.2002.4082" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1006%2Fnlme.2002.4082" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1006%2Fnlme.2002.4082"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12559833" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Amygdala%20modulation%20of%20memory%20consolidation%3A%20interaction%20with%20other%20brain%20systems&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib35" class="js-splitview-ref-item" data-legacy-id="bib35"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib35" href="javascript:;" aria-label="jumplink-bib35" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib35" class="ref-content " data-id="bib35"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">McIntyre</div> <div class="given-names">CK</div></div>,  <div class="name"><div class="surname">Power</div> <div class="given-names">AE</div></div>,  <div class="name"><div class="surname">Roozendaal</div> <div class="given-names">B</div></div>,  <div class="name"><div class="surname">McGaugh</div> <div class="given-names">JL</div></div>. </span><div class="article-title">Role of the basolateral amygdala in memory consolidation</div>, <div class="source ">Ann N Y Acad Sci</div>, <div class="year">2003</div>, vol. <div class="volume">985</div> (pg. <div class="fpage">273</div>-<div class="lpage">293</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Role%20of%20the%20basolateral%20amygdala%20in%20memory%20consolidation&amp;author=CK%20McIntyre&amp;author=AE%20Power&amp;author=B%20Roozendaal&amp;author=JL%20McGaugh&amp;publication_year=2003&amp;journal=Ann%20N%20Y%20Acad%20Sci&amp;volume=985&amp;pages=273-293" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1111/(ISSN)1749-6632" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1111%2F(ISSN)1749-6632" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1111%2F(ISSN)1749-6632"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12724165" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Role%20of%20the%20basolateral%20amygdala%20in%20memory%20consolidation&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib36" class="js-splitview-ref-item" data-legacy-id="bib36"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib36" href="javascript:;" aria-label="jumplink-bib36" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib36" class="ref-content " data-id="bib36"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Nakao</div> <div class="given-names">K</div></div>,  <div class="name"><div class="surname">Matsuyama</div> <div class="given-names">K</div></div>,  <div class="name"><div class="surname">Matsuki</div> <div class="given-names">N</div></div>,  <div class="name"><div class="surname">Ikegaya</div> <div class="given-names">Y</div></div>. </span><div class="article-title">Amygdala stimulation modulates hippocampal synaptic plasticity</div>, <div class="source ">Proc Natl Acad Sci USA</div>, <div class="year">2004</div>, vol. <div class="volume">101</div> (pg. <div class="fpage">14270</div>-<div class="lpage">14275</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Amygdala%20stimulation%20modulates%20hippocampal%20synaptic%20plasticity&amp;author=K%20Nakao&amp;author=K%20Matsuyama&amp;author=N%20Matsuki&amp;author=Y%20Ikegaya&amp;publication_year=2004&amp;journal=Proc%20Natl%20Acad%20Sci%20USA&amp;volume=101&amp;pages=14270-14275" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1073/pnas.0405709101" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1073%2Fpnas.0405709101" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1073%2Fpnas.0405709101"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15381775" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Amygdala%20stimulation%20modulates%20hippocampal%20synaptic%20plasticity&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib37" class="js-splitview-ref-item" data-legacy-id="bib37"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib37" href="javascript:;" aria-label="jumplink-bib37" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib37" class="ref-content " data-id="bib37"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Ochsner</div> <div class="given-names">KN</div></div>. </span><div class="article-title">Are affective events richly recollected or simply familiar? The experience and process of recognizing feelings past</div>, <div class="source ">J Exp Psychol Gen</div>, <div class="year">2000</div>, vol. <div class="volume">129</div> (pg. <div class="fpage">242</div>-<div class="lpage">261</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Are%20affective%20events%20richly%20recollected%20or%20simply%20familiar%3F%20The%20experience%20and%20process%20of%20recognizing%20feelings%20past&amp;author=KN%20Ochsner&amp;publication_year=2000&amp;journal=J%20Exp%20Psychol%20Gen&amp;volume=129&amp;pages=242-261" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1037/0096-3445.129.2.242" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1037%2F0096-3445.129.2.242" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1037%2F0096-3445.129.2.242"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/10868336" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Are%20affective%20events%20richly%20recollected%20or%20simply%20familiar%3F%20The%20experience%20and%20process%20of%20recognizing%20feelings%20past&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib38" class="js-splitview-ref-item" data-legacy-id="bib38"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib38" href="javascript:;" aria-label="jumplink-bib38" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib38" class="ref-content " data-id="bib38"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Paller</div> <div class="given-names">KA</div></div>,  <div class="name"><div class="surname">Wagner</div> <div class="given-names">AD</div></div>. </span><div class="article-title">Observing the transformation of experience into memory</div>, <div class="source ">Trends Cogn Sci</div>, <div class="year">2002</div>, vol. <div class="volume">6</div> (pg. <div class="fpage">93</div>-<div class="lpage">102</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Observing%20the%20transformation%20of%20experience%20into%20memory&amp;author=KA%20Paller&amp;author=AD%20Wagner&amp;publication_year=2002&amp;journal=Trends%20Cogn%20Sci&amp;volume=6&amp;pages=93-102" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/S1364-6613(00)01845-3" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2FS1364-6613(00)01845-3" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2FS1364-6613(00)01845-3"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15866193" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Observing%20the%20transformation%20of%20experience%20into%20memory&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib39" class="js-splitview-ref-item" data-legacy-id="bib39"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib39" href="javascript:;" aria-label="jumplink-bib39" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib39" class="ref-content " data-id="bib39"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Pare</div> <div class="given-names">D</div></div>,  <div class="name"><div class="surname">Dong</div> <div class="given-names">J</div></div>,  <div class="name"><div class="surname">Gaudreau</div> <div class="given-names">H</div></div>. </span><div class="article-title">Amygdalo-entorhinal relations and their reflection in the hippocampal formation: generation of sharp sleep potentials</div>, <div class="source ">J Neurosci</div>, <div class="year">1995</div>, vol. <div class="volume">15</div> (pg. <div class="fpage">2482</div>-<div class="lpage">2503</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Amygdalo-entorhinal%20relations%20and%20their%20reflection%20in%20the%20hippocampal%20formation%3A%20generation%20of%20sharp%20sleep%20potentials&amp;author=D%20Pare&amp;author=J%20Dong&amp;author=H%20Gaudreau&amp;publication_year=1995&amp;journal=J%20Neurosci&amp;volume=15&amp;pages=2482-2503" target="_blank">Google Scholar</a></span></p><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/7891183" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><div class="xslopenurl empty-target"><span class="js-inst-open-url-holders-nodoi"><a class="js-open-url-link" data-href-template="{targetURL}?sid=oup:orr&amp;genre=article&amp;atitle=Amygdalo-entorhinal+relations+and+their+reflection+in+the+hippocampal+formation%3a+generation+of+sharp+sleep+potentials&amp;aulast=Pare&amp;title=J+Neurosci&amp;date=1995&amp;spage=2482&amp;epage=2503&amp;volume=15" href="javascript:;"><span class="screenreader-text">OpenURL Placeholder Text</span></a></span></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Amygdalo-entorhinal%20relations%20and%20their%20reflection%20in%20the%20hippocampal%20formation%3A%20generation%20of%20sharp%20sleep%20potentials&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib40" class="js-splitview-ref-item" data-legacy-id="bib40"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib40" href="javascript:;" aria-label="jumplink-bib40" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib40" class="ref-content " data-id="bib40"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Paz</div> <div class="given-names">R</div></div>,  <div class="name"><div class="surname">Pelletier</div> <div class="given-names">JG</div></div>,  <div class="name"><div class="surname">Bauer</div> <div class="given-names">EP</div></div>,  <div class="name"><div class="surname">Pare</div> <div class="given-names">D</div></div>. </span><div class="article-title">Emotional enhancement of memory via amygdala-driven facilitation of rhinal interactions</div>, <div class="source ">Nat Neurosci</div>, <div class="year">2006</div>, vol. <div class="volume">9</div> (pg. <div class="fpage">1321</div>-<div class="lpage">1329</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Emotional%20enhancement%20of%20memory%20via%20amygdala-driven%20facilitation%20of%20rhinal%20interactions&amp;author=R%20Paz&amp;author=JG%20Pelletier&amp;author=EP%20Bauer&amp;author=D%20Pare&amp;publication_year=2006&amp;journal=Nat%20Neurosci&amp;volume=9&amp;pages=1321-1329" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1038/nn1771" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1038%2Fnn1771" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1038%2Fnn1771"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/16964249" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Emotional%20enhancement%20of%20memory%20via%20amygdala-driven%20facilitation%20of%20rhinal%20interactions&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib41" class="js-splitview-ref-item" data-legacy-id="bib41"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib41" href="javascript:;" aria-label="jumplink-bib41" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib41" class="ref-content " data-id="bib41"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Pelletier</div> <div class="given-names">JG</div></div>,  <div class="name"><div class="surname">Likhtik</div> <div class="given-names">E</div></div>,  <div class="name"><div class="surname">Filali</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Pare</div> <div class="given-names">D</div></div>. </span><div class="article-title">Lasting increases in basolateral amygdala activity after emotional arousal: implications for facilitated consolidation of emotional memories</div>, <div class="source ">Learn Mem</div>, <div class="year">2005</div>, vol. <div class="volume">12</div> (pg. <div class="fpage">96</div>-<div class="lpage">102</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Lasting%20increases%20in%20basolateral%20amygdala%20activity%20after%20emotional%20arousal%3A%20implications%20for%20facilitated%20consolidation%20of%20emotional%20memories&amp;author=JG%20Pelletier&amp;author=E%20Likhtik&amp;author=M%20Filali&amp;author=D%20Pare&amp;publication_year=2005&amp;journal=Learn%20Mem&amp;volume=12&amp;pages=96-102" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1101/lm.88605" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1101%2Flm.88605" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1101%2Flm.88605"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15805308" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Lasting%20increases%20in%20basolateral%20amygdala%20activity%20after%20emotional%20arousal%3A%20implications%20for%20facilitated%20consolidation%20of%20emotional%20memories&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib42" class="js-splitview-ref-item" data-legacy-id="bib42"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib42" href="javascript:;" aria-label="jumplink-bib42" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib42" class="ref-content " data-id="bib42"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Ranganath</div> <div class="given-names">C</div></div>,  <div class="name"><div class="surname">Yonelinas</div> <div class="given-names">AP</div></div>,  <div class="name"><div class="surname">Cohen</div> <div class="given-names">MX</div></div>,  <div class="name"><div class="surname">Dy</div> <div class="given-names">CJ</div></div>,  <div class="name"><div class="surname">Tom</div> <div class="given-names">SM</div></div>,  <div class="name"><div class="surname">D'Esposito</div> <div class="given-names">M</div></div>. </span><div class="article-title">Dissociable correlates of recollection and familiarity within the medial temporal lobes</div>, <div class="source ">Neuropsychologia</div>, <div class="year">2004</div>, vol. <div class="volume">42</div> (pg. <div class="fpage">2</div>-<div class="lpage">13</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Dissociable%20correlates%20of%20recollection%20and%20familiarity%20within%20the%20medial%20temporal%20lobes&amp;author=C%20Ranganath&amp;author=AP%20Yonelinas&amp;author=MX%20Cohen&amp;author=CJ%20Dy&amp;author=SM%20Tom&amp;author=M%20D%27Esposito&amp;publication_year=2004&amp;journal=Neuropsychologia&amp;volume=42&amp;pages=2-13" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/j.neuropsychologia.2003.07.006" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2Fj.neuropsychologia.2003.07.006" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2Fj.neuropsychologia.2003.07.006"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/14615072" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Dissociable%20correlates%20of%20recollection%20and%20familiarity%20within%20the%20medial%20temporal%20lobes&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib43" class="js-splitview-ref-item" data-legacy-id="bib43"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib43" href="javascript:;" aria-label="jumplink-bib43" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib43" class="ref-content " data-id="bib43"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Richardson</div> <div class="given-names">MP</div></div>,  <div class="name"><div class="surname">Strange</div> <div class="given-names">BA</div></div>,  <div class="name"><div class="surname">Dolan</div> <div class="given-names">RJ</div></div>. </span><div class="article-title">Encoding of emotional memories depends on amygdala and hippocampus and their interactions</div>, <div class="source ">Nat Neurosci</div>, <div class="year">2004</div>, vol. <div class="volume">7</div> (pg. <div class="fpage">278</div>-<div class="lpage">285</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Encoding%20of%20emotional%20memories%20depends%20on%20amygdala%20and%20hippocampus%20and%20their%20interactions&amp;author=MP%20Richardson&amp;author=BA%20Strange&amp;author=RJ%20Dolan&amp;publication_year=2004&amp;journal=Nat%20Neurosci&amp;volume=7&amp;pages=278-285" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1038/nn1190" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1038%2Fnn1190" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1038%2Fnn1190"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/14758364" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Encoding%20of%20emotional%20memories%20depends%20on%20amygdala%20and%20hippocampus%20and%20their%20interactions&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib44" class="js-splitview-ref-item" data-legacy-id="bib44"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib44" href="javascript:;" aria-label="jumplink-bib44" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib44" class="ref-content " data-id="bib44"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Rissman</div> <div class="given-names">J</div></div>,  <div class="name"><div class="surname">Gazzaley</div> <div class="given-names">A</div></div>,  <div class="name"><div class="surname">D'Esposito</div> <div class="given-names">M</div></div>. </span><div class="article-title">Measuring functional connectivity during distinct stages of a cognitive task</div>, <div class="source ">Neuroimage</div>, <div class="year">2004</div>, vol. <div class="volume">23</div> (pg. <div class="fpage">752</div>-<div class="lpage">763</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Measuring%20functional%20connectivity%20during%20distinct%20stages%20of%20a%20cognitive%20task&amp;author=J%20Rissman&amp;author=A%20Gazzaley&amp;author=M%20D%27Esposito&amp;publication_year=2004&amp;journal=Neuroimage&amp;volume=23&amp;pages=752-763" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/j.neuroimage.2004.06.035" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2Fj.neuroimage.2004.06.035" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2Fj.neuroimage.2004.06.035"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15488425" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Measuring%20functional%20connectivity%20during%20distinct%20stages%20of%20a%20cognitive%20task&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib45" class="js-splitview-ref-item" data-legacy-id="bib45"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib45" href="javascript:;" aria-label="jumplink-bib45" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib45" class="ref-content " data-id="bib45"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Roesler</div> <div class="given-names">R</div></div>,  <div class="name"><div class="surname">Roozendaal</div> <div class="given-names">B</div></div>,  <div class="name"><div class="surname">McGaugh</div> <div class="given-names">JL</div></div>. </span><div class="article-title">Basolateral amygdala lesions block the memory-enhancing effect of 8-Br-cAMP infused into the entorhinal cortex of rats after training</div>, <div class="source ">Eur J Neurosci</div>, <div class="year">2002</div>, vol. <div class="volume">15</div> (pg. <div class="fpage">905</div>-<div class="lpage">910</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Basolateral%20amygdala%20lesions%20block%20the%20memory-enhancing%20effect%20of%208-Br-cAMP%20infused%20into%20the%20entorhinal%20cortex%20of%20rats%20after%20training&amp;author=R%20Roesler&amp;author=B%20Roozendaal&amp;author=JL%20McGaugh&amp;publication_year=2002&amp;journal=Eur%20J%20Neurosci&amp;volume=15&amp;pages=905-910" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1046/j.1460-9568.2002.01924.x" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1046%2Fj.1460-9568.2002.01924.x" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1046%2Fj.1460-9568.2002.01924.x"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/11906532" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Basolateral%20amygdala%20lesions%20block%20the%20memory-enhancing%20effect%20of%208-Br-cAMP%20infused%20into%20the%20entorhinal%20cortex%20of%20rats%20after%20training&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib46" class="js-splitview-ref-item" data-legacy-id="bib46"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib46" href="javascript:;" aria-label="jumplink-bib46" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib46" class="ref-content " data-id="bib46"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Roozendaal</div> <div class="given-names">B</div></div>,  <div class="name"><div class="surname">Nguyen</div> <div class="given-names">BT</div></div>,  <div class="name"><div class="surname">Power</div> <div class="given-names">AE</div></div>,  <div class="name"><div class="surname">McGaugh</div> <div class="given-names">JL</div></div>. </span><div class="article-title">Basolateral amygdala noradrenergic influence enables enhancement of memory consolidation induced by hippocampal glucocorticoid receptor activation</div>, <div class="source ">Proc Natl Acad Sci USA</div>, <div class="year">1999</div>, vol. <div class="volume">96</div> (pg. <div class="fpage">11642</div>-<div class="lpage">11647</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Basolateral%20amygdala%20noradrenergic%20influence%20enables%20enhancement%20of%20memory%20consolidation%20induced%20by%20hippocampal%20glucocorticoid%20receptor%20activation&amp;author=B%20Roozendaal&amp;author=BT%20Nguyen&amp;author=AE%20Power&amp;author=JL%20McGaugh&amp;publication_year=1999&amp;journal=Proc%20Natl%20Acad%20Sci%20USA&amp;volume=96&amp;pages=11642-11647" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1073/pnas.96.20.11642" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1073%2Fpnas.96.20.11642" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1073%2Fpnas.96.20.11642"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/10500230" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Basolateral%20amygdala%20noradrenergic%20influence%20enables%20enhancement%20of%20memory%20consolidation%20induced%20by%20hippocampal%20glucocorticoid%20receptor%20activation&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib47" class="js-splitview-ref-item" data-legacy-id="bib47"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib47" href="javascript:;" aria-label="jumplink-bib47" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib47" class="ref-content " data-id="bib47"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Sharot</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Delgado</div> <div class="given-names">MR</div></div>,  <div class="name"><div class="surname">Phelps</div> <div class="given-names">EA</div></div>. </span><div class="article-title">How emotion enhances the feeling of remembering</div>, <div class="source ">Nat Neurosci</div>, <div class="year">2004</div>, vol. <div class="volume">7</div> (pg. <div class="fpage">1376</div>-<div class="lpage">1380</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=How%20emotion%20enhances%20the%20feeling%20of%20remembering&amp;author=T%20Sharot&amp;author=MR%20Delgado&amp;author=EA%20Phelps&amp;publication_year=2004&amp;journal=Nat%20Neurosci&amp;volume=7&amp;pages=1376-1380" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1038/nn1353" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1038%2Fnn1353" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1038%2Fnn1353"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15558065" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:How%20emotion%20enhances%20the%20feeling%20of%20remembering&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib48" class="js-splitview-ref-item" data-legacy-id="bib48"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib48" href="javascript:;" aria-label="jumplink-bib48" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib48" class="ref-content " data-id="bib48"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Sharot</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Phelps</div> <div class="given-names">EA</div></div>. </span><div class="article-title">How arousal modulates memory: disentangling the effects of attention and retention</div>, <div class="source ">Cogn Affect Behav Neurosci</div>, <div class="year">2004</div>, vol. <div class="volume">4</div> (pg. <div class="fpage">294</div>-<div class="lpage">306</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=How%20arousal%20modulates%20memory%3A%20disentangling%20the%20effects%20of%20attention%20and%20retention&amp;author=T%20Sharot&amp;author=EA%20Phelps&amp;publication_year=2004&amp;journal=Cogn%20Affect%20Behav%20Neurosci&amp;volume=4&amp;pages=294-306" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.3758/CABN.4.3.294" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.3758%2FCABN.4.3.294" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.3758%2FCABN.4.3.294"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/15535165" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:How%20arousal%20modulates%20memory%3A%20disentangling%20the%20effects%20of%20attention%20and%20retention&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib49" class="js-splitview-ref-item" data-legacy-id="bib49"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib49" href="javascript:;" aria-label="jumplink-bib49" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib49" class="ref-content " data-id="bib49"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Sharot</div> <div class="given-names">T</div></div>,  <div class="name"><div class="surname">Yonelinas</div> <div class="given-names">AP</div></div>. </span><div class="article-title">Differential time-dependent effects of emotion on recollective experience and memory for contextual information</div>, <div class="source ">Cognition</div>, <div class="year">2008</div>, vol. <div class="volume">106</div> (pg. <div class="fpage">538</div>-<div class="lpage">547</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Differential%20time-dependent%20effects%20of%20emotion%20on%20recollective%20experience%20and%20memory%20for%20contextual%20information&amp;author=T%20Sharot&amp;author=AP%20Yonelinas&amp;publication_year=2008&amp;journal=Cognition&amp;volume=106&amp;pages=538-547" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1016/j.cognition.2007.03.002" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1016%2Fj.cognition.2007.03.002" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1016%2Fj.cognition.2007.03.002"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/17451666" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Differential%20time-dependent%20effects%20of%20emotion%20on%20recollective%20experience%20and%20memory%20for%20contextual%20information&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib50" class="js-splitview-ref-item" data-legacy-id="bib50"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib50" href="javascript:;" aria-label="jumplink-bib50" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib50" class="ref-content " data-id="bib50"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Yamasaki</div> <div class="given-names">H</div></div>,  <div class="name"><div class="surname">LaBar</div> <div class="given-names">KS</div></div>,  <div class="name"><div class="surname">McCarthy</div> <div class="given-names">G</div></div>. </span><div class="article-title">Dissociable prefrontal brain systems for attention and emotion</div>, <div class="source ">Proc Natl Acad Sci USA</div>, <div class="year">2002</div>, vol. <div class="volume">99</div> (pg. <div class="fpage">11447</div>-<div class="lpage">11451</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Dissociable%20prefrontal%20brain%20systems%20for%20attention%20and%20emotion&amp;author=H%20Yamasaki&amp;author=KS%20LaBar&amp;author=G%20McCarthy&amp;publication_year=2002&amp;journal=Proc%20Natl%20Acad%20Sci%20USA&amp;volume=99&amp;pages=11447-11451" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1073/pnas.182176499" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1073%2Fpnas.182176499" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1073%2Fpnas.182176499"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/12177452" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Dissociable%20prefrontal%20brain%20systems%20for%20attention%20and%20emotion&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div><div content-id="bib51" class="js-splitview-ref-item" data-legacy-id="bib51"><div class="refLink-parent"><span class="refLink"><a name="jumplink-bib51" href="javascript:;" aria-label="jumplink-bib51" data-id=""></a></span></div><div class="ref false"><div id="ref-auto-bib51" class="ref-content " data-id="bib51"><div class="citation element-citation"><span class="person-group"><div class="name"><div class="surname">Yonelinas</div> <div class="given-names">AP</div></div>,  <div class="name"><div class="surname">Kroll</div> <div class="given-names">NEA</div></div>,  <div class="name"><div class="surname">Dobbins</div> <div class="given-names">I</div></div>,  <div class="name"><div class="surname">Lazzara</div> <div class="given-names">M</div></div>,  <div class="name"><div class="surname">Knight</div> <div class="given-names">RT</div></div>. </span><div class="article-title">Recollection and familiarity deficits in amnesia: convergence of remember-know, process dissociation, and receiver operating characteristic data</div>, <div class="source ">Neuropsychology</div>, <div class="year">1998</div>, vol. <div class="volume">12</div> (pg. <div class="fpage">323</div>-<div class="lpage">339</div>)<!--citationLinks: case 1--><div class="citation-links"></div><div class="citation-links"><p class="citation-links-compatibility"><span class="google-scholar-ref-link"><a class="openInAnotherWindow" href="https://scholar.google.com/scholar_lookup?title=Recollection%20and%20familiarity%20deficits%20in%20amnesia%3A%20convergence%20of%20remember-know%2C%20process%20dissociation%2C%20and%20receiver%20operating%20characteristic%20data&amp;author=AP%20Yonelinas&amp;author=NEA%20Kroll&amp;author=I%20Dobbins&amp;author=M%20Lazzara&amp;author=RT%20Knight&amp;publication_year=1998&amp;journal=Neuropsychology&amp;volume=12&amp;pages=323-339" target="_blank">Google Scholar</a></span></p><div class="crossref-doi js-ref-link"><a class="openInAnotherWindow" href="http://dx.doi.org/10.1037/0894-4105.12.3.323" target="_blank">Crossref</a></div><div class="adsDoiReference hide"><a class="openInAnotherWindow" href="http://adsabs.harvard.edu/cgi-bin/basic_connect?qsearch=10.1037%2F0894-4105.12.3.323" target="_blank">Search ADS</a></div><div class="xslopenurl empty-target"><span class="inst-open-url-holders" data-targetId="10.1037%2F0894-4105.12.3.323"> </span></div><div class="pub-id"><a href="http://www.ncbi.nlm.nih.gov/pubmed/9673991" class="link link-pub-id openInAnotherWindow" target="_blank">PubMed</a></div><p class="citation-links-compatibility"><span class="worldcat-reference-ref-link js-worldcat-preview-ref-link" style="display:none"><a class="openInAnotherWindow" href="https://www.worldcat.org/search?q=ti:Recollection%20and%20familiarity%20deficits%20in%20amnesia%3A%20convergence%20of%20remember-know%2C%20process%20dissociation%2C%20and%20receiver%20operating%20characteristic%20data&amp;qt=advanced&amp;dblist=638" target="_blank">WorldCat</a></span></p> </div></div></div></div></div></div>    <!-- /foreach in Model.Sections -->
+    <div class="widget widget-ArticlePubStateInfo widget-instance-OUP_ArticlePubStateInfo">
+         
+    </div>
+
+
+
+        <div class="article-metadata-standalone-panel clearfix"></div>
+
+        
+<div class="copyright copyright-statement">© The Author 2008. Published by Oxford University Press. All rights reserved. For permissions, please e-mail: journals.permissions@oxfordjournals.org</div><!-- /foreach -->
+
+        <span id="UserHasAccess" data-userHasAccess="True"></span>
+
+    </div><!-- /.widget-items -->
+</div><!-- /.module-widget -->
+
+
+
+
+
+ 
+    </div>
+    <div class="widget widget-RelatedTags widget-instance-OUP_Article_RelatedTags_Widget">
+            <div class="related-topic-tags">
+        <div class="related-topic-tag-label">Topic:</div>
+        <ul class="related-topic-tag-list">
+<li>
+                    <a href="https://academic.oup.com/cercor/search-results?f_SemanticFilterTopics=emotions"><span>emotions</span></a>
+                </li>
+<li>
+                    <a href="https://academic.oup.com/cercor/search-results?f_SemanticFilterTopics=amygdala"><span>amygdala</span></a>
+                </li>
+<li>
+                    <a href="https://academic.oup.com/cercor/search-results?f_SemanticFilterTopics=memory"><span>memory</span></a>
+                </li>
+<li>
+                    <a href="https://academic.oup.com/cercor/search-results?f_SemanticFilterTopics=functional magnetic resonance imaging"><span>functional magnetic resonance imaging</span></a>
+                </li>
+        </ul>
+    </div>
+ 
+    </div>
+    <div class="widget widget-SolrResourceMetadata widget-instance-OUP_Article_ResourceMetadata_Widget">
+        
+    <div class="article-metadata-panel solr-resource-metadata js-metadata-panel at-ContentMetadata">
+                <div class="article-metadata-tocSections">
+                    <div class="article-metadata-tocSections-title">Issue Section:</div>
+                        <a href="/cercor/search-results?f_TocHeadingTitle=Articles">Articles</a>
+                </div>
+
+    </div>
+
+
+ 
+    </div>
+    <div class="widget widget-EditorInformation widget-instance-OUP_Article_EditorInformation_Widget">
+        
+ 
+    </div>
+
+                <div id="ContentTabFilteredView"></div>
+                <div class="downloadImagesppt js-download-images-ppt st-download-images-ppt">
+                    <a id="lnkDownloadAllImages"
+                       class="js-download-all-images-link btn"
+                       href="/DownloadFile/DownloadImage.aspx?image=&amp;PPTtype=SlideSet&amp;ar=290170&amp;xsltPath=~/UI/app/XSLT&amp;siteId=5122">Download all slides</a>
+                </div>
+                    <div class="widget widget-ArticleDataRepositories widget-instance-Article_DryadLink">
+         
+    </div>
+
+                <div class="comments">
+    <div class="widget widget-UserCommentBody widget-instance-UserCommentBody_Article">
+        
+
+ 
+    </div>
+    <div class="widget widget-UserComment widget-instance-OUP_UserComment_Article">
+         
+    </div>
+
+                </div>
+            </div>
+        </div>
+
+    </div>
+</div>
+<div id="Sidebar" class="page-column page-column--right">
+    <div class="widget widget-AdBlock widget-instance-ArticlePageTopSidebar">
+        <div class="js-adBlock-parent-wrap">    
+    <div class="adBlockMainBodyTop-wrap js-adBlockMainBodyTop hide">
+    
+        <div id="adBlockMainBodyTop" class="js-adblock at-adblock">
+            <script>
+                googletag.cmd.push(function () {
+                    googletag.display('adBlockMainBodyTop');
+                });
+            </script>
+        </div>
+        <div class="advertisement-text at-adblock js-adblock-advertisement-text hide">Advertisement</div>
+    </div>
+</div> 
+    </div>
+<div class="widget widget-dynamic " data-count="1"> 
+
+    <div class="widget-dynamic-inner-wrap">
+
+<div class="widget widget-dynamic " data-count="8"> 
+
+    <div class="widget-dynamic-inner-wrap">
+
+    <div class="widget widget-ArticleLevelMetrics widget-instance-Article_RightRailB0Article_RightRail_ArticleLevelMetrics">
+        
+
+
+
+        <div class="artmet-wrapper horizontal-artmet">
+
+<div class="contentmet-border">
+    <div class="contentmet-wrapper horizontal-contentmet">
+            <div class="contentmet-citations contentmet-badges-wrap js-contentmet-citations hide">
+                <h3 class="contentmet-text">Citations</h3>
+                    <div class="contentmet-item contentmet-dimensions">
+    <div class="widget widget-DimensionsBadge widget-instance-ArticleLevelMetrics_DimensionsBadge">
+        <span class="__dimensions_badge_embed__" 
+      data-doi="10.1093/cercor/bhm262" 
+      data-legend="never" 
+      data-style="small_circle" 
+      data-hide-zero-citations="true"></span>
+<script async src="https://badge.dimensions.ai/badge.js" charset="utf-8"></script>
+ 
+    </div>
+
+                    </div>
+                            </div>
+                    <div class="contentmet-views contentmet-badges-wrap js-contentmet-views">
+                <h3 class="contentmet-text">Views</h3>
+                <div class="contentmet-item circle-text circle-text-views">
+                    <div class="contentmet-number">3,376</div>
+                </div>
+            </div>
+                    <div class="contentmet-item contentmet-badges-wrap">
+                    <h3 class="contentmet-text">Altmetric</h3>
+                    <div class="contentmet-item contentmet-altmetric">
+    <div class="widget widget-AltmetricLink widget-instance-ArticleLevelMetrics_AltmetricLinkSummary">
+            <!-- Altmetrics -->
+    <div id="altmetricEmbedId"
+         runat="server"
+         class='altmetric-embed'
+         data-badge-type="donut"
+         data-hide-no-mentions="false"
+         data-doi="10.1093/cercor/bhm262"
+
+        
+
+        ></div>
+         <script type='text/javascript' src='https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js'></script>
+ 
+    </div>
+
+                    </div>
+
+
+            </div>
+                    <div class="contentmet-modal-trigger-wrap clearfix">
+                <a href="javascript:;" class="artmet-modal-trigger js-artmet-modal-trigger at-alm-metrics-modal-trigger" data-resource-id="290170" data-resource-type="3">
+                    <img class="contentmet-info-icon" src="//oup.silverchair-cdn.com/UI/app/svg/i.svg" alt="Information">
+                    <span class="contentmet-more-info">More metrics information</span>
+                </a>
+            </div>
+    </div>
+</div>
+
+                <div class="artmet-modal js-artmet-modal" id="MetricsModal">
+                    <div class="artmet-modal-contents js-metric-modal-contents at-alm-modal-contents">
+                        <a class="artmet-close-modal js-artmet-close-modal">&#215;</a>
+                    </div>
+                </div>
+        </div>
+ 
+    </div>
+    <div class="widget widget-Alerts widget-instance-Article_RightRailB0Article_RightRail_Alerts">
+        
+    <div class="alertsWidget">
+        <h3>Email alerts</h3>
+                <div class="userAlert alertType-1">
+                    <a href="javascript:;" class="js-user-alert" role="button"
+                       data-userLoggedIn="False"
+                       data-alertType="1" href="javascript:;">Article activity alert</a>
+                </div>
+                <div class="userAlert alertType-3">
+                    <a href="javascript:;" class="js-user-alert" role="button"
+                       data-userLoggedIn="False"
+                       data-alertType="3" href="javascript:;">Advance article alerts</a>
+                </div>
+                <div class="userAlert alertType-5">
+                    <a href="javascript:;" class="js-user-alert" role="button"
+                       data-userLoggedIn="False"
+                       data-alertType="5" href="javascript:;">New issue alert</a>
+                </div>
+                    <div class="userAlert alertType-MarketingLink">
+                <a href="javascript:;" class="js-user-alert" role="button"
+                   data-userLoggedIn="False"
+                   data-additionalUrl="/my-account/communication-preferences" href="javascript:;">Receive exclusive offers and updates from Oxford Academic</a>
+            </div>
+        <div class="userAlertSignUpModal reveal-modal small" data-reveal>
+            <div class="userAlertSignUp at-userAlertSignUp"></div>
+            <a href="javascript:;" role="button" aria-label="Close" class="close-reveal-modal" href="javascript:;">
+                <i class="icon-general-close"></i>
+            </a>
+        </div>
+    </div>
+ 
+    </div>
+    <div class="widget widget-TrendMD widget-instance-Article_RightRailB0trendmd">
+        <script defer async src='//js.trendmd.com/trendmd.min.js'  data-trendmdconfig='{"journal_id":"62095","element":"#trendmd-suggestions"}'></script>
+
+<div id="trendmd-suggestions"></div> 
+    </div>
+    <div class="widget widget-ArticleCitedBy widget-instance-Article_RightRailB0Article_RightRail_ArticleCitedBy">
+        <div class="rail-widget_wrap vt-articles-cited-by">
+    <h3 class="article-cited-title">Citing articles via</h3>
+    <div class="widget-links_wrap">
+            <div class="article-cited-link-wrap web-of-science">
+                <a href="https://www.webofscience.com/api/gateway?GWVersion=2&SrcApp=PARTNER_APP&SrcAuth=Silverchair&KeyUT=WOS:000260135700003&DestLinkType=CitingArticles&DestApp=WOS_CPL&UsrCustomerID=61f30d8ae69c46f86624c5f98a3bc13a" target="_blank">Web of Science (128)</a>
+            </div>
+                    <div class="article-cited-link-wrap google-scholar-url">
+                <a href="http://scholar.google.com/scholar?q=link:https%3A%2F%2Facademic.oup.com%2Fcercor%2Farticle%2F18%2F11%2F2494%2F290170" target="_blank">Google Scholar</a>
+            </div>
+            </div>
+</div> 
+    </div>
+    <div class="widget widget-ArticleListNewAndPopular widget-instance-Article_RightRailB0Article_RightRail_ArticleNewPopularCombined">
+            <ul class="articleListNewAndPopularCombinedView">
+            <li>
+                <h3>
+                    <a href="javascript:;" class="articleListNewAndPopular-mode active" data-mode="MostRecent">Latest</a>
+                </h3>
+            </li>
+            <li>
+                <h3>
+                    <a href="javascript:;" class="articleListNewAndPopular-mode " data-mode="MostRead">Most Read</a>
+                </h3>
+            </li>
+            <li>
+                <h3>
+                    <a href="javascript:;" class="articleListNewAndPopular-mode " data-mode="MostCited">Most Cited</a>
+                </h3>
+            </li>
+    </ul>
+        <section class="articleListNewPopContent articleListNewAndPopular-ContentView-MostRecent hasContent">
+
+
+
+
+<div id="newPopularList-Article_RightRailB0Article_RightRail_ArticleNewPopularCombined" class="fb">
+
+    
+
+
+
+<div class="widget-layout widget-layout--vert ">
+            <div class="widget-columns widget-col-1">
+                    <div class="col">
+
+<div class="widget-dynamic-entry journalArticleItem at-widget-entry-SCL">
+    <span class="hfDoi" data-attribute="10.1093/cercor/bhad192" aria-hidden="true"></span>
+
+
+    
+
+
+<a class="journal-link" href="/cercor/advance-article/doi/10.1093/cercor/bhad192/7194194?searchresult=1">
+        <div class="widget-dynamic-journal-title">
+Functional connectivity changes in infants with varying degrees of unilateral hearing loss    </div>
+</a>
+
+ 
+
+
+
+
+
+<div class="widget-dynamic-journal-image-synopsis">
+        <div class="widget-dynamic-journal-synopsis">
+            
+        </div>
+</div>
+</div>
+<div class="widget-dynamic-entry journalArticleItem at-widget-entry-SCL">
+    <span class="hfDoi" data-attribute="10.1093/cercor/bhad202" aria-hidden="true"></span>
+
+
+    
+
+
+<a class="journal-link" href="/cercor/advance-article/doi/10.1093/cercor/bhad202/7194193?searchresult=1">
+        <div class="widget-dynamic-journal-title">
+The alpha-2A-adrenergic receptor gene polymorphism modulates gray matter structural networks, visual memory, and inhibitory cognitive control in children with attention deficit/hyperactivity disorder    </div>
+</a>
+
+ 
+
+
+
+
+
+<div class="widget-dynamic-journal-image-synopsis">
+        <div class="widget-dynamic-journal-synopsis">
+            
+        </div>
+</div>
+</div>
+<div class="widget-dynamic-entry journalArticleItem at-widget-entry-SCL">
+    <span class="hfDoi" data-attribute="10.1093/cercor/bhad204" aria-hidden="true"></span>
+
+
+    
+
+
+<a class="journal-link" href="/cercor/advance-article/doi/10.1093/cercor/bhad204/7194192?searchresult=1">
+        <div class="widget-dynamic-journal-title">
+Spatiotemporal connectivity maps abnormal communication pathways in major depressive disorder underlying gamma oscillations    </div>
+</a>
+
+ 
+
+
+
+
+
+<div class="widget-dynamic-journal-image-synopsis">
+        <div class="widget-dynamic-journal-synopsis">
+            
+        </div>
+</div>
+</div>
+<div class="widget-dynamic-entry journalArticleItem at-widget-entry-SCL">
+    <span class="hfDoi" data-attribute="10.1093/cercor/bhad199" aria-hidden="true"></span>
+
+
+    
+
+
+<a class="journal-link" href="/cercor/advance-article/doi/10.1093/cercor/bhad199/7194191?searchresult=1">
+        <div class="widget-dynamic-journal-title">
+Actigraphic evidence of persistent sleep disruption following repetitive mild traumatic brain injury in a gyrencephalic model    </div>
+</a>
+
+ 
+
+
+
+
+
+<div class="widget-dynamic-journal-image-synopsis">
+        <div class="widget-dynamic-journal-synopsis">
+            
+        </div>
+</div>
+</div>
+<div class="widget-dynamic-entry journalArticleItem at-widget-entry-SCL">
+    <span class="hfDoi" data-attribute="10.1093/cercor/bhad215" aria-hidden="true"></span>
+
+
+    
+
+
+<a class="journal-link" href="/cercor/advance-article/doi/10.1093/cercor/bhad215/7194190?searchresult=1">
+        <div class="widget-dynamic-journal-title">
+Spatiotemporal dynamics across visual cortical laminae support a predictive coding framework for interpreting mismatch responses    </div>
+</a>
+
+ 
+
+
+
+
+
+<div class="widget-dynamic-journal-image-synopsis">
+        <div class="widget-dynamic-journal-synopsis">
+            
+        </div>
+</div>
+</div>
+                    </div>
+            </div>
+
+</div></div>
+        </section>
+        <section class="articleListNewPopContent articleListNewAndPopular-ContentView-MostRead hide">
+        </section>
+        <section class="articleListNewPopContent articleListNewAndPopular-ContentView-MostCited hide">
+        </section>
+ 
+    </div>
+    <div class="widget widget-RelatedTaxonomies widget-instance-Article_RightRailB0Article_RightRail_RelatedTaxonomies">
+            <div class="widget-related-taxonomies-wrap vt-related-taxonomies">
+        <div class="widget-related-taxonomies_title">More from Oxford Academic</div>
+            <div class="widget-related-taxonomies">
+                <a id="more-from-oa-AcademicSubjects_MED00385" class="related-taxonomies-link" href="/search-results?tax=AcademicSubjects/MED00385">Clinical Neuroscience</a>
+            </div>
+            <div class="widget-related-taxonomies">
+                <a id="more-from-oa-AcademicSubjects_MED00010" class="related-taxonomies-link" href="/search-results?tax=AcademicSubjects/MED00010">Medicine and Health</a>
+            </div>
+            <div class="widget-related-taxonomies">
+                <a id="more-from-oa-AcademicSubjects_MED00310" class="related-taxonomies-link" href="/search-results?tax=AcademicSubjects/MED00310">Neurology</a>
+            </div>
+            <div class="widget-related-taxonomies">
+                <a id="more-from-oa-AcademicSubjects_SCI01870" class="related-taxonomies-link" href="/search-results?tax=AcademicSubjects/SCI01870">Neuroscience</a>
+            </div>
+            <div class="widget-related-taxonomies">
+                <a id="more-from-oa-AcademicSubjects_SCI00010" class="related-taxonomies-link" href="/search-results?tax=AcademicSubjects/SCI00010">Science and Mathematics</a>
+            </div>
+
+            <div class="widget-related-taxonomies">
+                <a id="more-from-oa-format-Books" class="related-taxonomies-link" href="/books">Books</a>
+            </div>
+            <div class="widget-related-taxonomies">
+                <a id="more-from-oa-format-Journals" class="related-taxonomies-link" href="/journals">Journals</a>
+            </div>
+    </div>
+ 
+    </div>
+
+    </div>
+
+</div>
+    </div>
+
+</div>    <div class="widget widget-AdBlock widget-instance-ArticlePageTopMainBodyBottom">
+        <div class="js-adBlock-parent-wrap">    
+    <div class="adBlockMainBodyBottom-wrap js-adBlockMainBodyBottom hide">
+    
+        <div id="adBlockMainBodyBottom" class="js-adblock at-adblock js-adblock-lazy-loading">
+            <script>
+                googletag.cmd.push(function () {
+                    googletag.display('adBlockMainBodyBottom');
+                });
+            </script>
+        </div>
+        <div class="advertisement-text at-adblock js-adblock-advertisement-text hide">Advertisement</div>
+    </div>
+</div> 
+    </div>
+
+</div>
+
+</div>
+<input id="hfArticleTitle" name="hfArticleTitle" type="hidden" value="Role of Amygdala Connectivity in the Persistence of Emotional Memories Over Time: An Event-Related fMRI Investigation | Cerebral Cortex | Oxford Academic" />
+<input id="hfLeftNavStickyOffset" name="hfLeftNavStickyOffset" type="hidden" value="29" />
+<input id="hfAreOpFeaturesEnabled" name="hfAreOpFeaturesEnabled" type="hidden" value="True" />
+
+
+
+                </div><!-- /.center-inner-row no-overflow -->
+            </section>
+    </div>
+
+        <div class="mobile-mask">
+        </div>
+
+        <section class="footer_wrap vt-site-footer">
+            
+
+
+    <div class="widget widget-SitePageFooter widget-instance-SitePageFooter">
+            <div class="ad-banner ad-banner-footer">
+    <div class="widget widget-AdBlock widget-instance-FooterAd">
+        <div class="js-adBlock-parent-wrap">    
+    <div class="adBlockFooter-wrap js-adBlockFooter hide">
+    
+        <div id="adBlockFooter" class="js-adblock at-adblock js-adblock-lazy-loading">
+            <script>
+                googletag.cmd.push(function () {
+                    googletag.display('adBlockFooter');
+                });
+            </script>
+        </div>
+        <div class="advertisement-text at-adblock js-adblock-advertisement-text hide">Advertisement</div>
+    </div>
+</div> 
+    </div>
+
+
+    <div class="widget widget-AdBlock widget-instance-StickyFooterAd">
+        <div class="js-adBlock-parent-wrap">    
+    <div class="adBlockStickyFooter-wrap js-adBlockStickyFooter hide">
+    
+        <div id="adBlockStickyFooter" class="js-adblock at-adblock js-adblock-lazy-loading">
+            <script>
+                googletag.cmd.push(function () {
+                    googletag.display('adBlockStickyFooter');
+                });
+            </script>
+        </div>
+        <div class="advertisement-text at-adblock js-adblock-advertisement-text hide">Advertisement</div>
+    </div>
+</div> 
+    </div>
+
+    </div>
+
+<div class="journal-footer journal-bg">
+    <div class="center-inner-row">
+
+<div class="journal-footer-menu">
+
+    <ul>
+<li class="link-1">
+    <a href="/cercor/pages/About">About Cerebral Cortex</a>
+</li> <li class="link-2">
+    <a href="/cercor/pages/Editorial_Board">Editorial Board</a>
+</li> <li class="link-3">
+    <a href="/cercor/pages/General_Instructions">Author Guidelines</a>
+</li> <li class="link-4">
+    <a href="https://www.facebook.com/OUPAcademic">Facebook</a>
+</li> <li class="link-5">
+    <a href="https://twitter.com/OxfordJournals">Twitter</a>
+</li> </ul><ul><li class="link-1">
+    <a href="/cercor/subscribe">Purchase</a>
+</li> <li class="link-2">
+    <a href="http://www.oxfordjournals.org/en/library-recommendation-form.html">Recommend to your Library</a>
+</li> <li class="link-3">
+    <a href="https://academic.oup.com/advertising-and-corporate-services/pages/cercor-media-kit">Advertising and Corporate Services</a>
+</li> <li class="link-4">
+    <a href="http://medicine-and-health-careernetwork.oxfordjournals.org">Journals Career Network</a>
+</li> 
+    </ul>
+
+
+</div><!-- /.journal-footer-menu -->
+        <div class="journal-footer-affiliations">
+            <!-- <h3>Affiliations</h3> -->
+<a href="" target="">
+    <img id="footer-logo-CerebralCortex" class="journal-footer-affiliations-logo" src="//oup.silverchair-cdn.com/data/SiteBuilderAssets/Live/Images/cercor/cercor_title1443091482.svg" alt="Cerebral Cortex" />
+</a>                        </div><!-- /.journal-footer-affiliations -->
+
+        <div class="journal-footer-colophon">
+            <ul>
+<li>Online ISSN 1460-2199</li>                <li>Print ISSN 1047-3211</li>                <li>Copyright &#169; 2023 Oxford University Press</li>
+            </ul>
+        </div><!-- /.journal-footer-colophon -->
+
+
+    </div><!-- /.center-inner-row -->
+</div><!-- /.journal-footer --> 
+    </div>
+
+    <div class="oup-footer">
+        <div class="center-inner-row">
+    <div class="widget widget-SelfServeContent widget-instance-OupUmbrellaFooterSelfServe">
+        
+
+
+
+    <input type="hidden" class="SelfServeContentId" value="GlobalFooter_Links" />
+    <input type="hidden" class="SelfServeVersionId" value="0" />
+
+<div class="oup-footer-row journal-links">
+<div class="global-footer selfservelinks">
+<ul>
+    <li><a href="/pages/about-oxford-academic">About Oxford Academic</a></li>
+    <li><a href="/pages/about-oxford-academic/publish-journals-with-us">Publish journals with us</a></li>
+    <li><a href="/pages/about-oxford-academic/our-university-press-partners">University press partners</a></li>
+    <li><a href="/pages/what-we-publish">What we publish</a></li>
+    <li><a href="/pages/new-features">New features</a>&nbsp;</li>
+</ul>
+</div>
+<div class="global-footer selfservelinks">
+<ul>
+    <li><a href="/pages/authoring">Authoring</a></li>
+    <li><a href="/pages/open-research/open-access">Open access</a></li>
+    <li><a href="/pages/purchasing">Purchasing</a></li>
+    <li><a href="/pages/institutional-account-management">Institutional account management</a></li>
+    <li><a href="https://academic.oup.com/pages/purchasing/rights-and-permissions">Rights and permissions</a></li>
+</ul>
+</div>
+<div class="global-footer selfservelinks">
+<ul>
+    <li><a href="/pages/get-help-with-access">Get help with access</a></li>
+    <li><a href="/pages/about-oxford-academic/accessibility">Accessibility</a></li>
+    <li><a href="/pages/contact-us">Contact us</a></li>
+    <li><a href="/pages/advertising">Advertising</a></li>
+    <li><a href="/pages/media-enquiries">Media enquiries</a></li>
+</ul>
+</div>
+<div class="global-footer selfservelinks global-footer-external">
+<ul>
+    <li><a href="https://global.oup.com/">Oxford University Press</a></li>
+    <li><a href="https://www.mynewsdesk.com/uk/oxford-university-press">News</a></li>
+    <li><a href="https://languages.oup.com/">Oxford Languages</a></li>
+    <li><a href="https://www.ox.ac.uk/">University of Oxford</a></li>
+</ul>
+</div>
+<div class="OUP-mission">
+<p>Oxford University Press is a department of the University of Oxford. It furthers the University's objective of excellence in research, scholarship, and education by publishing worldwide</p>
+<img class="journal-footer-logo" src="//oup.silverchair-cdn.com/UI/app/svg/umbrella/oup-logo.svg" alt="Oxford University Press" width="150" height="42" />
+</div>
+</div>
+<div class="oup-footer-row">
+<div class="oup-footer-row-links">
+<ul>
+    <li>Copyright © 2023 Oxford University Press</li>
+    <li><button id="Change-Preferences" type="button" onclick="window.top.document.dispatchEvent(new Event('changeConsent'))">Cookie settings</button></li>
+    <li><a href="https://global.oup.com/cookiepolicy">Cookie policy</a></li>
+    <li><a href="https://global.oup.com/privacy">Privacy policy</a></li>
+    <li><a href="/pages/legal-and-policy/legal-notice">Legal notice</a></li>
+</ul>
+</div>
+</div>
+<style type="text/css">
+    /* Issue right column fix for tablet/mobile */
+    @media (max-width: 1200px) {
+    .pg_issue .widget-instance-OUP_Issue {
+    width: 100%;
+    }
+    }
+    .sf-facet-list .sf-facet label,
+    .sf-facet-list .taxonomy-label-wrap label {
+    font-size: 0.9375rem;
+    }
+    .issue-pagination-wrap .pagination-container {
+    float: right;
+    }
+</style>
+
+
+
+ 
+    </div>
+
+        </div>
+    </div>
+    <div class="ss-ui-only">
+
+    </div>
+
+        </section>
+</div>
+
+
+
+
+
+
+    
+
+
+
+    <div class="widget widget-SiteWideModals widget-instance-SiteWideModals">
+        <div id="revealModal" class="reveal-modal" data-reveal>
+    <div id="revealContent"></div>
+    <a class="close-reveal-modal" href="javascript:;"><i class="icon-general-close"></i><span class="screenreader-text">Close</span></a>
+</div>
+
+<div id="globalModalContainer" class="modal-global-container">
+    <div id="globalModalContent">
+        <div class="js-globalModalPlaceholder"></div>
+    </div>
+    <a class="close-modal js-close-modal" href="javascript:;"><i class="icon-general-close"><span class="screenreader-text">Close</span></i></a>
+</div>
+<div id="globalModalOverlay" class="modal-overlay js-modal-overlay"></div>
+
+<div id="NeedSubscription" class="reveal-modal small" data-reveal>
+    <div class="subscription-needed">
+        <h5>This Feature Is Available To Subscribers Only</h5>
+        <p><a href="/sign-in">Sign In</a> or <a href="/my-account/register?siteId=5122&amp;returnUrl=%2fcercor%2farticle%2f18%2f11%2f2494%2f290170%3fsearchresult%3d1">Create an Account</a></p>
+    </div>
+    <a class="close-reveal-modal" href="javascript:;"><i class="icon-general-close"></i><span class="screenreader-text">Close</span></a>
+</div>
+
+<div id="noAccessReveal" class="reveal-modal tiny" data-reveal>
+    <p>This PDF is available to Subscribers Only</p>
+    <a class="hide-for-article-page" id="articleLinkToPurchase" data-reveal><span>View Article Abstract & Purchase Options</span></a>
+    <div class="issue-purchase-modal">
+        <p>For full access to this pdf, sign in to an existing account, or purchase an annual subscription.</p>
+    </div>
+    <a class="close-reveal-modal" href="javascript:;"><i class="icon-general-close"></i><span class="screenreader-text">Close</span></a>
+</div>
+ 
+    </div>
+
+    
+
+
+<script src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+
+
+<script src="//cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>
+
+    <!-- CookiePro Default Categories -->
+    <!-- When the Cookie Compliance code loads, if cookies for the associated group have consent...
+         it will dynamically change the tag to: script type=text/JavaScript...
+         the code inside the tags will then be recognized and run as normal. -->
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <script>
+        var NTPT_PGEXTRA = 'event_type=full-text\u0026supplier_tag=SC_Journals\u0026object_type=Article\u0026taxonomy=taxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aSCI01870%7cnodeLabel%3aNeuroscience%7cnodeLevel%3a2%3btaxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aMED00385%7cnodeLabel%3aClinical+Neuroscience%7cnodeLevel%3a2%3btaxId%3a39%7ctaxLabel%3aAcademicSubjects%7cnodeId%3aMED00310%7cnodeLabel%3aNeurology%7cnodeLevel%3a2\u0026siteid=cercor\u0026authentication_method=IP\u0026authzrequired=false\u0026account_id=22482551\u0026account_list=22482551,20003025,20001100,20058187\u0026result_click=true\u0026authnips=136.62.3.74\u0026doi=10.1093/cercor/bhm262';
+    </script>
+    <!-- Copyright 2001-2010, IBM Corporation All rights reserved. -->
+    <script type="text/javascript" src="//ouptag.scholarlyiq.com/ntpagetag.js" class="optanon-category-C0002"></script>
+        <noscript>
+            <img src="//ouptag.scholarlyiq.com/ntpagetag.gif?js=0" height="1" width="1" border="0" hspace="0" vspace="0" alt="Scholarly IQ" />
+        </noscript>
+
+
+
+
+
+
+
+
+
+
+    <script type="text/javascript" src="//oup.silverchair-cdn.com/Themes/Client/app/jsdist/v-638216042113932239/site.min.js"></script>
+
+
+    
+    
+    
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/chartist.js/latest/chartist.min.js"></script>
+
+    <script type="text/javascript" src="//oup.silverchair-cdn.com/Themes/Client/app/jsdist/v-638216041991781897/article-page.min.js"></script>
+
+
+
+    
+
+    
+    
+
+
+
+
+    <div class="ad-banner js-ad-riser ad-banner-riser">
+
+    <div class="widget widget-AdBlock widget-instance-RiserAd">
+            
+
+ 
+    </div>
+
+    </div>
+
+
+
+    </body>
+</html>
+


### PR DESCRIPTION
Adds source specific text extraction, with the goal of specifically extracting the body of the HTML article only.

Sources covered:

HighWire

Need to do:
Springer
ScienceDirect
Frontiers
JCN
Plos
Sage
Springer
Wiley