### PR TITLE
Fixing ingest.py and writing additional test for test_ace.py

### DIFF
--- a/ace/ingest.py
+++ b/ace/ingest.py
@@ -69,5 +69,6 @@ def add_articles(db, files, commit=True, table_dir=None, limit=None,
             db.add(article)
             if commit and (i % 100 == 0 or i == len(files) - 1):
                 db.save()
+    db.save()
 
     return missing_sources


### PR DESCRIPTION
Fixed the bug on ingest.py that it would save the database every 100 articles, which was not allowing other papers to be saved if the count was lower than 100.

Writing the other test for the other journal examples we have available and to check whether or not if we need to update those test journals